### PR TITLE
auto-improve: remove dead Rust code  iteration 2

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,31 +15,6 @@ pub fn check_path_exists(path: String) -> String {
     }
 }
 
-/// Compute the document path of a file relative to a workspace root.
-/// Returns a forward-slash-separated relative path when the file is under root,
-/// or just the filename as a fallback. Used for the MRSF sidecar `document` field.
-pub fn compute_document_path(file_path: String, root: Option<String>) -> String {
-    use std::path::Path;
-
-    if let Some(ref root_str) = root {
-        if !root_str.is_empty() {
-            let file = Path::new(&file_path);
-            let root_path = Path::new(root_str);
-            if let Ok(relative) = file.strip_prefix(root_path) {
-                let rel_str = relative.to_string_lossy();
-                if !rel_str.is_empty() {
-                    return rel_str.replace('\\', "/");
-                }
-            }
-        }
-    }
-    // Fallback: return just the filename
-    Path::new(&file_path)
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or(file_path)
-}
-
 // Types are re-exported from core::types above
 
 pub type LaunchArgsState = Arc<Mutex<Option<LaunchArgs>>>;

--- a/src-tauri/src/core/anchors.rs
+++ b/src-tauri/src/core/anchors.rs
@@ -5,9 +5,6 @@ use super::types::CommentAnchor;
 /// MRSF §6.2: max selected_text length
 pub const SELECTED_TEXT_MAX_LENGTH: usize = 4096;
 
-/// MRSF §6.1: recommended max text length
-pub const TEXT_MAX_LENGTH: usize = 16384;
-
 /// Compute SHA-256 hash of selected text, returned as lowercase hex string.
 pub fn compute_selected_text_hash(text: &str) -> String {
     let mut hasher = Sha256::new();

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -1,5 +1,5 @@
 use mdown_review_lib::commands::{
-    compute_document_path, read_binary_file, read_dir,
+    read_binary_file, read_dir,
     read_text_file, CommentsChangedEvent, LaunchArgs, LaunchArgsState,
     MrsfComment, MrsfSidecar,
 };
@@ -280,60 +280,6 @@ fn read_dir_hides_review_sidecars() {
     assert!(names.contains(&"config.json"));
     assert!(!names.contains(&"readme.md.review.yaml"), "YAML review sidecars should be hidden");
     assert!(!names.contains(&"main.rs.review.json"), "JSON review sidecars should be hidden");
-}
-
-// ── compute_document_path ─────────────────────────────────────────────────
-
-#[test]
-fn compute_document_path_returns_relative_with_root() {
-    let result = compute_document_path("/workspace/project/src/file.md".into(), Some("/workspace/project".into()));
-    assert_eq!(result, "src/file.md");
-}
-
-#[test]
-fn compute_document_path_returns_filename_without_root() {
-    let result = compute_document_path("/some/path/file.md".into(), None);
-    assert_eq!(result, "file.md");
-}
-
-#[test]
-fn compute_document_path_returns_filename_when_not_under_root() {
-    let result = compute_document_path("/other/path/file.md".into(), Some("/workspace/project".into()));
-    assert_eq!(result, "file.md");
-}
-
-#[test]
-fn compute_document_path_handles_nested_deeply() {
-    let result = compute_document_path("/root/a/b/c/d/file.md".into(), Some("/root".into()));
-    assert_eq!(result, "a/b/c/d/file.md");
-}
-
-#[test]
-fn compute_document_path_returns_filename_when_root_equals_file() {
-    // When file_path == root, strip_prefix yields empty string; fallback to filename
-    let result = compute_document_path("/workspace/project".into(), Some("/workspace/project".into()));
-    assert_eq!(result, "project");
-}
-
-#[test]
-#[cfg(windows)]
-fn compute_document_path_uses_forward_slashes() {
-    let result = compute_document_path(r"C:\Users\dev\project\src\file.md".into(), Some(r"C:\Users\dev\project".into()));
-    assert_eq!(result, "src/file.md");
-}
-
-#[test]
-fn compute_document_path_root_with_trailing_separator() {
-    // Root with trailing slash should still work
-    let result = compute_document_path("/workspace/project/file.md".into(), Some("/workspace/project/".into()));
-    assert_eq!(result, "file.md");
-}
-
-#[test]
-fn compute_document_path_returns_filename_with_empty_root() {
-    // Empty root string should fallback to filename, not return absolute path
-    let result = compute_document_path("/workspace/project/file.md".into(), Some("".into()));
-    assert_eq!(result, "file.md");
 }
 
 // ── FileChangeEvent serialization ─────────────────────────────────────────


### PR DESCRIPTION
Autonomous improvement iteration 2/30. Goal: Complete architecture refactoring.

Changes:
- Remove dead \compute_document_path\ function from commands.rs (not called from production code)
- Remove 8 associated integration tests
- Remove unused \TEXT_MAX_LENGTH\ constant from core/anchors.rs