### PR TITLE
chore: add native E2E tests to release-gate CI

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -142,3 +142,53 @@ jobs:
   # NOTE: Native E2E tests require a real desktop environment (WebView2 + CDP)
   # which is not available on GitHub Actions runners. Run them locally before
   # publishing a release — the publish-release skill enforces this gate.
+
+  # ── Native E2E tests (Windows, WebView2 + CDP) ──────────────────────────
+  # Builds the debug binary and runs Playwright tests against a real Tauri
+  # window via CDP.  windows-latest has WebView2 Runtime pre-installed and
+  # a desktop session, so this works without extra setup.
+  native-e2e:
+    name: Native E2E (Windows)
+    needs: test
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build debug binary
+        working-directory: src-tauri
+        run: cargo build
+
+      - name: Install Playwright (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Native E2E tests
+        run: npm run test:e2e:native
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-native-e2e
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,9 +151,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # NOTE: Native E2E tests require a real desktop environment (WebView2 + CDP)
-  # which is not available on GitHub Actions runners. Run them locally before
-  # publishing a release — the publish-release skill enforces this gate.
+  # Native E2E tests run in release-gate.yml before merge.
+  # They require WebView2 + CDP on a Windows runner (debug binary).
 
   publish-update-manifest:
     needs: [create-release, build]


### PR DESCRIPTION
Adds a native-e2e job to release-gate.yml that builds the debug binary on windows-latest and runs Playwright tests against a real Tauri window via CDP. windows-latest has WebView2 pre-installed and a desktop session. Runs after test matrix passes, only on release/ branches.