### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## v0.3.1 — 2026-04-21
+
+### Features
+- feat: regenerate rasterized icons from updated gradient SVG
+- feat: redesign site — scroll snap, sticky nav, indigo palette, remove releases tab
+- feat: rebrand with indigo gradient identity and clean up icon folder
+- feat: sticky frosted nav, scroll-padding-top, and reveal transition delay
+- feat: add CSS scroll snap proximity for slide-style page sections
+- feat: add scroll reveal animation to page sections
+- feat: remove GitHub Releases tab from download section
+- feat: simplify site palette to single indigo brand color
+- feat: update favicon with gradient and adaptive dark/light background
+- feat: update app icon with indigo gradient
+- feat: replace install section with platform-aware tabs
+- feat: simplify How It Works to single-column with app mock on step 2 only
+- feat: remove screenshot section and replace Copilot references with agent
+- feat: replace app icon with brand identity icon
+- feat: apply indigo brand identity to site nav and app welcome screen
+
+### Fixes
+- fix: transparent background on app icon SVG
+- fix: reveal animation fires after snap via scrollend, no opacity hide
+- fix: remove unused afterEach import causing TS6133 build error
+- fix: make hero full viewport height to push sections below fold
+- fix: scroll restore, sidecar reload bugs, and comprehensive test coverage
+- fix: skip reveal animation for sections already in viewport on load
+- fix: add trailing newline to icon.svg
+- fix: use currentColor for SVG brand color, simplify icon font family
+- fix: use CSS variable for brand color, clean up welcome-logo font-size
+
+### Other
+- chore: remove site review sidecar
+- chore: remove unused icon variants
+- docs: overhaul site and README, add branding and redesign specs
+- style: remove dead terminal CSS and orphaned responsive rules
+- copy: reframe how-it-works steps to user perspective
+
 ## v0.3.0 — 2026-04-20
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdownreview",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdownreview",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@shikijs/rehype": "^4.0.2",
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdownreview",
   "private": true,
   "description": "Review AI Agent's work",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2443,7 +2443,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mdownreview"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -3814,9 +3814,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5160,7 +5160,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5169,7 +5169,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6308,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdownreview"
-version = "0.3.0"
+version = "0.3.1"
 description = "A desktop markdown reviewer for developers"
 license = "MIT"
 authors = ["davidzh"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mdownreview",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.mdownreview.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v0.3.1. Merge this PR, then the release tag will be created automatically.