### PR TITLE
feat: overhaul installation system with consistent naming, ARM64, and install scripts

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -107,30 +107,55 @@ Format each section with commit messages grouped by type:
 - Use today's date in YYYY-MM-DD format
 - Preserve any existing changelog entries below this new entry
 
-## Step 8: Stage and Commit Version Files
+## Step 8: Create Release Branch, Stage and Commit
 
-Sync lockfiles to the new version, then stage and commit all files.
+Create a release branch, sync lockfiles, then stage and commit all files.
 
 Run each command separately (do not chain with `&&`):
 
-1. `npm install --package-lock-only`
-2. `cargo generate-lockfile --manifest-path src-tauri/Cargo.toml`
-3. `git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json CHANGELOG.md`
-4. `git commit -m "chore: release v{version}"`
+1. `git checkout -b release/v{version}`
+2. `npm install --package-lock-only`
+3. `cargo generate-lockfile --manifest-path src-tauri/Cargo.toml`
+4. `git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json CHANGELOG.md`
+5. `git commit -m "chore: release v{version}"`
 
-## Step 9: Create Tag and Push
+## Step 9: Push Branch and Create Pull Request
 
-Create the annotated tag and push to the remote. Run each command separately:
+Push the release branch and open a PR against `main`:
 
-1. `git tag -a v{version} -m "Release v{version}"`
-2. `git push origin main --follow-tags`
+1. `git push origin release/v{version}`
+2. Create PR via `gh pr create --base main --head release/v{version} --title "chore: release v{version}" --body "Version bump to v{version}. Merge this PR, then the release tag will be created automatically."`
 
-## Step 10: Print Release Information
+Print the PR URL and tell the user:
+
+```
+PR created: {pr_url}
+Please merge the PR on GitHub, then come back and confirm so I can tag the release.
+```
+
+**Wait for the user to confirm the PR is merged** using the ask_user tool with choices:
+- `Merged — create the tag`
+- `Cancel release`
+
+If the user cancels, clean up: `git checkout main && git branch -D release/v{version} && git push origin --delete release/v{version}` (each command separately), then stop.
+
+## Step 10: Tag the Merged Commit and Push
+
+After the user confirms the PR is merged:
+
+1. `git checkout main`
+2. `git pull origin main`
+3. `git tag -a v{version} -m "Release v{version}"`
+4. `git push origin v{version}`
+
+The tag push triggers the release workflow (`.github/workflows/release.yml`).
+
+## Step 11: Print Release Information
 
 Print a link to view the GitHub Actions workflow:
 
 ```
-Release v{version} published!
+Release v{version} tagged and pushed!
 Monitor the build at: https://github.com/dryotta/mdownreview/actions
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,20 +99,33 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            name: Windows
-            artifact: windows-installer
-            bundle-path: src-tauri/target/release/bundle/nsis/*.exe
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+            artifact_ext: zip
+
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
+            artifact_ext: zip
 
           - os: macos-latest
-            name: macOS Apple Silicon
-            artifact: macos-arm-installer
-            bundle-path: src-tauri/target/release/bundle/dmg/*.dmg
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+            artifact_ext: dmg
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -130,17 +143,39 @@ jobs:
 
       - name: Clean stale bundles from cache
         shell: bash
-        run: rm -rf src-tauri/target/release/bundle src-tauri/target/debug/bundle 2>/dev/null || true
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
 
       - name: Build Tauri app
-        run: npm run tauri:build
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Package artifact
+        shell: bash
+        run: |
+          NAME="mdownreview-${{ matrix.name }}"
+          if [[ "${{ matrix.artifact_ext }}" == "zip" ]]; then
+            nsis_zip=$(ls -t ${{ matrix.target_dir }}/bundle/nsis/*.nsis.zip 2>/dev/null | head -1)
+            [ -z "$nsis_zip" ] && { echo "::error::NSIS zip not found"; exit 1; }
+            cp "$nsis_zip" "${NAME}.zip"
+            echo "ARTIFACT=${NAME}.zip" >> "$GITHUB_ENV"
+          else
+            dmg=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
+            [ -z "$dmg" ] && { echo "::error::DMG not found"; exit 1; }
+            cp "$dmg" "${NAME}.dmg"
+            echo "ARTIFACT=${NAME}.dmg" >> "$GITHUB_ENV"
+          fi
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.bundle-path }}
+          name: ${{ matrix.name }}
+          path: ${{ env.ARTIFACT }}
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,28 +32,52 @@ jobs:
           gh release create "${{ steps.tag.outputs.tag }}" \
             --draft \
             --title "mdownreview ${{ steps.tag.outputs.tag }}" \
-            --notes "Download the installer for your platform from the Assets section below."
+            --notes "## Install
+
+          **macOS**
+          \`\`\`
+          curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh
+          \`\`\`
+
+          **Windows**
+          \`\`\`
+          powershell -ExecutionPolicy ByPass -c \"irm https://dryotta.github.io/mdownreview/install.ps1 | iex\"
+          \`\`\`
+
+          Or download the installer for your platform from the Assets section below."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     needs: create-release
+    name: Build (${{ matrix.name }})
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-latest
-            artifact_glob: src-tauri/target/release/bundle/nsis/*.exe
-            updater_glob: src-tauri/target/release/bundle/nsis/*.nsis.zip
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
           - os: macos-latest
-            artifact_glob: src-tauri/target/release/bundle/dmg/*.dmg
-            updater_glob: src-tauri/target/release/bundle/macos/*.app.tar.gz
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -71,37 +95,59 @@ jobs:
 
       - name: Clean stale bundles from cache
         shell: bash
-        run: rm -rf src-tauri/target/release/bundle src-tauri/target/debug/bundle 2>/dev/null || true
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
 
       - name: Build Tauri app
-        run: npm run tauri:build
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-      - name: Upload installer to release
+      - name: Rename and upload artifacts
         shell: bash
         run: |
           TAG="${{ needs.create-release.outputs.tag }}"
-          file=$(ls -t ${{ matrix.artifact_glob }} 2>/dev/null | head -1)
-          [ -z "$file" ] && { echo "No artifact found for ${{ matrix.artifact_glob }}"; exit 1; }
-          # Delete any stale .exe/.dmg assets first — prevents duplicates on re-runs
-          # and cleans up assets left over from app renames.
-          gh release view "$TAG" --json assets \
-            --jq '.assets[] | select(.name | test("[.](exe|dmg)$")) | .name' \
-            | while IFS= read -r name; do
-                gh release delete-asset "$TAG" "$name" --yes 2>/dev/null || true
-              done
-          gh release upload "$TAG" "$file"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION="${TAG#v}"
+          NAME="mdownreview-${VERSION}-${{ matrix.name }}"
 
-      - name: Upload updater bundle to release
-        shell: bash
-        run: |
-          for f in ${{ matrix.updater_glob }} ${{ matrix.updater_glob }}.sig; do
-            [ -f "$f" ] && gh release upload "${{ needs.create-release.outputs.tag }}" "$f" --clobber || true
-          done
+          if [[ "${{ matrix.name }}" == windows-* ]]; then
+            # Rename the NSIS zip (serves as both download and updater artifact)
+            nsis_zip=$(ls -t ${{ matrix.target_dir }}/bundle/nsis/*.nsis.zip 2>/dev/null | head -1)
+            [ -z "$nsis_zip" ] && { echo "::error::NSIS zip not found"; exit 1; }
+            cp "$nsis_zip" "${NAME}.zip"
+            gh release upload "$TAG" "${NAME}.zip" --clobber
+
+            # Upload the signature file with matching name
+            sig="${nsis_zip}.sig"
+            if [ -f "$sig" ]; then
+              cp "$sig" "${NAME}.zip.sig"
+              gh release upload "$TAG" "${NAME}.zip.sig" --clobber
+            fi
+          else
+            # Rename the DMG for human download
+            dmg=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
+            [ -z "$dmg" ] && { echo "::error::DMG not found"; exit 1; }
+            cp "$dmg" "${NAME}.dmg"
+            gh release upload "$TAG" "${NAME}.dmg" --clobber
+
+            # Rename the .app.tar.gz updater bundle
+            app_tar=$(ls -t ${{ matrix.target_dir }}/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+            if [ -n "$app_tar" ]; then
+              cp "$app_tar" "${NAME}.app.tar.gz"
+              gh release upload "$TAG" "${NAME}.app.tar.gz" --clobber
+              sig="${app_tar}.sig"
+              if [ -f "$sig" ]; then
+                cp "$sig" "${NAME}.app.tar.gz.sig"
+                gh release upload "$TAG" "${NAME}.app.tar.gz.sig" --clobber
+              fi
+            fi
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -117,33 +163,26 @@ jobs:
           TAG="${{ needs.create-release.outputs.tag }}"
           VERSION="${TAG#v}"
           BASE_URL="https://github.com/dryotta/mdownreview/releases/download/${TAG}"
+          NAME="mdownreview-${VERSION}"
 
           mkdir -p /tmp/sigs
 
-          # Fetch sig file content by jq-safe pattern (use [.] for literal dots)
-          fetch_sig() {
-            local pattern="$1"
-            local fname
-            fname=$(gh release view "$TAG" --json assets \
-              --jq ".assets[] | select(.name | test(\"${pattern}\")) | .name" | head -1)
-            [ -z "$fname" ] && { echo ""; return; }
-            gh release download "$TAG" --pattern "$fname" --dir /tmp/sigs 2>/dev/null
-            cat "/tmp/sigs/${fname}" 2>/dev/null || echo ""
+          # Read signature file content from a release asset
+          read_sig() {
+            local asset_name="$1"
+            gh release download "$TAG" --pattern "${asset_name}" --dir /tmp/sigs 2>/dev/null || true
+            cat "/tmp/sigs/${asset_name}" 2>/dev/null || echo ""
           }
 
-          WIN_SIG=$(fetch_sig ".*[.]nsis[.]zip[.]sig$")
-          ARM_SIG=$(fetch_sig ".*[.]app[.]tar[.]gz[.]sig$")
+          # Verify all required updater assets exist before generating manifest
+          for asset in "${NAME}-windows-x64.zip" "${NAME}-windows-arm64.zip" "${NAME}-macos-arm64.app.tar.gz"; do
+            gh release view "$TAG" --json assets --jq ".assets[].name" | grep -q "^${asset}$" || \
+              { echo "::error::Required updater asset not found: $asset"; exit 1; }
+          done
 
-          WIN_ZIP=$(gh release view "$TAG" --json assets \
-            --jq '.assets[] | select(.name | test("[.]nsis[.]zip$")) | .name' | head -1)
-          ARM_APP=$(gh release view "$TAG" --json assets \
-            --jq '.assets[] | select(.name | test("[.]app[.]tar[.]gz$")) | .name' | head -1)
-
-          [ -z "$WIN_ZIP" ] && { echo "::error::NSIS updater zip not found on release"; exit 1; }
-          [ -z "$ARM_APP" ] && { echo "::error::macOS updater bundle not found on release"; exit 1; }
-
-          # URL-encode spaces in filenames (productName "mdownreview" produces spaces)
-          url_encode() { echo "$1" | sed 's/ /%20/g'; }
+          WIN_X64_SIG=$(read_sig "${NAME}-windows-x64.zip.sig")
+          WIN_ARM64_SIG=$(read_sig "${NAME}-windows-arm64.zip.sig")
+          MAC_ARM64_SIG=$(read_sig "${NAME}-macos-arm64.app.tar.gz.sig")
 
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -154,12 +193,16 @@ jobs:
             "pub_date": "${PUB_DATE}",
             "platforms": {
               "windows-x86_64": {
-                "signature": "${WIN_SIG}",
-                "url": "${BASE_URL}/$(url_encode "${WIN_ZIP}")"
+                "signature": "${WIN_X64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-x64.zip"
+              },
+              "windows-aarch64": {
+                "signature": "${WIN_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-arm64.zip"
               },
               "darwin-aarch64": {
-                "signature": "${ARM_SIG}",
-                "url": "${BASE_URL}/$(url_encode "${ARM_APP}")"
+                "signature": "${MAC_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-macos-arm64.app.tar.gz"
               }
             }
           }

--- a/docs/superpowers/plans/2026-04-20-installation-system.md
+++ b/docs/superpowers/plans/2026-04-20-installation-system.md
@@ -1,0 +1,722 @@
+# Installation System Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Overhaul the release/CI pipeline to produce consistently named artifacts with OS+arch labels, add Windows ARM64 builds, and provide `curl | sh` / `irm | iex` install scripts.
+
+**Architecture:** GitHub Actions workflows are updated to a 3-entry build matrix (win-x64, win-arm64, mac-arm64) with a post-build rename step. Install scripts hosted on GitHub Pages detect platform and download from GitHub Releases. The Tauri updater continues to work via renamed `.nsis.zip` and `.app.tar.gz` artifacts referenced by `latest.json`.
+
+**Tech Stack:** GitHub Actions, Tauri v2 bundler, NSIS, Bash, PowerShell, GitHub Pages
+
+**Spec:** `docs/superpowers/specs/2026-04-20-installation-system-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `.github/workflows/release.yml` | Modify | 3-entry build matrix, rename step, updated latest.json |
+| `.github/workflows/ci.yml` | Modify | 3-entry build matrix matching release |
+| `site/install.sh` | Create | macOS shell install script |
+| `site/install.ps1` | Create | Windows PowerShell install script |
+| `site/index.html` | Modify | Add Quick Install section |
+
+---
+
+### Task 1: Update release.yml build matrix and artifact upload
+
+**Files:**
+- Modify: `.github/workflows/release.yml:39-106`
+
+The current `build` job has a 2-entry matrix (windows-latest, macos-latest) that uploads Tauri's default-named artifacts. Replace it with a 3-entry matrix that:
+1. Adds per-entry fields: `name`, `rust_target`, `target_dir`, `tauri_args`
+2. Adds Windows ARM64 entry with `--target aarch64-pc-windows-msvc`
+3. Renames Tauri output to `mdownreview-{ver}-{os}-{arch}.{ext}` before upload
+4. Removes the old extension-wide delete logic (replaced by exact-name `--clobber`)
+
+Tauri default output filenames (productName `mdownreview`, version `0.2.6`):
+- Windows x64: `src-tauri/target/release/bundle/nsis/mdownreview_0.2.6_x64.nsis.zip`
+- Windows ARM64: `src-tauri/target/aarch64-pc-windows-msvc/release/bundle/nsis/mdownreview_0.2.6_arm64.nsis.zip`
+- macOS ARM64 DMG: `src-tauri/target/release/bundle/dmg/mdownreview_0.2.6_aarch64.dmg`
+- macOS ARM64 updater: `src-tauri/target/release/bundle/macos/mdownreview.app.tar.gz`
+
+- [ ] **Step 1: Replace the build job**
+
+Replace lines 39–106 of `.github/workflows/release.yml` (the entire `build:` job) with:
+
+```yaml
+  build:
+    needs: create-release
+    name: Build (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
+          - os: macos-latest
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clean stale bundles from cache
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+
+      - name: Build Tauri app
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Rename and upload artifacts
+        shell: bash
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          VERSION="${TAG#v}"
+          NAME="mdownreview-${VERSION}-${{ matrix.name }}"
+
+          if [[ "${{ matrix.name }}" == windows-* ]]; then
+            # Rename the NSIS zip (serves as both download and updater artifact)
+            nsis_zip=$(ls -t ${{ matrix.target_dir }}/bundle/nsis/*.nsis.zip 2>/dev/null | head -1)
+            [ -z "$nsis_zip" ] && { echo "::error::NSIS zip not found"; exit 1; }
+            cp "$nsis_zip" "${NAME}.zip"
+            gh release upload "$TAG" "${NAME}.zip" --clobber
+
+            # Upload the signature file with matching name
+            sig="${nsis_zip}.sig"
+            if [ -f "$sig" ]; then
+              cp "$sig" "${NAME}.zip.sig"
+              gh release upload "$TAG" "${NAME}.zip.sig" --clobber
+            fi
+          else
+            # Rename the DMG for human download
+            dmg=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
+            [ -z "$dmg" ] && { echo "::error::DMG not found"; exit 1; }
+            cp "$dmg" "${NAME}.dmg"
+            gh release upload "$TAG" "${NAME}.dmg" --clobber
+
+            # Rename the .app.tar.gz updater bundle
+            app_tar=$(ls -t ${{ matrix.target_dir }}/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+            if [ -n "$app_tar" ]; then
+              cp "$app_tar" "${NAME}.app.tar.gz"
+              gh release upload "$TAG" "${NAME}.app.tar.gz" --clobber
+              sig="${app_tar}.sig"
+              if [ -f "$sig" ]; then
+                cp "$sig" "${NAME}.app.tar.gz.sig"
+                gh release upload "$TAG" "${NAME}.app.tar.gz.sig" --clobber
+              fi
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: No output (success). If Python yaml module isn't available, use: `npx yaml-lint .github/workflows/release.yml` or visually inspect indentation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: update release build matrix with consistent naming and ARM64
+
+- 3-entry matrix: windows-x64, windows-arm64, macos-arm64
+- Rename Tauri artifacts to mdownreview-{ver}-{os}-{arch}.{ext}
+- Windows .nsis.zip serves as both download and updater artifact
+- Remove extension-wide asset deletion, use --clobber instead"
+```
+
+---
+
+### Task 2: Update release.yml latest.json manifest generation
+
+**Files:**
+- Modify: `.github/workflows/release.yml:108-170` (the `publish-update-manifest` job)
+
+The `latest.json` generation must reference the new consistently named files and add `windows-aarch64`.
+
+- [ ] **Step 1: Replace the latest.json generation step**
+
+Replace the `Build and upload latest.json` step content (lines ~114-168) with:
+
+```yaml
+      - name: Build and upload latest.json
+        shell: bash
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          VERSION="${TAG#v}"
+          BASE_URL="https://github.com/dryotta/mdownreview/releases/download/${TAG}"
+          NAME="mdownreview-${VERSION}"
+
+          mkdir -p /tmp/sigs
+
+          # Read signature file content from a release asset
+          read_sig() {
+            local asset_name="$1"
+            gh release download "$TAG" --pattern "${asset_name}" --dir /tmp/sigs 2>/dev/null || true
+            cat "/tmp/sigs/${asset_name}" 2>/dev/null || echo ""
+          }
+
+          WIN_X64_SIG=$(read_sig "${NAME}-windows-x64.zip.sig")
+          WIN_ARM64_SIG=$(read_sig "${NAME}-windows-arm64.zip.sig")
+          MAC_ARM64_SIG=$(read_sig "${NAME}-macos-arm64.app.tar.gz.sig")
+
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          cat > /tmp/latest.json <<EOF
+          {
+            "version": "${VERSION}",
+            "notes": "See release notes on GitHub.",
+            "pub_date": "${PUB_DATE}",
+            "platforms": {
+              "windows-x86_64": {
+                "signature": "${WIN_X64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-x64.zip"
+              },
+              "windows-aarch64": {
+                "signature": "${WIN_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-arm64.zip"
+              },
+              "darwin-aarch64": {
+                "signature": "${MAC_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-macos-arm64.app.tar.gz"
+              }
+            }
+          }
+          EOF
+
+          gh release upload "$TAG" /tmp/latest.json --clobber
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: No output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: update latest.json manifest for new naming and ARM64
+
+- Reference renamed artifacts by exact name (no glob matching)
+- Add windows-aarch64 platform entry
+- Simpler sig reading via exact filename download"
+```
+
+---
+
+### Task 3: Update CI workflow build matrix
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:92-146`
+
+Mirror the release workflow's 3-entry build matrix for CI. CI uploads artifacts to `actions/upload-artifact` instead of a GitHub Release.
+
+- [ ] **Step 1: Replace the build job**
+
+Replace lines 92–146 of `.github/workflows/ci.yml` (the entire `build:` job) with:
+
+```yaml
+  # ── Installer builds (Windows + macOS) ───────────────────────────────────
+  # Runs in parallel with the test job above.
+  build:
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+            artifact_ext: zip
+
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
+            artifact_ext: zip
+
+          - os: macos-latest
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+            artifact_ext: dmg
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clean stale bundles from cache
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+
+      - name: Build Tauri app
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          NAME="mdownreview-${{ matrix.name }}"
+          if [[ "${{ matrix.artifact_ext }}" == "zip" ]]; then
+            nsis_zip=$(ls -t ${{ matrix.target_dir }}/bundle/nsis/*.nsis.zip 2>/dev/null | head -1)
+            [ -z "$nsis_zip" ] && { echo "::error::NSIS zip not found"; exit 1; }
+            cp "$nsis_zip" "${NAME}.zip"
+            echo "ARTIFACT=${NAME}.zip" >> "$GITHUB_ENV"
+          else
+            dmg=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
+            [ -z "$dmg" ] && { echo "::error::DMG not found"; exit 1; }
+            cp "$dmg" "${NAME}.dmg"
+            echo "ARTIFACT=${NAME}.dmg" >> "$GITHUB_ENV"
+          fi
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ env.ARTIFACT }}
+          retention-days: 14
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: No output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: update CI build matrix to match release naming
+
+- 3-entry matrix: windows-x64, windows-arm64, macos-arm64
+- Rename artifacts to mdownreview-{os}-{arch}.{ext} (no version in CI)
+- Upload via actions/upload-artifact with 14-day retention"
+```
+
+---
+
+### Task 4: Create macOS install script
+
+**Files:**
+- Create: `site/install.sh`
+
+Shell script for `curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh`. Detects macOS ARM64, downloads DMG from latest GitHub Release, mounts it, copies .app to ~/Applications.
+
+- [ ] **Step 1: Create `site/install.sh`**
+
+```bash
+#!/bin/sh
+set -eu
+
+APP_NAME="mdownreview"
+GITHUB_REPO="dryotta/mdownreview"
+INSTALL_DIR="$HOME/Applications"
+
+main() {
+  need_cmd curl
+  need_cmd hdiutil
+  need_cmd cp
+  need_cmd rm
+  need_cmd mktemp
+
+  # Only macOS is supported
+  OS="$(uname -s)"
+  case "$OS" in
+    Darwin) ;;
+    *) err "This script only supports macOS. For Windows, use install.ps1." ;;
+  esac
+
+  # Detect architecture
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    arm64)  ARCH_LABEL="arm64" ;;
+    x86_64) ARCH_LABEL="arm64" ; say "Note: Intel Mac detected. Installing ARM64 build (runs via Rosetta 2)." ;;
+    *) err "Unsupported architecture: $ARCH" ;;
+  esac
+
+  say "Fetching latest release..."
+  TAG=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+  [ -z "$TAG" ] && err "Could not determine latest release tag."
+  VERSION="${TAG#v}"
+
+  FILENAME="${APP_NAME}-${VERSION}-macos-${ARCH_LABEL}.dmg"
+  URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${FILENAME}"
+
+  TMPDIR_INSTALL="$(mktemp -d)"
+  trap 'cleanup' EXIT
+
+  say "Downloading ${FILENAME}..."
+  curl -fSL --progress-bar -o "${TMPDIR_INSTALL}/${FILENAME}" "$URL"
+
+  say "Mounting disk image..."
+  MOUNT_POINT=$(hdiutil attach -nobrowse -readonly "${TMPDIR_INSTALL}/${FILENAME}" \
+    | grep '/Volumes/' | sed 's/.*\(\/Volumes\/.*\)/\1/')
+  [ -z "$MOUNT_POINT" ] && err "Failed to mount DMG."
+
+  APP_PATH=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" | head -1)
+  [ -z "$APP_PATH" ] && { hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true; err "No .app found in DMG."; }
+
+  mkdir -p "$INSTALL_DIR"
+  APP_BASENAME="$(basename "$APP_PATH")"
+
+  # Remove existing installation if present
+  if [ -d "${INSTALL_DIR}/${APP_BASENAME}" ]; then
+    say "Removing previous installation..."
+    rm -rf "${INSTALL_DIR}/${APP_BASENAME}"
+  fi
+
+  say "Installing to ${INSTALL_DIR}/${APP_BASENAME}..."
+  cp -R "$APP_PATH" "$INSTALL_DIR/"
+
+  hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+
+  say ""
+  say "✓ ${APP_NAME} ${VERSION} installed to ${INSTALL_DIR}/${APP_BASENAME}"
+  say "  Open it from ~/Applications or run:"
+  say "    open \"${INSTALL_DIR}/${APP_BASENAME}\""
+}
+
+cleanup() {
+  [ -d "${TMPDIR_INSTALL:-}" ] && rm -rf "$TMPDIR_INSTALL"
+  # Attempt unmount in case of early exit
+  [ -n "${MOUNT_POINT:-}" ] && hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+}
+
+say() {
+  printf '%s\n' "$@"
+}
+
+err() {
+  say "error: $1" >&2
+  exit 1
+}
+
+need_cmd() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    err "need '$1' (command not found)"
+  fi
+}
+
+main "$@"
+```
+
+- [ ] **Step 2: Verify script syntax**
+
+Run: `bash -n site/install.sh`
+Expected: No output (syntax OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/install.sh
+git commit -m "feat: add macOS install script
+
+curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh
+
+- Detects macOS, ARM64 architecture
+- Downloads latest DMG from GitHub Releases
+- Mounts DMG, copies .app to ~/Applications
+- Cleans up temp files on exit"
+```
+
+---
+
+### Task 5: Create Windows PowerShell install script
+
+**Files:**
+- Create: `site/install.ps1`
+
+PowerShell script for `irm https://dryotta.github.io/mdownreview/install.ps1 | iex`. Detects architecture, downloads zip from latest GitHub Release, extracts, runs NSIS setup silently.
+
+- [ ] **Step 1: Create `site/install.ps1`**
+
+```powershell
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the latest version of mdownreview on Windows.
+.DESCRIPTION
+    Downloads the latest mdownreview installer from GitHub Releases,
+    extracts it, and runs the NSIS setup in silent mode (current-user install).
+.EXAMPLE
+    powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$AppName = 'mdownreview'
+$GitHubRepo = 'dryotta/mdownreview'
+
+function Get-Architecture {
+    try {
+        $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
+        $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
+        $p = $t.GetProperty("OSArchitecture")
+        switch ($p.GetValue($null).ToString()) {
+            "X64"   { return "x64" }
+            "Arm64" { return "arm64" }
+            default { throw "Unsupported architecture: $_" }
+        }
+    } catch {
+        # Fallback for older PowerShell
+        if ([System.Environment]::Is64BitOperatingSystem) {
+            return "x64"
+        } else {
+            throw "Unsupported architecture: 32-bit Windows is not supported."
+        }
+    }
+}
+
+function Install-Mdownreview {
+    Write-Host "Detecting architecture..."
+    $arch = Get-Architecture
+    Write-Host "  Architecture: $arch"
+
+    Write-Host "Fetching latest release..."
+    $releaseUrl = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+    $release = Invoke-RestMethod -Uri $releaseUrl -UseBasicParsing
+    $tag = $release.tag_name
+    $version = $tag.TrimStart('v')
+    Write-Host "  Latest version: $version"
+
+    $fileName = "$AppName-$version-windows-$arch.zip"
+    $downloadUrl = "https://github.com/$GitHubRepo/releases/download/$tag/$fileName"
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "$AppName-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        $zipPath = Join-Path $tempDir $fileName
+        Write-Host "Downloading $fileName..."
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+
+        Write-Host "Extracting..."
+        Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+        # Find the setup exe inside the extracted files
+        $setupExe = Get-ChildItem -Path $tempDir -Filter "*setup*.exe" -Recurse | Select-Object -First 1
+        if (-not $setupExe) {
+            $setupExe = Get-ChildItem -Path $tempDir -Filter "*.exe" -Recurse | Select-Object -First 1
+        }
+        if (-not $setupExe) {
+            throw "No installer executable found in the downloaded archive."
+        }
+
+        Write-Host "Running installer silently..."
+        $process = Start-Process -FilePath $setupExe.FullName -ArgumentList '/S' -Wait -PassThru
+        if ($process.ExitCode -ne 0) {
+            throw "Installer exited with code $($process.ExitCode)."
+        }
+
+        Write-Host ""
+        Write-Host "Done! $AppName $version has been installed." -ForegroundColor Green
+        Write-Host "  You can launch it from the Start Menu or by searching for '$AppName'."
+    } finally {
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Install-Mdownreview
+```
+
+- [ ] **Step 2: Verify script syntax**
+
+Run: `powershell -NoProfile -Command "Get-Command -Syntax { . 'site\install.ps1' }" 2>&1` or simply parse: `powershell -NoProfile -Command "[System.Management.Automation.PSParser]::Tokenize((Get-Content 'site\install.ps1' -Raw), [ref]$null) | Out-Null; Write-Host 'Syntax OK'"`
+Expected: "Syntax OK"
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/install.ps1
+git commit -m "feat: add Windows PowerShell install script
+
+powershell -ExecutionPolicy ByPass -c 'irm https://dryotta.github.io/mdownreview/install.ps1 | iex'
+
+- Detects x64 or ARM64 architecture
+- Downloads latest zip from GitHub Releases
+- Extracts and runs NSIS setup.exe silently (/S flag)
+- Cleans up temp files"
+```
+
+---
+
+### Task 6: Update site landing page
+
+**Files:**
+- Modify: `site/index.html:51-58`
+
+Add a "Quick Install" section before the existing "Build from source" section.
+
+- [ ] **Step 1: Add Quick Install section**
+
+Insert the following HTML before line 52 (`<section class="install">` with "Build from source"):
+
+```html
+  <section class="install">
+    <h2>Quick Install</h2>
+    <p><strong>macOS</strong></p>
+    <pre><code>curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh</code></pre>
+    <p><strong>Windows</strong></p>
+    <pre><code>powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"</code></pre>
+    <p>Or download directly from <a href="https://github.com/dryotta/mdownreview/releases/latest">GitHub Releases</a>.</p>
+  </section>
+
+```
+
+This goes between the `</section>` closing the features section (line 50) and the existing `<section class="install">` for "Build from source" (line 52).
+
+- [ ] **Step 2: Verify HTML renders correctly**
+
+Open `site/index.html` in a browser and visually confirm the Quick Install section appears above Build from source.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/index.html
+git commit -m "docs: add Quick Install section to landing page
+
+Shows curl|sh and irm|iex one-liner install commands
+for macOS and Windows with a link to GitHub Releases."
+```
+
+---
+
+### Task 7: Update release notes template and final verification
+
+**Files:**
+- Modify: `.github/workflows/release.yml:29-36` (release notes text)
+
+- [ ] **Step 1: Update release notes text**
+
+Update the `--notes` in the `create-release` job to document the new naming and install commands:
+
+```yaml
+      - name: Create draft release
+        run: |
+          # Skip creation if release already exists (re-run scenario)
+          gh release view "${{ steps.tag.outputs.tag }}" &>/dev/null || \
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --draft \
+            --title "mdownreview ${{ steps.tag.outputs.tag }}" \
+            --notes "## Install
+
+          **macOS**
+          \`\`\`
+          curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh
+          \`\`\`
+
+          **Windows**
+          \`\`\`
+          powershell -ExecutionPolicy ByPass -c \"irm https://dryotta.github.io/mdownreview/install.ps1 | iex\"
+          \`\`\`
+
+          Or download the installer for your platform from the Assets section below."
+```
+
+- [ ] **Step 2: Full YAML validation of both workflows**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); yaml.safe_load(open('.github/workflows/ci.yml')); print('Both workflows valid')"
+```
+Expected: "Both workflows valid"
+
+- [ ] **Step 3: Review all changed files**
+
+Run: `git diff --stat HEAD~6` (or however many commits were made)
+Expected: 5 files changed:
+- `.github/workflows/release.yml`
+- `.github/workflows/ci.yml`
+- `site/install.sh` (new)
+- `site/install.ps1` (new)
+- `site/index.html`
+
+- [ ] **Step 4: Commit release notes change**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: update release notes template with install commands"
+```
+
+- [ ] **Step 5: Verify existing tests still pass**
+
+Run: `npm test`
+Expected: All Vitest tests pass (no source code was changed).
+
+Run: `cd src-tauri && cargo test`
+Expected: All Rust tests pass (no Rust source code was changed).

--- a/docs/superpowers/specs/2026-04-20-installation-system-design.md
+++ b/docs/superpowers/specs/2026-04-20-installation-system-design.md
@@ -1,0 +1,170 @@
+# Installation System Overhaul
+
+## Problem
+
+Current release artifacts have inconsistent naming (no OS label, mixed arch formats like `x64` vs `aarch64`), no Windows ARM64 build, and no way to install from the command line. Users must manually navigate GitHub Releases to find the right download.
+
+## Goals
+
+1. Mark Windows and macOS clearly in release filenames
+2. Use consistent naming across all release artifacts
+3. Mark CPU architecture clearly for each file
+4. Add Windows ARM64 build
+5. Eliminate duplicate artifacts — single zip serves as both download and Tauri updater bundle
+6. Provide `curl | sh` and `irm | iex` install scripts (like uv)
+
+## Non-Goals
+
+- macOS x86_64 build (ARM64-only; Intel Macs use Rosetta 2)
+- Linux builds
+- Version pinning in install scripts (latest only)
+- Homebrew / winget / scoop packages
+
+## Naming Convention
+
+All release assets follow: `mdownreview-{version}-{os}-{arch}.{ext}`
+
+- Lowercase, dash-separated
+- OS: `windows`, `macos`
+- Arch: `x64`, `arm64`
+
+## Release Artifacts
+
+Per release tag, the following assets are uploaded:
+
+| Asset | Description |
+|---|---|
+| `mdownreview-{ver}-windows-x64.zip` | NSIS setup.exe in a zip (download + updater) |
+| `mdownreview-{ver}-windows-x64.zip.sig` | Updater signature |
+| `mdownreview-{ver}-windows-arm64.zip` | NSIS setup.exe in a zip (download + updater) |
+| `mdownreview-{ver}-windows-arm64.zip.sig` | Updater signature |
+| `mdownreview-{ver}-macos-arm64.dmg` | macOS disk image (human download) |
+| `mdownreview-{ver}-macos-arm64.app.tar.gz` | macOS updater bundle |
+| `mdownreview-{ver}-macos-arm64.app.tar.gz.sig` | macOS updater signature |
+| `latest.json` | Tauri updater manifest |
+
+The Windows `.zip` serves double duty: users download and extract it to run the installer; the Tauri updater downloads and extracts it to apply updates. This avoids duplicating the NSIS bundle.
+
+For macOS, the DMG and `.app.tar.gz` remain separate because the Tauri updater cannot process a DMG.
+
+## Build Matrix
+
+### Release Workflow (`.github/workflows/release.yml`)
+
+Three matrix entries:
+
+| Runner | Rust Target | Tauri Build Args | Output |
+|---|---|---|---|
+| `windows-latest` | `x86_64-pc-windows-msvc` | (none) | NSIS zip + sig |
+| `windows-latest` | `aarch64-pc-windows-msvc` | `--target aarch64-pc-windows-msvc` | NSIS zip + sig |
+| `macos-latest` | `aarch64-apple-darwin` | (none) | DMG + app.tar.gz + sig |
+
+Windows ARM64 is cross-compiled on the `windows-latest` runner using `rustup target add aarch64-pc-windows-msvc`.
+
+**Post-build rename step:** Each matrix entry renames Tauri's default output files to the consistent naming convention before uploading to the GitHub Release.
+
+**Path handling:** Native builds output to `src-tauri/target/release/bundle/`. Cross-compiled ARM64 builds output to `src-tauri/target/aarch64-pc-windows-msvc/release/bundle/`. The matrix includes per-entry `target_dir` fields.
+
+### CI Workflow (`.github/workflows/ci.yml`)
+
+Same 3-entry matrix, producing identically named artifacts for CI verification. Artifacts are uploaded with `actions/upload-artifact` (14-day retention), not to a GitHub Release.
+
+### Updater Manifest (`latest.json`)
+
+References the consistently named updater artifacts:
+
+```json
+{
+  "version": "0.2.6",
+  "platforms": {
+    "windows-x86_64": {
+      "signature": "...",
+      "url": "https://github.com/dryotta/mdownreview/releases/download/v0.2.6/mdownreview-0.2.6-windows-x64.zip"
+    },
+    "windows-aarch64": {
+      "signature": "...",
+      "url": "https://github.com/dryotta/mdownreview/releases/download/v0.2.6/mdownreview-0.2.6-windows-arm64.zip"
+    },
+    "darwin-aarch64": {
+      "signature": "...",
+      "url": "https://github.com/dryotta/mdownreview/releases/download/v0.2.6/mdownreview-0.2.6-macos-arm64.app.tar.gz"
+    }
+  }
+}
+```
+
+## Install Scripts
+
+### Shell Script (`site/install.sh`)
+
+For macOS. Hosted on GitHub Pages at `https://dryotta.github.io/mdownreview/install.sh`.
+
+**Usage:**
+```bash
+curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh
+```
+
+**Behavior:**
+1. Detect architecture via `uname -m` (only `arm64` supported; exits with message for others)
+2. Fetch latest release tag from `https://api.github.com/repos/dryotta/mdownreview/releases/latest`
+3. Download `mdownreview-{ver}-macos-arm64.dmg` to a temp directory
+4. Mount DMG via `hdiutil attach`
+5. Copy `.app` bundle to `~/Applications/` (creates directory if needed)
+6. Unmount DMG via `hdiutil detach`
+7. Clean up temp files
+8. Print success message
+
+**Error handling:** Validates HTTP status codes, checks for expected files, prints clear messages on failure, cleans up temp on exit (trap).
+
+### PowerShell Script (`site/install.ps1`)
+
+For Windows. Hosted on GitHub Pages at `https://dryotta.github.io/mdownreview/install.ps1`.
+
+**Usage:**
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"
+```
+
+**Behavior:**
+1. Detect architecture via `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` → maps `X64` to `x64`, `Arm64` to `arm64`
+2. Fetch latest release tag from GitHub API
+3. Download `mdownreview-{ver}-windows-{arch}.zip` to temp directory
+4. Extract zip using `Expand-Archive`
+5. Run the NSIS setup.exe with `/S` flag (silent install, current-user mode)
+6. Clean up temp files
+7. Print success message
+
+**Error handling:** Uses `try/catch`, validates downloads, checks installer exit code.
+
+## Site Updates
+
+### `site/index.html`
+
+Add a "Quick Install" section above the existing "Build from source" section:
+
+```html
+<section class="install">
+  <h2>Quick Install</h2>
+  <p><strong>macOS</strong></p>
+  <pre><code>curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh</code></pre>
+  <p><strong>Windows</strong></p>
+  <pre><code>powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"</code></pre>
+</section>
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `.github/workflows/release.yml` | New 3-entry build matrix, rename step, unified zip artifacts, updated latest.json generation |
+| `.github/workflows/ci.yml` | Matching 3-entry build matrix with consistent artifact naming |
+| `site/install.sh` | New macOS shell install script |
+| `site/install.ps1` | New Windows PowerShell install script |
+| `site/index.html` | Add Quick Install section |
+
+## Testing
+
+- **Workflow validation:** Push to a test branch with a tag to verify the release workflow produces correctly named artifacts
+- **Install scripts:** Manual testing on macOS (ARM64) and Windows (x64 + ARM64 if available)
+- **Updater:** Verify `latest.json` is correctly generated and the Tauri updater can fetch updates from the new URLs
+- Existing `cargo test`, `npm test`, and `npm run test:e2e` remain unaffected (no source code changes)

--- a/site/index.html
+++ b/site/index.html
@@ -50,6 +50,15 @@
   </section>
 
   <section class="install">
+    <h2>Quick Install</h2>
+    <p><strong>macOS</strong></p>
+    <pre><code>curl -LsSf https://dryotta.github.io/mdownreview/install.sh | sh</code></pre>
+    <p><strong>Windows</strong></p>
+    <pre><code>powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"</code></pre>
+    <p>Or download directly from <a href="https://github.com/dryotta/mdownreview/releases/latest">GitHub Releases</a>.</p>
+  </section>
+
+  <section class="install">
     <h2>Build from source</h2>
     <pre><code>git clone https://github.com/dryotta/mdownreview
 cd mdownreview

--- a/site/install.ps1
+++ b/site/install.ps1
@@ -1,0 +1,89 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the latest version of mdownreview on Windows.
+.DESCRIPTION
+    Downloads the latest mdownreview installer from GitHub Releases,
+    extracts it, and runs the NSIS setup in silent mode (current-user install).
+.EXAMPLE
+    powershell -ExecutionPolicy ByPass -c "irm https://dryotta.github.io/mdownreview/install.ps1 | iex"
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$AppName = 'mdownreview'
+$GitHubRepo = 'dryotta/mdownreview'
+
+function Get-Architecture {
+    try {
+        $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
+        $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
+        $p = $t.GetProperty("OSArchitecture")
+        switch ($p.GetValue($null).ToString()) {
+            "X64"   { return "x64" }
+            "Arm64" { return "arm64" }
+            default { throw "Unsupported architecture: $_" }
+        }
+    } catch {
+        # Fallback for older PowerShell
+        $arch = $env:PROCESSOR_ARCHITECTURE
+        if ($arch -eq "AMD64") {
+            return "x64"
+        } elseif ($arch -eq "ARM64") {
+            return "arm64"
+        } else {
+            throw "Unsupported architecture: $arch"
+        }
+    }
+}
+
+function Install-Mdownreview {
+    Write-Host "Detecting architecture..."
+    $arch = Get-Architecture
+    Write-Host "  Architecture: $arch"
+
+    Write-Host "Fetching latest release..."
+    $releaseUrl = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+    $release = Invoke-RestMethod -Uri $releaseUrl -UseBasicParsing
+    $tag = $release.tag_name
+    $version = $tag.TrimStart('v')
+    Write-Host "  Latest version: $version"
+
+    $fileName = "$AppName-$version-windows-$arch.zip"
+    $downloadUrl = "https://github.com/$GitHubRepo/releases/download/$tag/$fileName"
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "$AppName-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        $zipPath = Join-Path $tempDir $fileName
+        Write-Host "Downloading $fileName..."
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+
+        Write-Host "Extracting..."
+        Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+        # Find the setup exe inside the extracted files
+        $setupExe = Get-ChildItem -Path $tempDir -Filter "*setup*.exe" -Recurse | Select-Object -First 1
+        if (-not $setupExe) {
+            $setupExe = Get-ChildItem -Path $tempDir -Filter "*.exe" -Recurse | Select-Object -First 1
+        }
+        if (-not $setupExe) {
+            throw "No installer executable found in the downloaded archive."
+        }
+
+        Write-Host "Running installer silently..."
+        $process = Start-Process -FilePath $setupExe.FullName -ArgumentList '/S' -Wait -PassThru
+        if ($process.ExitCode -ne 0) {
+            throw "Installer exited with code $($process.ExitCode)."
+        }
+
+        Write-Host ""
+        Write-Host "Done! $AppName $version has been installed." -ForegroundColor Green
+        Write-Host "  You can launch it from the Start Menu or by searching for '$AppName'."
+    } finally {
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Install-Mdownreview

--- a/site/install.sh
+++ b/site/install.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+APP_NAME="mdownreview"
+GITHUB_REPO="dryotta/mdownreview"
+INSTALL_DIR="$HOME/Applications"
+
+main() {
+  need_cmd curl
+  need_cmd hdiutil
+  need_cmd cp
+  need_cmd rm
+  need_cmd mktemp
+
+  # Only macOS is supported
+  OS="$(uname -s)"
+  case "$OS" in
+    Darwin) ;;
+    *) err "This script only supports macOS. For Windows, use install.ps1." ;;
+  esac
+
+  # Detect architecture
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    arm64)  ARCH_LABEL="arm64" ;;
+    x86_64) ARCH_LABEL="arm64" ; say "Note: Intel Mac detected. Installing ARM64 build (runs via Rosetta 2)." ;;
+    *) err "Unsupported architecture: $ARCH" ;;
+  esac
+
+  say "Fetching latest release..."
+  TAG=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+  [ -z "$TAG" ] && err "Could not determine latest release tag."
+  VERSION="${TAG#v}"
+
+  FILENAME="${APP_NAME}-${VERSION}-macos-${ARCH_LABEL}.dmg"
+  URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${FILENAME}"
+
+  TMPDIR_INSTALL="$(mktemp -d)"
+  trap 'cleanup' EXIT
+
+  say "Downloading ${FILENAME}..."
+  curl -fSL --progress-bar -o "${TMPDIR_INSTALL}/${FILENAME}" "$URL"
+
+  say "Mounting disk image..."
+  MOUNT_POINT=$(hdiutil attach -nobrowse -readonly "${TMPDIR_INSTALL}/${FILENAME}" \
+    | grep '/Volumes/' | sed 's/.*\(\/Volumes\/.*\)/\1/')
+  [ -z "$MOUNT_POINT" ] && err "Failed to mount DMG."
+
+  APP_PATH=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" | head -1)
+  [ -z "$APP_PATH" ] && { hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true; err "No .app found in DMG."; }
+
+  mkdir -p "$INSTALL_DIR"
+  APP_BASENAME="$(basename "$APP_PATH")"
+
+  # Remove existing installation if present
+  if [ -d "${INSTALL_DIR}/${APP_BASENAME}" ]; then
+    say "Removing previous installation..."
+    rm -rf "${INSTALL_DIR}/${APP_BASENAME}"
+  fi
+
+  say "Installing to ${INSTALL_DIR}/${APP_BASENAME}..."
+  cp -R "$APP_PATH" "$INSTALL_DIR/"
+
+  hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+
+  say ""
+  say "✓ ${APP_NAME} ${VERSION} installed to ${INSTALL_DIR}/${APP_BASENAME}"
+  say "  Open it from ~/Applications or run:"
+  say "    open \"${INSTALL_DIR}/${APP_BASENAME}\""
+}
+
+cleanup() {
+  [ -d "${TMPDIR_INSTALL:-}" ] && rm -rf "$TMPDIR_INSTALL"
+  # Attempt unmount in case of early exit
+  [ -n "${MOUNT_POINT:-}" ] && hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+}
+
+say() {
+  printf '%s\n' "$@"
+}
+
+err() {
+  say "error: $1" >&2
+  exit 1
+}
+
+need_cmd() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    err "need '$1' (command not found)"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Overhauls the release and CI pipelines for consistent artifact naming, adds Windows ARM64 builds, and introduces one-line install scripts.

### Changes

**Release pipeline** (.github/workflows/release.yml)
- 3-entry build matrix: windows-x64, windows-arm64, macos-arm64
- Consistent naming: mdownreview-{version}-{os}-{arch}.{ext}
- Updated latest.json manifest with all 3 platform keys
- Added asset validation before generating updater manifest
- Release notes include install commands

**CI pipeline** (.github/workflows/ci.yml)
- Build matrix matches release pipeline (windows-x64, windows-arm64, macos-arm64)

**Install scripts**
- site/install.sh - macOS install via curl pipe sh
- site/install.ps1 - Windows install via irm pipe iex
- Landing page (site/index.html) updated with Quick Install section

**Publish-release skill** (.claude/skills/publish-release/SKILL.md)
- Updated for PR-based flow (main branch is now protected)

### Design decisions
- .nsis.zip serves dual purpose: user download AND Tauri updater artifact
- macOS ARM64 only (Intel uses Rosetta 2)
- Install scripts hosted on GitHub Pages, download from GitHub Releases API
- PowerShell fallback uses PROCESSOR_ARCHITECTURE env var for correct ARM64 detection
