### PR TITLE
ci: add release-gate workflow and update publish-release skill

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -119,32 +119,64 @@ Run each command separately (do not chain with `&&`):
 4. `git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json CHANGELOG.md`
 5. `git commit -m "chore: release v{version}"`
 
-## Step 9: Push Branch and Create Pull Request
+## Step 9: Push Branch, Create Pull Request, and Wait for CI
 
 Push the release branch and open a PR against `main`:
 
 1. `git push origin release/v{version}`
-2. Create PR via `gh pr create --base main --head release/v{version} --title "chore: release v{version}" --body "Version bump to v{version}. Merge this PR, then the release tag will be created automatically."`
+2. Create PR via `gh pr create --base main --head release/v{version} --title "chore: release v{version}" --body "Version bump to v{version}. Merge this PR after CI passes, then the release tag will be created."`
 
 Print the PR URL and tell the user:
 
 ```
 PR created: {pr_url}
-Please merge the PR on GitHub, then come back and confirm so I can tag the release.
+Waiting for release-gate CI checks to complete...
 ```
 
-**Wait for the user to confirm the PR is merged** using the ask_user tool with choices:
-- `Merged — create the tag`
-- `Cancel release`
+### Wait for CI checks
 
-If the user cancels, clean up: `git checkout main && git branch -D release/v{version} && git push origin --delete release/v{version}` (each command separately), then stop.
+Wait 30 seconds for GitHub to register the workflow run, then poll CI:
 
-## Step 10: Tag the Merged Commit and Push
+Run `gh pr checks {pr_url} --watch` using async mode (this blocks until all checks resolve, which may take 20+ minutes for cross-platform builds).
+
+**Read the exit code and output:**
+
+- **Exit code 0 (all checks passed):**
+
+  Print to the user:
+
+  ```
+  ✅ All release-gate checks passed!
+  Please merge the PR on GitHub, then come back and confirm.
+  ```
+
+  Then ask the user to confirm using the ask_user tool with choices:
+  - `Merged — create the tag`
+  - `Cancel release`
+
+- **Non-zero exit code (some checks failed):**
+
+  Print the `gh pr checks` output so the user can see which checks failed. Then ask using the ask_user tool with choices:
+  - `I pushed a fix — re-check`
+  - `Cancel release`
+
+  If the user chose to re-check, wait 10 seconds then run `gh pr checks {pr_url} --watch` again (loop back to the polling step).
+
+  If the user cancels, clean up: run each command separately:
+  1. `git checkout main`
+  2. `git branch -D release/v{version}`
+  3. `git push origin --delete release/v{version}`
+  Then stop.
+
+## Step 10: Verify CI and Tag the Merged Commit
 
 After the user confirms the PR is merged:
 
 1. `git checkout main`
 2. `git pull origin main`
+
+**Verify checks one final time** by running `gh pr checks {pr_url}`. If any check is not passing, warn the user and ask for confirmation before proceeding.
+
 3. `git tag -a v{version} -m "Release v{version}"`
 4. `git push origin v{version}`
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,179 @@
+name: Release Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── Cross-platform tests (Linux, Windows, macOS) ─────────────────────────
+  test:
+    name: Test (${{ matrix.name }})
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux
+          - os: windows-latest
+            name: windows
+          - os: macos-latest
+            name: macos
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Rust tests
+        working-directory: src-tauri
+        run: cargo test
+
+      - name: Vitest unit tests
+        run: npm test
+
+      - name: Install Playwright (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright E2E tests (browser mode)
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.name }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
+  # ── Installer builds (Windows + macOS) ───────────────────────────────────
+  build:
+    name: Build (${{ matrix.name }})
+    needs: test
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+          - os: macos-latest
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clean stale bundles from cache
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+
+      - name: Build Tauri app
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+  # ── Native E2E (Windows only — WebView2 supports CDP) ───────────────────
+  native-e2e:
+    name: Native E2E (Windows)
+    needs: test
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build debug binary for testing
+        working-directory: src-tauri
+        run: cargo build
+
+      - name: Run native E2E tests
+        run: npm run test:e2e:native
+
+      - name: Upload native test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/docs/superpowers/plans/2026-04-22-release-gate-ci.md
+++ b/docs/superpowers/plans/2026-04-22-release-gate-ci.md
@@ -1,0 +1,373 @@
+# Release Gate CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate releases on a full cross-platform test suite (Windows, macOS, Linux) before the release tag is created.
+
+**Architecture:** A new `release-gate.yml` GitHub Actions workflow runs on PRs from `release/*` branches. It tests on all three platforms and builds on Windows/macOS. The `publish-release` skill is updated to poll CI checks and block until green before allowing merge and tag.
+
+**Tech Stack:** GitHub Actions, `gh` CLI (`gh pr checks --watch`), Playwright, Vitest, Cargo
+
+---
+
+### Task 1: Create `release-gate.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/release-gate.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/release-gate.yml` with this exact content:
+
+```yaml
+name: Release Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── Cross-platform tests (Linux, Windows, macOS) ─────────────────────────
+  test:
+    name: Test (${{ matrix.name }})
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux
+          - os: windows-latest
+            name: windows
+          - os: macos-latest
+            name: macos
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Rust tests
+        working-directory: src-tauri
+        run: cargo test
+
+      - name: Vitest unit tests
+        run: npm test
+
+      - name: Install Playwright (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright E2E tests (browser mode)
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.name }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
+  # ── Installer builds (Windows + macOS) ───────────────────────────────────
+  build:
+    name: Build (${{ matrix.name }})
+    needs: test
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+          - os: macos-latest
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clean stale bundles from cache
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+
+      - name: Build Tauri app
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+  # ── Native E2E (Windows only — WebView2 supports CDP) ───────────────────
+  native-e2e:
+    name: Native E2E (Windows)
+    needs: test
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build debug binary for testing
+        working-directory: src-tauri
+        run: cargo build
+
+      - name: Run native E2E tests
+        run: npm run test:e2e:native
+
+      - name: Upload native test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-playwright-report
+          path: playwright-report/
+          retention-days: 7
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/release-gate.yml'))"
+```
+
+If python/yaml aren't available, manually verify indentation is consistent (2-space indent throughout, no tabs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release-gate.yml
+git commit -m "ci: add release-gate workflow for cross-platform test matrix"
+```
+
+---
+
+### Task 2: Update the publish-release skill
+
+**Files:**
+- Modify: `.claude/skills/publish-release/SKILL.md`
+
+The changes replace Step 9 and Step 10 in the existing skill to add CI polling and gating.
+
+- [ ] **Step 1: Replace Step 9 in SKILL.md**
+
+Find the current Step 9 section (starting with `## Step 9: Push Branch and Create Pull Request`) and replace it entirely with:
+
+```markdown
+## Step 9: Push Branch, Create Pull Request, and Wait for CI
+
+Push the release branch and open a PR against `main`:
+
+1. `git push origin release/v{version}`
+2. Create PR via `gh pr create --base main --head release/v{version} --title "chore: release v{version}" --body "Version bump to v{version}. Merge this PR after CI passes, then the release tag will be created."`
+
+Print the PR URL and tell the user:
+
+```
+PR created: {pr_url}
+Waiting for release-gate CI checks to complete...
+```
+
+### Wait for CI checks
+
+Wait 30 seconds for GitHub to register the workflow run, then poll CI:
+
+Run `gh pr checks {pr_url} --watch` using async mode (this blocks until all checks resolve, which may take 20+ minutes for cross-platform builds).
+
+**Read the exit code and output:**
+
+- **Exit code 0 (all checks passed):**
+
+  Print to the user:
+
+  ```
+  ✅ All release-gate checks passed!
+  Please merge the PR on GitHub, then come back and confirm.
+  ```
+
+  Then ask the user to confirm using the ask_user tool with choices:
+  - `Merged — create the tag`
+  - `Cancel release`
+
+- **Non-zero exit code (some checks failed):**
+
+  Print the `gh pr checks` output so the user can see which checks failed. Then ask using the ask_user tool with choices:
+  - `I pushed a fix — re-check`
+  - `Cancel release`
+
+  If the user chose to re-check, wait 10 seconds then run `gh pr checks {pr_url} --watch` again (loop back to the polling step).
+
+  If the user cancels, clean up: run each command separately:
+  1. `git checkout main`
+  2. `git branch -D release/v{version}`
+  3. `git push origin --delete release/v{version}`
+  Then stop.
+```
+
+- [ ] **Step 2: Replace Step 10 in SKILL.md**
+
+Find the current Step 10 section (starting with `## Step 10: Tag the Merged Commit and Push`) and replace it with:
+
+```markdown
+## Step 10: Verify CI and Tag the Merged Commit
+
+After the user confirms the PR is merged:
+
+1. `git checkout main`
+2. `git pull origin main`
+
+**Verify checks one final time** by running `gh pr checks {pr_url}`. If any check is not passing, warn the user and ask for confirmation before proceeding.
+
+3. `git tag -a v{version} -m "Release v{version}"`
+4. `git push origin v{version}`
+
+The tag push triggers the release workflow (`.github/workflows/release.yml`).
+```
+
+- [ ] **Step 3: Verify the complete SKILL.md reads correctly**
+
+Read through the full SKILL.md to verify:
+- Steps are numbered 1–11 with no gaps or duplicates
+- Step 9 references `gh pr checks {pr_url} --watch`
+- Step 10 includes the post-merge check verification
+- The cancel/cleanup flow is consistent between Step 9 and Step 10
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/publish-release/SKILL.md
+git commit -m "chore: update publish-release skill to gate on CI checks"
+```
+
+---
+
+### Task 3: Validate the workflow with a dry-run PR
+
+This task verifies the workflow triggers correctly. It must be done manually after Tasks 1–2 are committed and pushed.
+
+- [ ] **Step 1: Create a feature branch and push all changes**
+
+```bash
+git checkout -b feature/release-gate-ci
+git push -u origin HEAD
+```
+
+- [ ] **Step 2: Create a PR for the workflow and skill changes**
+
+```bash
+gh pr create --base main --head feature/release-gate-ci --title "ci: add release-gate workflow and update publish-release skill" --body "Adds cross-platform CI gating for releases. See docs/superpowers/specs/2026-04-22-release-gate-ci-design.md for design."
+```
+
+- [ ] **Step 3: Merge the PR (manual)**
+
+Review and merge the PR on GitHub. This gets the workflow file onto `main` so it can trigger on future release PRs.
+
+- [ ] **Step 4: Test with a dummy release branch**
+
+After the workflow is on `main`, test it:
+
+```bash
+git checkout main && git pull
+git checkout -b release/v0.0.0-test
+# Make a trivial change (e.g., add a blank line to CHANGELOG.md)
+git add CHANGELOG.md
+git commit -m "test: verify release-gate workflow"
+git push -u origin release/v0.0.0-test
+gh pr create --base main --head release/v0.0.0-test --title "test: release gate dry run" --body "Testing release-gate.yml triggers correctly. Will close without merging."
+```
+
+- [ ] **Step 5: Verify the workflow runs**
+
+Check the PR's checks tab on GitHub. Verify:
+- `Release Gate / Test (linux)` — runs
+- `Release Gate / Test (windows)` — runs
+- `Release Gate / Test (macos)` — runs
+- `Release Gate / Build (windows-x64)` — runs after tests pass
+- `Release Gate / Build (macos-arm64)` — runs after tests pass
+- `Release Gate / Native E2E (Windows)` — runs after tests pass
+- Regular `CI` workflow either doesn't trigger or only runs its Linux test job
+
+- [ ] **Step 6: Clean up the test branch**
+
+```bash
+gh pr close --delete-branch
+git checkout main && git pull
+git branch -D release/v0.0.0-test 2>/dev/null || true
+```

--- a/docs/superpowers/specs/2026-04-22-release-gate-ci-design.md
+++ b/docs/superpowers/specs/2026-04-22-release-gate-ci-design.md
@@ -1,0 +1,220 @@
+# Release Gate CI — Design Spec
+
+## Problem
+
+The publish-release workflow creates a tag immediately after the PR is merged, with no CI verification that the release candidate actually works. Tests run post-tag in the release workflow, but by then the release is already in progress. Native E2E tests only run on Windows in the release workflow and not at PR time at all.
+
+**Goal:** Before a release tag is created, the full test suite must pass on all target platforms (Windows, macOS, Linux), including native E2E on Windows.
+
+## Approach
+
+Two changes:
+
+1. **New `release-gate.yml` workflow** — triggered only on PRs from `release/*` branches to `main`. Runs the complete test matrix across all platforms.
+2. **Updated `publish-release` skill** — after creating the PR, polls CI status and blocks until all checks pass before allowing the user to merge and tag.
+
+## Workflow: `.github/workflows/release-gate.yml`
+
+### Trigger
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+    # Only release branches — avoids running on every PR
+    # GitHub Actions doesn't support branch filtering on head ref in `on:`,
+    # so we use a path-independent trigger and filter in the job condition.
+```
+
+Since GitHub Actions doesn't natively filter on head branch name in `pull_request` triggers, each job uses an `if` condition:
+
+```yaml
+if: startsWith(github.head_ref, 'release/')
+```
+
+This ensures the expensive cross-platform matrix only runs for release PRs, not for regular feature/fix PRs.
+
+### Job Matrix
+
+| Job | Runner | What it runs |
+|---|---|---|
+| `test-linux` | `ubuntu-latest` | cargo test, vitest, browser E2E |
+| `test-windows` | `windows-latest` | cargo test, vitest, browser E2E |
+| `test-macos` | `macos-latest` | cargo test, vitest, browser E2E |
+| `build-windows` | `windows-latest` | Tauri build (x64) |
+| `build-macos` | `macos-latest` | Tauri build (arm64) |
+| `native-e2e` | `windows-latest` | Native E2E via CDP (needs build-windows) |
+
+### Job Details
+
+#### `test` (matrix: linux, windows, macos)
+
+A single job definition with a platform matrix:
+
+```yaml
+test:
+  name: Test (${{ matrix.name }})
+  runs-on: ${{ matrix.os }}
+  if: startsWith(github.head_ref, 'release/')
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        - os: ubuntu-latest
+          name: linux
+        - os: windows-latest
+          name: windows
+        - os: macos-latest
+          name: macos
+```
+
+Steps:
+1. Checkout
+2. Set up Rust (stable)
+3. Cache Rust artifacts (`Swatinem/rust-cache@v2`)
+4. Set up Node.js (LTS)
+5. Install npm dependencies (`npm ci`)
+6. Install system dependencies (Linux only: `libwebkit2gtk-4.1-dev`, etc.)
+7. `cargo test` (in `src-tauri/`)
+8. `npm test` (vitest)
+9. Install Playwright (chromium only)
+10. `npm run test:e2e` (browser E2E)
+11. Upload Playwright report on failure
+
+**Linux system deps** are needed for `cargo test` to compile the Tauri crate (links against WebKit GTK). Windows and macOS have their WebView SDKs built in.
+
+**macOS note:** `macos-latest` uses Apple Silicon (M-series). Playwright's Chromium runs natively on arm64.
+
+#### `build` (matrix: windows-x64, macos-arm64)
+
+Reuses the same build steps as `ci.yml`:
+
+```yaml
+build:
+  name: Build (${{ matrix.name }})
+  needs: test
+  runs-on: ${{ matrix.os }}
+  if: startsWith(github.head_ref, 'release/')
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        - os: windows-latest
+          name: windows-x64
+          rust_target: x86_64-pc-windows-msvc
+          target_dir: src-tauri/target/release
+          tauri_args: ""
+        - os: macos-latest
+          name: macos-arm64
+          rust_target: aarch64-apple-darwin
+          target_dir: src-tauri/target/release
+          tauri_args: ""
+```
+
+Steps: checkout, Rust, Node, npm ci, clean stale bundles, `npm run tauri:build`.
+
+Build artifacts are uploaded for the native E2E job to consume (Windows) and as a general verification that the release builds succeed.
+
+**No Linux build** — we don't ship a Linux binary.
+
+**No signing keys needed** — this is a verification build, not the release build. The release workflow handles signing. However, if the build fails without signing keys (Tauri may require them), we'll need to pass `TAURI_SIGNING_PRIVATE_KEY` from secrets.
+
+#### `native-e2e` (Windows only)
+
+```yaml
+native-e2e:
+  name: Native E2E (Windows)
+  needs: test  # doesn't need the release build — uses debug binary
+  runs-on: windows-latest
+  if: startsWith(github.head_ref, 'release/')
+```
+
+Steps:
+1. Checkout
+2. Node.js + npm ci
+3. Install Playwright (chromium)
+4. Rust + rust-cache
+5. `cargo build` (debug binary for testing)
+6. `npm run test:e2e:native`
+7. Upload report on failure
+
+This mirrors what `release.yml` currently does, moved to PR time.
+
+### Why not extend `ci.yml`?
+
+- `ci.yml` runs on every PR and every push to main. Adding Windows/macOS runners to every PR would waste CI minutes and slow down feedback for non-release changes.
+- A separate workflow makes the release gate explicit and keeps regular CI fast.
+- The `if: startsWith(github.head_ref, 'release/')` condition ensures zero cost for non-release PRs even though the workflow file triggers on all PRs.
+
+## Skill Changes: `.claude/skills/publish-release/SKILL.md`
+
+### Current flow (steps 9-10)
+
+```
+Step 9: Push branch, create PR
+Step 10: Ask user "merged?" → tag
+```
+
+### New flow (steps 9-10)
+
+```
+Step 9:  Push branch, create PR
+Step 9a: Wait 30s for workflow to register
+Step 9b: Poll `gh pr checks <pr-url> --watch` (blocks until all checks resolve)
+Step 9c: If any check failed → show failures, ask user to fix or cancel
+         If all green → tell user "All checks passed", ask to merge
+Step 10: User confirms merged
+Step 10a: Verify checks still green via `gh pr checks`
+Step 10b: Tag and push
+```
+
+### Polling mechanism
+
+The `gh pr checks --watch` command blocks until all checks complete, then exits with:
+- Exit code 0 if all checks passed
+- Non-zero if any check failed
+
+This is simpler and more reliable than manual polling with `gh run list`.
+
+### Failure handling
+
+If checks fail:
+- Show the user which checks failed (from `gh pr checks` output)
+- Offer choices: "Push a fix and re-run" or "Cancel release"
+- If the user pushes a fix, re-poll with `gh pr checks --watch`
+- If cancel, clean up branch as before
+
+### Retry loop
+
+The skill should support the user pushing fixes:
+
+```
+loop:
+  poll checks → if all green → break
+  show failures → ask: fix or cancel?
+  if cancel → cleanup, stop
+  if fix → tell user to push, then re-poll
+```
+
+## What doesn't change
+
+- **`ci.yml`** — unchanged. Still runs cargo test + vitest + browser E2E on Linux for every PR.
+- **`release.yml`** — unchanged. Still builds, signs, publishes, and runs native E2E after tag push. The release-gate is a pre-tag safety net, not a replacement.
+- **Native E2E test code** — no changes to `e2e/native/` tests or Playwright configs.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| macOS runner costs (arm64 is more expensive) | Only triggers on `release/*` PRs — typically 1-2 per week max |
+| Build fails without signing keys | Test with a PR first; if needed, pass secrets to the build job |
+| `gh pr checks --watch` hangs if a check never completes | The skill can add a timeout (e.g., 30 min) and fall back to manual check |
+| Flaky native E2E tests block release | Skill shows failures and lets user choose to retry or skip |
+
+## Test Plan
+
+1. Create a `release/v0.0.0-test` branch with a dummy version bump
+2. Open PR → verify `release-gate.yml` triggers with all jobs
+3. Verify `ci.yml` does NOT run its expensive jobs (or runs normally on Linux only)
+4. Verify non-release PRs don't trigger `release-gate.yml` jobs
+5. Merge and delete the test branch (no tag)


### PR DESCRIPTION
Adds cross-platform CI gating for releases. New release-gate.yml workflow runs on release/* PRs with tests on Linux/Windows/macOS, builds on Windows/macOS, and native E2E on Windows. Updated publish-release skill polls CI before allowing merge/tag.