### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.3.4 — 2026-04-23
+
+### Fixes
+- break scroll feedback loop in ViewerRouter (#37)
+
+### Other
+- update and add skills (validate-ci, groom-issues, implement-issues) (#38)
+
 ## v0.3.3 — 2026-04-23
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdownreview",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdownreview",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@shikijs/rehype": "^4.0.2",
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdownreview",
   "private": true,
   "description": "Review AI Agent's work",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mdownreview"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdownreview"
-version = "0.3.3"
+version = "0.3.4"
 description = "A desktop markdown reviewer for developers"
 license = "MIT"
 authors = ["davidzh"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mdownreview",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "com.mdownreview.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v0.3.4. Merge this PR after CI passes, then the release tag will be created.