### PR TITLE
chore: optimize CI/CD workflows for speed and cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'src-tauri/**'
-      - 'e2e/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'vite.config.*'
-      - 'tsconfig*'
-      - 'vitest.config.*'
-      - 'playwright.config.*'
-      - 'eslint.config.*'
-      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
     paths:
@@ -90,11 +76,11 @@ jobs:
             test-results/
           retention-days: 7
 
-  # ── Installer builds (Windows + macOS) ───────────────────────────────────
-  # Runs after tests pass to avoid wasting build minutes on test failures.
+  # ── Installer builds (Windows x64 + macOS) ──────────────────────────────
+  # Runs in parallel with tests. Windows ARM64 build is in release-gate only
+  # (cross-compilation takes ~8m; not needed for every PR).
   build:
     name: Build (${{ matrix.name }})
-    needs: test
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -105,13 +91,6 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             target_dir: src-tauri/target/release
             tauri_args: ""
-            artifact_ext: zip
-
-          - os: windows-latest
-            name: windows-arm64
-            rust_target: aarch64-pc-windows-msvc
-            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
-            tauri_args: "--target aarch64-pc-windows-msvc"
             artifact_ext: zip
 
           - os: macos-latest

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   # ── Cross-platform tests (Linux, Windows, macOS) ─────────────────────────
+  # All jobs run in parallel — no needs dependencies.
   test:
     name: Test (${{ matrix.name }})
     if: startsWith(github.head_ref, 'release/')
@@ -59,8 +60,25 @@ jobs:
       - name: Vitest unit tests
         run: npm test
 
+      - name: Get Playwright version
+        id: pw-version
+        shell: bash
+        run: echo "version=$(npx playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ${{ runner.os == 'Windows' && '~/AppData/Local/ms-playwright' || '~/.cache/ms-playwright' }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Playwright E2E tests (browser mode)
         run: npm run test:e2e
@@ -75,31 +93,13 @@ jobs:
             test-results/
           retention-days: 7
 
-  # ── Installer builds (Windows + macOS) ───────────────────────────────────
-  build:
-    name: Build (${{ matrix.name }})
-    needs: test
+  # ── Windows ARM64 build ─────────────────────────────────────────────────
+  # Only built in release-gate (cross-compilation is ~8m).
+  # x64 and macOS builds are already validated in CI.
+  build-arm64:
+    name: Build (windows-arm64)
     if: startsWith(github.head_ref, 'release/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            name: windows-x64
-            rust_target: x86_64-pc-windows-msvc
-            target_dir: src-tauri/target/release
-            tauri_args: ""
-          - os: windows-latest
-            name: windows-arm64
-            rust_target: aarch64-pc-windows-msvc
-            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
-            tauri_args: "--target aarch64-pc-windows-msvc"
-          - os: macos-latest
-            name: macos-arm64
-            rust_target: aarch64-apple-darwin
-            target_dir: src-tauri/target/release
-            tauri_args: ""
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.rust_target }}
+          targets: aarch64-pc-windows-msvc
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -125,23 +125,13 @@ jobs:
 
       - name: Clean stale bundles from cache
         shell: bash
-        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+        run: rm -rf src-tauri/target/*/release/bundle 2>/dev/null || true
 
       - name: Build Tauri app
-        shell: bash
-        run: |
-          if [ -n "${{ matrix.tauri_args }}" ]; then
-            npm run tauri:build -- ${{ matrix.tauri_args }}
-          else
-            npm run tauri:build
-          fi
+        run: npm run tauri:build -- --target aarch64-pc-windows-msvc
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-  # NOTE: Native E2E tests require a real desktop environment (WebView2 + CDP)
-  # which is not available on GitHub Actions runners. Run them locally before
-  # publishing a release — the publish-release skill enforces this gate.
 
   # ── Native E2E tests (Windows, WebView2 + CDP) ──────────────────────────
   # Builds the debug binary and runs Playwright tests against a real Tauri
@@ -149,7 +139,6 @@ jobs:
   # a desktop session, so this works without extra setup.
   native-e2e:
     name: Native E2E (Windows)
-    needs: test
     if: startsWith(github.head_ref, 'release/')
     runs-on: windows-latest
 
@@ -177,8 +166,25 @@ jobs:
         working-directory: src-tauri
         run: cargo build
 
+      - name: Get Playwright version
+        id: pw-version
+        shell: bash
+        run: echo "version=$(npx playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/AppData/Local/ms-playwright
+          key: playwright-Windows-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright (Chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Native E2E tests
         run: npm run test:e2e:native


### PR DESCRIPTION
## Changes

1. **CI: parallel test + build**  removed \
eeds: test\ so builds start immediately (saves ~2m)
2. **CI: drop windows-arm64 build**  cross-compilation takes ~8m; moved to release-gate only
3. **CI: remove push trigger on main**  PR trigger is sufficient; avoids duplicate runs on merge
4. **Release gate: all jobs in parallel**  tests, native E2E, and arm64 build run concurrently (saves ~6.6m)
5. **Release gate: remove redundant builds**  x64 and macOS builds already validated in CI
6. **Release gate: cache Playwright on Windows**  ~3m savings per Windows test job

## Expected impact

| Workflow | Before | After |
|---|---|---|
| CI (per PR) | ~10m | ~4m |
| Release gate | ~16m | ~9m |
| Runner minutes saved |  | ~50% |