### PR TITLE
auto-improve: architecture cleanup  iteration 1

### DIFF
--- a/.claude/self-improve-loop-state.md
+++ b/.claude/self-improve-loop-state.md
@@ -5,3 +5,11 @@ head_sha: 3449ada7a90a9c5736065c676fcec5ec7c370d09
 max_iterations: 30
 ---
 # Iteration Log
+
+## Iteration 1 — PASSED
+- Branch: auto-improve/loop-1-stabilize-memo-add-tests
+- PR: https://github.com/dryotta/mdownreview/pull/45
+- CI: passed (Test Linux, Build macOS-arm64, Build windows-x64)
+- Expert review: 6/6 approved, suggestions: perf expert noted IPC storm claim overstated (string-key guard already prevented it, but memo still eliminates wasted tree traversals); test-gap reviewer noted additional edge-case tests for future iterations
+- Goal assessor confidence: 82%
+- Summary: Stabilized FolderTree mergedList memo, added useUnresolvedCounts (5 tests) and useTheme (3 tests) coverage

--- a/.claude/self-improve-loop-state.md
+++ b/.claude/self-improve-loop-state.md
@@ -1,0 +1,7 @@
+---
+goal: "Complete architecture refactoring: move model/viewmodel to Rust, clean up web layer, eliminate duplicate/dead code, complete test coverage across native and web layers."
+started_at: 2026-04-23T19:30:00-07:00
+head_sha: 3449ada7a90a9c5736065c676fcec5ec7c370d09
+max_iterations: 30
+---
+# Iteration Log

--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -73,76 +73,71 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
 
   // Build visible flat list for keyboard nav
   type TreeNode = { path: string; isDir: boolean; depth: number; name: string; isGhost?: boolean };
-  
-  function buildFlatList(
-    parentPath: string,
-    depth: number
-  ): TreeNode[] {
-    const entries = childrenCache[parentPath] ?? [];
-    const result: TreeNode[] = [];
-    for (const entry of entries) {
-      if (filter) {
-        const matchesSelf =
-          !entry.is_dir && entry.name.toLowerCase().includes(filter.toLowerCase());
-        const hasMatchingChild = entry.is_dir && hasMatch(entry.path);
-        if (!matchesSelf && !hasMatchingChild) continue;
+
+  const mergedList = useMemo(() => {
+    function hasMatch(folderPath: string): boolean {
+      const entries = childrenCache[folderPath] ?? [];
+      return entries.some(
+        (e) =>
+          (!e.is_dir && e.name.toLowerCase().includes(filter.toLowerCase())) ||
+          (e.is_dir && hasMatch(e.path))
+      );
+    }
+
+    function buildFlatList(parentPath: string, depth: number): TreeNode[] {
+      const entries = childrenCache[parentPath] ?? [];
+      const result: TreeNode[] = [];
+      for (const entry of entries) {
+        if (filter) {
+          const matchesSelf =
+            !entry.is_dir && entry.name.toLowerCase().includes(filter.toLowerCase());
+          const hasMatchingChild = entry.is_dir && hasMatch(entry.path);
+          if (!matchesSelf && !hasMatchingChild) continue;
+        }
+        result.push({ path: entry.path, isDir: entry.is_dir, depth, name: entry.name });
+        if (entry.is_dir && expandedFolders[entry.path]) {
+          result.push(...buildFlatList(entry.path, depth + 1));
+        }
       }
-      result.push({ path: entry.path, isDir: entry.is_dir, depth, name: entry.name });
-      if (entry.is_dir && expandedFolders[entry.path]) {
-        result.push(...buildFlatList(entry.path, depth + 1));
+      return result;
+    }
+
+    const flatList = root ? buildFlatList(root, 0) : [];
+    const merged: TreeNode[] = [...flatList];
+
+    if (root) {
+      for (const ghost of ghostEntries) {
+        const alreadyInTree = flatList.some((n) => n.path === ghost.sourcePath);
+        if (alreadyInTree) continue;
+
+        const sep = ghost.sourcePath.includes("/") ? "/" : "\\";
+        const parts = ghost.sourcePath.split(sep);
+        const parentPath = parts.slice(0, -1).join(sep);
+        const fileName = parts[parts.length - 1];
+
+        const parentIdx = merged.findIndex((n) => n.path === parentPath && n.isDir);
+        if (parentIdx === -1 && parentPath !== root) continue;
+
+        const parentDepth = parentIdx >= 0 ? merged[parentIdx].depth : -1;
+        const ghostDepth = parentDepth + 1;
+
+        let insertIdx = parentIdx + 1;
+        while (insertIdx < merged.length && merged[insertIdx].depth >= ghostDepth) {
+          insertIdx++;
+        }
+
+        merged.splice(insertIdx, 0, {
+          path: ghost.sourcePath,
+          isDir: false,
+          depth: ghostDepth,
+          name: fileName,
+          isGhost: true,
+        });
       }
     }
-    return result;
-  }
 
-  function hasMatch(folderPath: string): boolean {
-    const entries = childrenCache[folderPath] ?? [];
-    return entries.some(
-      (e) =>
-        (!e.is_dir && e.name.toLowerCase().includes(filter.toLowerCase())) ||
-        (e.is_dir && hasMatch(e.path))
-    );
-  }
-
-  const flatList = root ? buildFlatList(root, 0) : [];
-  
-  // Merge ghost entries into flat list
-  const mergedList = [...flatList];
-  if (root) {
-    for (const ghost of ghostEntries) {
-      // Only show if the source file isn't already in the tree
-      const alreadyInTree = flatList.some((n) => n.path === ghost.sourcePath);
-      if (alreadyInTree) continue;
-      
-      // Find the parent directory
-      const sep = ghost.sourcePath.includes("/") ? "/" : "\\";
-      const parts = ghost.sourcePath.split(sep);
-      const parentPath = parts.slice(0, -1).join(sep);
-      const fileName = parts[parts.length - 1];
-      
-      // Check if parent is in the expanded tree
-      const parentIdx = mergedList.findIndex((n) => n.path === parentPath && n.isDir);
-      if (parentIdx === -1 && parentPath !== root) continue;
-      
-      // Calculate depth
-      const parentDepth = parentIdx >= 0 ? mergedList[parentIdx].depth : -1;
-      const ghostDepth = parentDepth + 1;
-      
-      // Insert after parent's children (find last child at same or deeper level)
-      let insertIdx = parentIdx + 1;
-      while (insertIdx < mergedList.length && mergedList[insertIdx].depth >= ghostDepth) {
-        insertIdx++;
-      }
-      
-      mergedList.splice(insertIdx, 0, {
-        path: ghost.sourcePath,
-        isDir: false,
-        depth: ghostDepth,
-        name: fileName,
-        isGhost: true,
-      });
-    }
-  }
+    return merged;
+  }, [root, childrenCache, expandedFolders, filter, ghostEntries]);
 
   // Collect visible file paths for badge counts
   const filePaths = useMemo(

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useTheme } from "../useTheme";
+
+describe("useTheme", () => {
+  it("returns 'light' when data-theme is not set (default)", () => {
+    document.documentElement.removeAttribute("data-theme");
+    const { result, unmount } = renderHook(() => useTheme());
+    expect(result.current).toBe("light");
+    unmount();
+  });
+
+  it("returns current data-theme value when set", () => {
+    document.documentElement.setAttribute("data-theme", "dark");
+    const { result, unmount } = renderHook(() => useTheme());
+    expect(result.current).toBe("dark");
+    unmount();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("reactively updates when data-theme attribute changes", async () => {
+    document.documentElement.removeAttribute("data-theme");
+    const { result, unmount } = renderHook(() => useTheme());
+    expect(result.current).toBe("light");
+
+    act(() => {
+      document.documentElement.setAttribute("data-theme", "dark");
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("dark");
+    });
+
+    unmount();
+    document.documentElement.removeAttribute("data-theme");
+  });
+});

--- a/src/hooks/__tests__/useUnresolvedCounts.test.ts
+++ b/src/hooks/__tests__/useUnresolvedCounts.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { listen } from "@tauri-apps/api/event";
+import { getUnresolvedCounts } from "@/lib/tauri-commands";
+import { useUnresolvedCounts } from "../useUnresolvedCounts";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((_eventName: string, _callback: unknown) =>
+    Promise.resolve(() => {})
+  ),
+}));
+
+vi.mock("@/lib/tauri-commands", () => ({
+  getUnresolvedCounts: vi.fn().mockResolvedValue({}),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useUnresolvedCounts", () => {
+  it("returns {} for empty filePaths array", async () => {
+    const { result } = renderHook(() => useUnresolvedCounts([]));
+    await act(async () => {});
+    expect(result.current).toEqual({});
+    expect(getUnresolvedCounts).not.toHaveBeenCalled();
+  });
+
+  it("calls getUnresolvedCounts IPC with provided paths", async () => {
+    const mockCounts = { "/a.md": 3, "/b.md": 1 };
+    vi.mocked(getUnresolvedCounts).mockResolvedValueOnce(mockCounts);
+
+    const { result } = renderHook(() =>
+      useUnresolvedCounts(["/a.md", "/b.md"])
+    );
+    await act(async () => {});
+
+    expect(getUnresolvedCounts).toHaveBeenCalledWith(["/a.md", "/b.md"]);
+    expect(result.current).toEqual(mockCounts);
+  });
+
+  it("re-fires when comments-changed event is emitted", async () => {
+    vi.mocked(getUnresolvedCounts)
+      .mockResolvedValueOnce({ "/a.md": 1 })
+      .mockResolvedValueOnce({ "/a.md": 5 });
+
+    const { result } = renderHook(() => useUnresolvedCounts(["/a.md"]));
+    await act(async () => {});
+    expect(result.current).toEqual({ "/a.md": 1 });
+
+    // Find the comments-changed listener and invoke it
+    const commentsCall = vi.mocked(listen).mock.calls.find(
+      (c) => c[0] === "comments-changed"
+    );
+    expect(commentsCall).toBeDefined();
+    const commentsCallback = commentsCall![1] as () => void;
+
+    await act(async () => {
+      commentsCallback();
+    });
+    await act(async () => {});
+
+    expect(getUnresolvedCounts).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ "/a.md": 5 });
+  });
+
+  it("re-fires when file-changed event with kind=review is emitted", async () => {
+    vi.mocked(getUnresolvedCounts)
+      .mockResolvedValueOnce({ "/a.md": 1 })
+      .mockResolvedValueOnce({ "/a.md": 7 });
+
+    const { result } = renderHook(() => useUnresolvedCounts(["/a.md"]));
+    await act(async () => {});
+    expect(result.current).toEqual({ "/a.md": 1 });
+
+    // Find the file-changed listener and invoke with kind=review
+    const fileCall = vi.mocked(listen).mock.calls.find(
+      (c) => c[0] === "file-changed"
+    );
+    expect(fileCall).toBeDefined();
+    const fileCallback = fileCall![1] as (event: {
+      payload: { kind: string };
+    }) => void;
+
+    await act(async () => {
+      fileCallback({ payload: { kind: "review" } });
+    });
+    await act(async () => {});
+
+    expect(getUnresolvedCounts).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ "/a.md": 7 });
+  });
+
+  it("deduplicates when result is structurally equal", async () => {
+    const counts = { "/a.md": 2 };
+    vi.mocked(getUnresolvedCounts)
+      .mockResolvedValueOnce({ "/a.md": 2 })
+      .mockResolvedValueOnce({ "/a.md": 2 });
+
+    const { result } = renderHook(() => useUnresolvedCounts(["/a.md"]));
+    await act(async () => {});
+
+    const firstRef = result.current;
+    expect(firstRef).toEqual(counts);
+
+    // Trigger reload via comments-changed
+    const commentsCall = vi.mocked(listen).mock.calls.find(
+      (c) => c[0] === "comments-changed"
+    );
+    const commentsCallback = commentsCall![1] as () => void;
+
+    await act(async () => {
+      commentsCallback();
+    });
+    await act(async () => {});
+
+    // Should be the same reference since values are structurally equal
+    expect(result.current).toBe(firstRef);
+  });
+});


### PR DESCRIPTION
Autonomous improvement iteration 1/30. Goal: Complete architecture refactoring  move model/viewmodel to Rust, clean up web layer, eliminate duplicate/dead code, complete test coverage.

Changes:
- Stabilize FolderTree mergedList with useMemo (fixes perf bug + ESLint warning)
- Add useUnresolvedCounts test suite (5 tests)
- Add useTheme test suite (3 tests)