### PR TITLE
fix: break scroll feedback loop in ViewerRouter

### DIFF
--- a/e2e/native/04-scroll-stability.spec.ts
+++ b/e2e/native/04-scroll-stability.spec.ts
@@ -1,0 +1,287 @@
+import { test, expect, setRootViaTest } from "./fixtures";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+/**
+ * Native E2E tests for scroll stability.
+ *
+ * WHY NATIVE: These tests require the real rendering pipeline with actual
+ * scroll containers, real Tauri IPC, and real content rendering to reproduce
+ * the scroll feedback loop bug. Browser tests with mocked IPC don't exercise
+ * the full React render cycle that triggers Zustand store updates and the
+ * resulting useEffect re-fires that cause the oscillation.
+ */
+test.describe("Scroll Stability", () => {
+  /**
+   * Helper: find the actual scroll container (the ViewerRouter wrapper div
+   * with overflow:auto that wraps the viewer content).
+   */
+  async function getScrollContainer(nativePage: import("@playwright/test").Page) {
+    // The scroll container is the parent of EnhancedViewer/MarkdownViewer/SourceView
+    // It has style="flex: 1; overflow: auto" set by ViewerRouter
+    return nativePage.evaluate(() => {
+      // Find by looking for the element that has both overflow and scrollHeight > clientHeight
+      const candidates = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+      for (const el of candidates) {
+        if (el.scrollHeight > el.clientHeight + 10) return true;
+      }
+      return false;
+    });
+  }
+
+  test("29.1 - programmatic scroll position is stable (no oscillation from feedback loop)", async ({ nativePage }) => {
+    // Create a large file that definitely overflows the viewport
+    const tmpDir = path.join(os.tmpdir(), `mdownreview-scroll-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "large.md");
+
+    // Generate 200 lines of content to ensure scrolling is needed
+    const lines: string[] = ["# Large Document for Scroll Test", ""];
+    for (let i = 1; i <= 200; i++) {
+      lines.push(`## Section ${i}`);
+      lines.push("");
+      lines.push(`This is paragraph ${i} with enough text to fill the line and make the document scrollable.`);
+      lines.push("");
+    }
+    fs.writeFileSync(tmpFile, lines.join("\n"));
+
+    try {
+      await setRootViaTest(nativePage, tmpDir);
+
+      // Wait for the markdown viewer to render content
+      await expect(nativePage.locator(".markdown-viewer")).toBeVisible({ timeout: 10_000 });
+      await expect(nativePage.locator(".markdown-viewer")).toContainText("Section 1", { timeout: 5_000 });
+
+      // Let the viewer fully settle (Shiki async highlighting, layout, etc.)
+      await nativePage.waitForTimeout(2000);
+
+      // Programmatically scroll in increments and verify monotonic increase
+      const scrollPositions: number[] = [];
+      for (let step = 0; step < 5; step++) {
+        const targetScroll = (step + 1) * 200;
+
+        const actualPos = await nativePage.evaluate((target) => {
+          const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+          for (const el of containers) {
+            if (el.scrollHeight > el.clientHeight + 10) {
+              el.scrollTop = target;
+              return el.scrollTop;
+            }
+          }
+          return -1;
+        }, targetScroll);
+
+        // Wait for any React effects to settle
+        await nativePage.waitForTimeout(500);
+
+        // Re-read the position to check for oscillation
+        const settledPos = await nativePage.evaluate(() => {
+          const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+          for (const el of containers) {
+            if (el.scrollHeight > el.clientHeight + 10) {
+              return el.scrollTop;
+            }
+          }
+          return -1;
+        });
+
+        scrollPositions.push(settledPos);
+
+        // Position should not have drifted from where we set it
+        expect(
+          Math.abs(settledPos - actualPos),
+          `Scroll position drifted after settling at step ${step}: set to ${actualPos}, settled at ${settledPos}. ` +
+          `This indicates a scroll feedback loop.`
+        ).toBeLessThan(5);
+      }
+
+      // Verify scroll positions are monotonically increasing
+      for (let i = 1; i < scrollPositions.length; i++) {
+        expect(
+          scrollPositions[i],
+          `Position at step ${i} (${scrollPositions[i]}) should be >= step ${i - 1} (${scrollPositions[i - 1]})`
+        ).toBeGreaterThanOrEqual(scrollPositions[i - 1]);
+      }
+
+      // Verify we actually scrolled
+      expect(scrollPositions[scrollPositions.length - 1]).toBeGreaterThan(0);
+
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("29.2 - scroll position is stable after settling (no jitter)", async ({ nativePage }) => {
+    // Create a large source file (non-markdown) to test SourceView scroll too
+    const tmpDir = path.join(os.tmpdir(), `mdownreview-scroll-src-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "large.ts");
+
+    // Generate a large TypeScript file
+    const srcLines: string[] = ["// Large TypeScript file for scroll test"];
+    for (let i = 1; i <= 300; i++) {
+      srcLines.push(`export function fn${i}(): string {`);
+      srcLines.push(`  return "result from function ${i}";`);
+      srcLines.push(`}`);
+      srcLines.push("");
+    }
+    fs.writeFileSync(tmpFile, srcLines.join("\n"));
+
+    try {
+      await setRootViaTest(nativePage, tmpDir);
+
+      // Wait for the source view to render
+      await expect(nativePage.locator(".source-view")).toBeVisible({ timeout: 10_000 });
+      await expect(nativePage.locator(".source-view")).toContainText("fn1", { timeout: 5_000 });
+
+      // Let the viewer fully settle
+      await nativePage.waitForTimeout(2000);
+
+      // Programmatically scroll down
+      await nativePage.evaluate(() => {
+        const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+        for (const el of containers) {
+          if (el.scrollHeight > el.clientHeight + 10) {
+            el.scrollTop = 500;
+            return;
+          }
+        }
+      });
+      await nativePage.waitForTimeout(500);
+
+      // Capture scroll position multiple times over 1 second to check for jitter
+      const samples: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const pos = await nativePage.evaluate(() => {
+          const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+          for (const el of containers) {
+            if (el.scrollHeight > el.clientHeight + 10) {
+              return el.scrollTop;
+            }
+          }
+          return -1;
+        });
+        samples.push(pos);
+        await nativePage.waitForTimeout(200);
+      }
+
+      // All samples should be the same (no oscillation after settling)
+      const first = samples[0];
+      for (let i = 1; i < samples.length; i++) {
+        expect(
+          Math.abs(samples[i] - first),
+          `Scroll position should be stable after settling. ` +
+          `Sample ${i} = ${samples[i]} differs from sample 0 = ${first}. ` +
+          `All samples: [${samples.join(", ")}]`
+        ).toBeLessThan(2);
+      }
+
+      // Verify we're actually scrolled (not stuck at 0)
+      expect(first).toBeGreaterThan(0);
+
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("29.3 - wheel scroll moves content and settles without fighting", async ({ nativePage }) => {
+    const tmpDir = path.join(os.tmpdir(), `mdownreview-scroll-wheel-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "scroll-test.md");
+
+    const lines: string[] = ["# Wheel Scroll Test", ""];
+    for (let i = 1; i <= 150; i++) {
+      lines.push(`Paragraph ${i}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.`);
+      lines.push("");
+    }
+    fs.writeFileSync(tmpFile, lines.join("\n"));
+
+    try {
+      await setRootViaTest(nativePage, tmpDir);
+      await expect(nativePage.locator(".markdown-viewer")).toBeVisible({ timeout: 10_000 });
+      await expect(nativePage.locator(".markdown-viewer")).toContainText("Paragraph 1", { timeout: 5_000 });
+      await nativePage.waitForTimeout(2000);
+
+      // Move mouse to the viewer area first
+      const viewerBox = await nativePage.locator(".markdown-viewer").boundingBox();
+      expect(viewerBox).toBeTruthy();
+      await nativePage.mouse.move(
+        viewerBox!.x + viewerBox!.width / 2,
+        viewerBox!.y + viewerBox!.height / 2
+      );
+
+      // Send wheel-down events
+      for (let i = 0; i < 10; i++) {
+        await nativePage.mouse.wheel(0, 120);
+        await nativePage.waitForTimeout(100);
+      }
+
+      // Wait for scroll to settle
+      await nativePage.waitForTimeout(1000);
+
+      const posAfterWheel = await nativePage.evaluate(() => {
+        const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+        for (const el of containers) {
+          if (el.scrollHeight > el.clientHeight + 10) {
+            return el.scrollTop;
+          }
+        }
+        return 0;
+      });
+
+      // Verify scroll moved (wheel events reached the scroll container)
+      // If wheel events don't reach, we fall back to verifying stability
+      if (posAfterWheel > 0) {
+        // Verify position is stable after wheel stops
+        await nativePage.waitForTimeout(500);
+        const posAfterSettle = await nativePage.evaluate(() => {
+          const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+          for (const el of containers) {
+            if (el.scrollHeight > el.clientHeight + 10) {
+              return el.scrollTop;
+            }
+          }
+          return 0;
+        });
+
+        expect(
+          Math.abs(posAfterSettle - posAfterWheel),
+          `Scroll position should be stable after wheel stops. Was ${posAfterWheel}, now ${posAfterSettle}`
+        ).toBeLessThan(2);
+      }
+
+      // Also verify programmatic scroll still works correctly
+      const scrollTarget = 400;
+      await nativePage.evaluate((target) => {
+        const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+        for (const el of containers) {
+          if (el.scrollHeight > el.clientHeight + 10) {
+            el.scrollTop = target;
+            return;
+          }
+        }
+      }, scrollTarget);
+
+      await nativePage.waitForTimeout(500);
+
+      const finalPos = await nativePage.evaluate(() => {
+        const containers = document.querySelectorAll<HTMLElement>('[style*="overflow"]');
+        for (const el of containers) {
+          if (el.scrollHeight > el.clientHeight + 10) {
+            return el.scrollTop;
+          }
+        }
+        return -1;
+      });
+
+      expect(
+        Math.abs(finalPos - scrollTarget),
+        `Programmatic scroll should hold position. Target ${scrollTarget}, actual ${finalPos}`
+      ).toBeLessThan(5);
+
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/components/viewers/ViewerRouter.tsx
+++ b/src/components/viewers/ViewerRouter.tsx
@@ -16,11 +16,11 @@ export function ViewerRouter({ path }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const setScrollTop = useStore((s) => s.setScrollTop);
-  const tab = useStore((s) => s.tabs.find((t) => t.path === path));
   const ghostEntries = useStore((s) => s.ghostEntries);
   const isGhost = ghostEntries.some((g) => g.sourcePath === path);
 
-  const savedScrollTop = tab?.scrollTop ?? 0;
+  // Guard flag: suppresses scroll-save during programmatic scroll restore
+  const restoringRef = useRef(false);
 
   const fileSize = useMemo(
     () => content ? new TextEncoder().encode(content).length : undefined,
@@ -30,23 +30,47 @@ export function ViewerRouter({ path }: Props) {
   // Restore scroll position after content renders.
   // Uses a rAF retry loop because async syntax highlighting (Shiki) and
   // images can change layout after the initial React render.
+  //
+  // IMPORTANT: reads the restore target from the store at effect time via
+  // useStore.getState() instead of depending on a derived `savedScrollTop`.
+  // This breaks the save→re-render→restore→save feedback loop that caused
+  // infinite scroll oscillation.
   useEffect(() => {
-    if (!scrollRef.current || status !== "ready" || savedScrollTop <= 0) return;
+    if (!scrollRef.current || status !== "ready") return;
+
+    const target = useStore.getState().tabs.find((t) => t.path === path)?.scrollTop ?? 0;
+
+    // Explicitly restore to 0 on tab switch when target is 0
+    if (target <= 0) {
+      scrollRef.current.scrollTop = 0;
+      return;
+    }
 
     let cancelled = false;
-    let retries = 10;
+    let retries = 20; // More retries for async Shiki highlighting
 
     const tryRestore = () => {
-      if (cancelled || !scrollRef.current || retries <= 0) return;
-      scrollRef.current.scrollTop = savedScrollTop;
-      if (scrollRef.current.scrollTop > 0) return; // Scroll applied successfully
+      if (cancelled || !scrollRef.current || retries <= 0) {
+        restoringRef.current = false;
+        return;
+      }
+      restoringRef.current = true;
+      scrollRef.current.scrollTop = target;
+      // Check if scroll was applied (content tall enough)
+      if (scrollRef.current.scrollTop > 0) {
+        restoringRef.current = false;
+        return;
+      }
       retries--;
       requestAnimationFrame(tryRestore);
     };
 
     requestAnimationFrame(tryRestore);
-    return () => { cancelled = true; };
-  }, [path, status, content, savedScrollTop]);
+    return () => {
+      cancelled = true;
+      restoringRef.current = false;
+    };
+  }, [path, status, content]);
 
   useEffect(() => {
     return () => {
@@ -55,6 +79,9 @@ export function ViewerRouter({ path }: Props) {
   }, [path]);
 
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    // Skip saves during programmatic scroll restore to prevent feedback loop
+    if (restoringRef.current) return;
+
     const top = (e.target as HTMLDivElement).scrollTop;
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {

--- a/src/components/viewers/__tests__/ViewerRouter.test.tsx
+++ b/src/components/viewers/__tests__/ViewerRouter.test.tsx
@@ -256,3 +256,81 @@ describe("ViewerRouter scroll throttle", () => {
     spy.mockRestore();
   });
 });
+
+describe("ViewerRouter scroll feedback loop prevention", () => {
+  let rafCallbacks: Array<() => void>;
+  let rafIdCounter: number;
+  let cancelledIds: Set<number>;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    rafIdCounter = 0;
+    cancelledIds = new Set();
+
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = ++rafIdCounter;
+      rafCallbacks.push(() => {
+        if (!cancelledIds.has(id)) cb(performance.now());
+      });
+      return id;
+    });
+    vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
+      cancelledIds.add(id);
+    });
+  });
+
+  function flushRaf() {
+    const batch = rafCallbacks.splice(0);
+    batch.forEach((cb) => cb());
+  }
+
+  it("scroll-save does not trigger scroll-restore (no feedback loop)", () => {
+    mockUseFileContent.mockReturnValue({ status: "ready", content: "text" });
+    useStore.setState({ tabs: [{ path: "/loop.txt", scrollTop: 0 }] });
+
+    render(<ViewerRouter path="/loop.txt" />);
+
+    const container = screen.getByTestId("enhanced-viewer").parentElement!;
+
+    // Simulate user scrolling repeatedly
+    for (let i = 1; i <= 10; i++) {
+      fireEvent.scroll(container, { target: { scrollTop: i * 50 } });
+      act(() => flushRaf());
+    }
+
+    // Store should have the final scroll position
+    const tab = useStore.getState().tabs.find((t) => t.path === "/loop.txt");
+    expect(tab?.scrollTop).toBe(500);
+  });
+
+  it("setScrollTop is a no-op when value is unchanged", () => {
+    useStore.setState({ tabs: [{ path: "/noop.txt", scrollTop: 200 }] });
+
+    const stateBefore = useStore.getState();
+    useStore.getState().setScrollTop("/noop.txt", 200);
+    const stateAfter = useStore.getState();
+
+    // Should be the exact same reference (no unnecessary re-renders)
+    expect(stateAfter.tabs).toBe(stateBefore.tabs);
+  });
+
+  it("setScrollTop updates when value changes", () => {
+    useStore.setState({ tabs: [{ path: "/change.txt", scrollTop: 100 }] });
+
+    useStore.getState().setScrollTop("/change.txt", 300);
+
+    const tab = useStore.getState().tabs.find((t) => t.path === "/change.txt");
+    expect(tab?.scrollTop).toBe(300);
+  });
+
+  it("setScrollTop is a no-op for non-existent tab", () => {
+    useStore.setState({ tabs: [{ path: "/exists.txt", scrollTop: 0 }] });
+
+    const stateBefore = useStore.getState();
+    useStore.getState().setScrollTop("/missing.txt", 100);
+    const stateAfter = useStore.getState();
+
+    // Should not create a new state
+    expect(stateAfter.tabs).toBe(stateBefore.tabs);
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -191,10 +191,13 @@ export const useStore = create<Store>()(
       },
       closeAllTabs: () => set({ tabs: [], activeTabPath: null, viewModeByTab: {}, lastSaveByPath: {} }),
       setActiveTab: (path) => set({ activeTabPath: path }),
-      setScrollTop: (path, scrollTop) =>
+      setScrollTop: (path, scrollTop) => {
+        const tab = get().tabs.find((t) => t.path === path);
+        if (!tab || tab.scrollTop === scrollTop) return;
         set((s) => ({
           tabs: s.tabs.map((t) => (t.path === path ? { ...t, scrollTop } : t)),
-        })),
+        }));
+      },
       viewModeByTab: {},
       setViewMode: (path, mode) =>
         set((s) => ({


### PR DESCRIPTION
## Problem

Scrolling with mouse wheel or keyboard caused the view to oscillate up and down - an infinite scroll fight between the user and a programmatic scroll restore.

## Root Cause

ViewerRouter.tsx had a feedback loop:

1. User scrolls -> handleScroll saves position to Zustand store
2. Store update -> savedScrollTop changes -> useEffect re-fires
3. useEffect programmatically sets scrollTop back to saved value
4. During continuous scrolling, the browser has already moved past that position
5. The programmatic assignment scrolls back -> triggers another onScroll -> repeat

The savedScrollTop was in the useEffect dependency array, meaning the scroll-restore effect (designed for tab switching) fired on every scroll position change.

## Fixes

- **ViewerRouter.tsx**: Read restore target via useStore.getState() inside the effect instead of depending on savedScrollTop; added restoringRef guard to suppress save during programmatic restore; explicit restore-to-0 on tab switch
- **store/index.ts**: setScrollTop is now a no-op when value is unchanged or tab not found (eliminates unnecessary store churn)

## Tests

- 4 new unit tests: feedback loop prevention, store no-op for unchanged/missing tabs
- 3 new native E2E tests: programmatic scroll stability, jitter detection, wheel scroll settlement

## Verification

- ESLint: clean
- Vitest: 496 passed
- Browser E2E: 40 passed
- Native E2E: 13 passed
