### PR TITLE
ci: cache apt packages, gate builds on tests, add arm64 to release-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,9 @@ jobs:
           retention-days: 7
 
   # ── Installer builds (Windows + macOS) ───────────────────────────────────
-  # Only on push to main (not PRs) — saves ~800s of billed minutes per PR.
-  # Release-gate workflow covers cross-platform builds for release branches.
+  # Runs after tests pass to avoid wasting build minutes on test failures.
   build:
     name: Build (${{ matrix.name }})
-    if: github.event_name == 'push'
     needs: test
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,11 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y -q \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf
+      - name: Cache Linux system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: 1.0
 
       - name: Rust tests
         working-directory: src-tauri
@@ -94,9 +91,12 @@ jobs:
           retention-days: 7
 
   # ── Installer builds (Windows + macOS) ───────────────────────────────────
-  # Runs in parallel with the test job above.
+  # Only on push to main (not PRs) — saves ~800s of billed minutes per PR.
+  # Release-gate workflow covers cross-platform builds for release branches.
   build:
     name: Build (${{ matrix.name }})
+    if: github.event_name == 'push'
+    needs: test
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -47,13 +47,10 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y -q \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: 1.0
 
       - name: Rust tests
         working-directory: src-tauri
@@ -93,6 +90,11 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             target_dir: src-tauri/target/release
             tauri_args: ""
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
           - os: macos-latest
             name: macos-arm64
             rust_target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary

Optimizes CI workflows and enforces native E2E as a local pre-release gate.

## CI Workflow Changes

### ci.yml
- **Concurrency group**: cancels superseded runs on same branch/PR
- **Cache apt packages** via `awalsh128/cache-apt-pkgs-action` — saves ~400s per run (was 77% of test job)
- **Builds depend on test** (`needs: test`): failed tests no longer waste build minutes

### release.yml
- **Removed broken `test-native` job** — CDP/WebView2 not available on GH Actions runners, and it wasn't blocking `publish-release` anyway

### release-gate.yml
- **Concurrency group**: cancels superseded runs
- **Cache apt packages** for Linux test runner
- **Removed broken `native-e2e` job** — same CDP issue, was causing false gate failures
- **Added windows-arm64** to build matrix (coverage gap — was only building x64 + macOS)

## Skill Updates

### run-tests
- Documents native E2E as local-only (cannot run in CI)
- Clear instructions for running locally on Windows

### publish-release
- **New Step 8.5: Local Test Gate** — requires all 3 test suites (unit, browser e2e, native e2e) to pass locally before pushing the release branch
- Only runs on Windows (tells user to find a Windows machine otherwise)

## Evidence
- Release gate run [#24801327417](https://github.com/dryotta/mdownreview/actions/runs/24801327417): Native E2E failed with `CDP endpoint on port 9222 did not become ready within 15000ms`
- CI timing analysis: `Install Linux system dependencies: 418s` out of 542s total test job (77%)
