### PR TITLE
fix: prevent empty .review.yaml sidecars

### DIFF
--- a/.claude/hooks/check-test-exists.js
+++ b/.claude/hooks/check-test-exists.js
@@ -1,5 +1,8 @@
 // Warns when a source file in src/lib/ or src/components/ is written without a test file.
-const raw = require('fs').readFileSync(0, 'utf8');
+import { readFileSync, existsSync } from "fs";
+import { dirname, basename, join } from "path";
+
+const raw = readFileSync(0, "utf8");
 try {
   const fp = JSON.parse(raw)?.tool_input?.file_path;
   if (!fp) process.exit(0);
@@ -7,13 +10,11 @@ try {
   if (/(__tests__|\.test\.|test-setup|__mocks__)/.test(fp)) process.exit(0);
   if (!/\.(ts|tsx)$/.test(fp)) process.exit(0);
 
-  // Derive expected test path: insert __tests__ before filename
-  const path = require('path');
-  const dir = path.dirname(fp);
-  const base = path.basename(fp).replace(/\.tsx?$/, (m) => `.test${m}`);
-  const testPath = path.join(dir, '__tests__', base);
+  const dir = dirname(fp);
+  const base = basename(fp).replace(/\.tsx?$/, (m) => `.test${m}`);
+  const testPath = join(dir, "__tests__", base);
 
-  if (!require('fs').existsSync(testPath)) {
+  if (!existsSync(testPath)) {
     process.stderr.write(`⚠  No test file: ${testPath}\n`);
   }
 } catch (_) {}

--- a/.claude/hooks/prettier-on-edit.js
+++ b/.claude/hooks/prettier-on-edit.js
@@ -1,9 +1,14 @@
 // Runs prettier on the edited file after Write/Edit tool calls.
-const { execSync } = require('child_process');
-const raw = require('fs').readFileSync(0, 'utf8');
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+
+const raw = readFileSync(0, "utf8");
 try {
   const fp = JSON.parse(raw)?.tool_input?.file_path;
   if (fp && /\.(ts|tsx|js|jsx|css)$/.test(fp)) {
-    execSync(`npx prettier --write ${JSON.stringify(fp)}`, { stdio: 'inherit', shell: true });
+    execSync(`npx prettier --write ${JSON.stringify(fp)}`, {
+      stdio: "inherit",
+      shell: true,
+    });
   }
 } catch (_) {}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,6 +172,18 @@ pub fn read_binary_file(path: String) -> Result<String, String> {
 #[tauri::command]
 pub fn save_review_comments(file_path: String, document: String, comments: Vec<MrsfComment>) -> Result<(), String> {
     let sidecar_path = std::path::PathBuf::from(format!("{}.review.yaml", file_path));
+
+    // When all comments are gone, remove the sidecar rather than leaving an empty file.
+    if comments.is_empty() {
+        if sidecar_path.exists() {
+            std::fs::remove_file(&sidecar_path).map_err(|e| {
+                tracing::error!("[rust] command error: {}", e);
+                e.to_string()
+            })?;
+        }
+        return Ok(());
+    }
+
     let payload = MrsfSidecar {
         mrsf_version: "1.0".to_string(),
         document,

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -138,6 +138,35 @@ fn load_review_comments_returns_none_when_missing() {
 }
 
 #[test]
+fn save_review_comments_deletes_sidecar_when_empty() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let file_path = tmp.path().to_str().unwrap().to_string();
+    let sidecar_path = format!("{}.review.yaml", file_path);
+
+    // Write a sidecar with one comment, then save empty to clear it.
+    save_review_comments(file_path.clone(), "test.md".to_string(), vec![make_mrsf_comment("c1")]).unwrap();
+    assert!(std::path::Path::new(&sidecar_path).exists());
+
+    save_review_comments(file_path.clone(), "test.md".to_string(), vec![]).unwrap();
+    assert!(!std::path::Path::new(&sidecar_path).exists(), "empty save should delete the sidecar");
+
+    // Subsequent load should return None (no sidecar).
+    let result = load_review_comments(file_path).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn save_review_comments_empty_is_noop_when_no_sidecar() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let file_path = tmp.path().to_str().unwrap().to_string();
+    let sidecar_path = format!("{}.review.yaml", file_path);
+
+    // Saving empty with no pre-existing sidecar must not create one.
+    save_review_comments(file_path, "test.md".to_string(), vec![]).unwrap();
+    assert!(!std::path::Path::new(&sidecar_path).exists(), "empty save must not create a sidecar");
+}
+
+#[test]
 fn load_mrsf_json_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let file = dir.path().join("test.md");

--- a/src/hooks/__tests__/useAutoSaveComments.test.ts
+++ b/src/hooks/__tests__/useAutoSaveComments.test.ts
@@ -27,14 +27,24 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const comment1 = { id: "c1", author: "A", timestamp: "2026-01-01T00:00:00Z", text: "test", resolved: false };
+const comment1 = {
+  id: "c1",
+  author: "A",
+  timestamp: "2026-01-01T00:00:00Z",
+  text: "test",
+  resolved: false,
+};
 
 describe("useAutoSaveComments", () => {
   it("does not save on initial load (not dirty)", async () => {
     renderHook(() => useAutoSaveComments("/path/file.md", [comment1], 1));
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).not.toHaveBeenCalled();
   });
@@ -48,8 +58,12 @@ describe("useAutoSaveComments", () => {
     const comment2 = { ...comment1, id: "c2", text: "new" };
     rerender({ comments: [comment1, comment2], loadKey: 1 });
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).toHaveBeenCalledTimes(1);
   });
@@ -64,13 +78,17 @@ describe("useAutoSaveComments", () => {
     const comment2 = { ...comment1, id: "c2" };
     rerender({ comments: [comment1, comment2], loadKey: 1 });
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).toHaveBeenCalledWith(
       "/path/sub/file.md",
       "sub/file.md",
-      expect.any(Array),
+      expect.any(Array)
     );
   });
 
@@ -86,7 +104,9 @@ describe("useAutoSaveComments", () => {
     // Unmount before debounce fires
     unmount();
 
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).toHaveBeenCalledTimes(1);
   });
@@ -94,8 +114,12 @@ describe("useAutoSaveComments", () => {
   it("does not save when loadKey is 0 (not loaded)", async () => {
     renderHook(() => useAutoSaveComments("/path/file.md", [comment1], 0));
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).not.toHaveBeenCalled();
   });
@@ -103,8 +127,12 @@ describe("useAutoSaveComments", () => {
   it("does not create empty sidecar when opening file with no sidecar", async () => {
     renderHook(() => useAutoSaveComments("/path/file.md", undefined, 1));
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).not.toHaveBeenCalled();
   });
@@ -119,8 +147,12 @@ describe("useAutoSaveComments", () => {
     const externalComments = [{ ...comment1, text: "externally edited" }];
     rerender({ comments: externalComments, loadKey: 2 });
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(commands.saveReviewComments).not.toHaveBeenCalled();
   });
@@ -134,10 +166,33 @@ describe("useAutoSaveComments", () => {
     const comment2 = { ...comment1, id: "c2" };
     rerender({ comments: [comment1, comment2], loadKey: 1 });
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(useStore.getState().lastSaveByPath["/path/file.md"]).toBeGreaterThan(0);
+  });
+
+  it("records sidecar path in save timestamp to suppress watcher reload", async () => {
+    const { rerender } = renderHook(
+      ({ comments, loadKey }) => useAutoSaveComments("/path/file.md", comments, loadKey),
+      { initialProps: { comments: [comment1], loadKey: 1 } }
+    );
+
+    const comment2 = { ...comment1, id: "c2" };
+    rerender({ comments: [comment1, comment2], loadKey: 1 });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(useStore.getState().lastSaveByPath["/path/file.md.review.yaml"]).toBeGreaterThan(0);
   });
 
   it("does not record save timestamp on save failure", async () => {
@@ -150,8 +205,12 @@ describe("useAutoSaveComments", () => {
     const comment2 = { ...comment1, id: "c2" };
     rerender({ comments: [comment1, comment2], loadKey: 1 });
 
-    await act(async () => { vi.advanceTimersByTime(600); });
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
     expect(useStore.getState().lastSaveByPath["/path/file.md"]).toBeUndefined();
   });

--- a/src/hooks/useAutoSaveComments.ts
+++ b/src/hooks/useAutoSaveComments.ts
@@ -63,13 +63,18 @@ export function useAutoSaveComments(
 
     enrichCommentsWithCommit(commentsToSave, filePath)
       .then((enriched) => saveReviewComments(filePath, document, enriched))
-      .then(() => recordSave(filePath))
+      .then(() => {
+        recordSave(filePath);
+        recordSave(`${filePath}.review.yaml`);
+      })
       .catch((err) => logError(`Failed to save review comments for ${filePath}: ${err}`));
   }, [comments, filePath, root, recordSave]);
 
   // Store latest doSave in a ref for the unmount effect
   const doSaveRef = useRef(doSave);
-  useEffect(() => { doSaveRef.current = doSave; }, [doSave]);
+  useEffect(() => {
+    doSaveRef.current = doSave;
+  }, [doSave]);
 
   // Debounced save effect — cleanup only cancels timer (no flush)
   useEffect(() => {


### PR DESCRIPTION
## Root causes

Two independent bugs combined to create empty `.review.yaml` files in the workspace.

### 1. `recordSave` key mismatch
`recordSave(filePath)` stored the source file path (`file.md`) in `lastSaveByPath`, but the Rust watcher emits `file-changed` events using the **sidecar** path (`file.md.review.yaml`). The 1500ms debounce in `useFileWatcher` looked up `lastSaveByPath["file.md.review.yaml"]` — always `0` — so every save triggered a sidecar reload unnecessarily.

**Fix:** record both paths after a successful save in `useAutoSaveComments`.

### 2. Empty sidecar written on delete-all
When all comments were deleted/resolved, `save_review_comments` wrote `{mrsf_version, document, comments: []}` to disk. These empty files persisted and cluttered the workspace.

**Fix:** in Rust `save_review_comments`, if `comments` is empty, delete the sidecar if it exists and return early. Saving with no comments to a file that never had a sidecar is a no-op.

## Changes
- `src-tauri/src/commands.rs` — delete sidecar on empty save, no-op if never existed
- `src/hooks/useAutoSaveComments.ts` — record both source and sidecar paths on save
- `src-tauri/tests/commands_integration.rs` — 2 new Rust tests
- `src/hooks/__tests__/useAutoSaveComments.test.ts` — 1 new TS test
- `.claude/hooks/*.js` — ESM fix re-applied from unmerged PR #14

## Test plan
- [ ] `npm test` — 419 tests pass
- [ ] `cargo test` (in `src-tauri/`) — 18 tests pass
- [ ] Open a file with no comments in the app, close it — no `.review.yaml` created
- [ ] Add a comment, resolve it, close tab — sidecar is deleted not left empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)