### PR TITLE
fix: transparent background on app icon SVG

### DIFF
--- a/src-tauri/icons/icon.svg
+++ b/src-tauri/icons/icon.svg
@@ -5,7 +5,6 @@
       <stop offset="100%" stop-color="#4B4FD9"/>
     </linearGradient>
   </defs>
-  <rect width="100" height="100" rx="20" fill="#18181b"/>
   <rect x="1.5" y="1.5" width="97" height="97" rx="18.5" fill="none" stroke="url(#g)" stroke-width="3"/>
   <text x="50" y="70"
     text-anchor="middle"


### PR DESCRIPTION
Removes the dark `#18181b` background rect from `icon.svg` so the icon renders on a transparent background.