### PR TITLE
auto-improve: remove dead vm barrel and unused type exports  iteration 3

### DIFF
--- a/.claude/self-improve-loop-state.md
+++ b/.claude/self-improve-loop-state.md
@@ -13,3 +13,11 @@ max_iterations: 30
 - Expert review: 6/6 approved, suggestions: perf expert noted IPC storm claim overstated (string-key guard already prevented it, but memo still eliminates wasted tree traversals); test-gap reviewer noted additional edge-case tests for future iterations
 - Goal assessor confidence: 82%
 - Summary: Stabilized FolderTree mergedList memo, added useUnresolvedCounts (5 tests) and useTheme (3 tests) coverage
+
+## Iteration 2 — PASSED
+- Branch: auto-improve/loop-2-remove-dead-rust-code
+- PR: https://github.com/dryotta/mdownreview/pull/46
+- CI: passed (Test Linux, Build macOS-arm64, Build windows-x64)
+- Expert review: 6/6 approved, no blocks
+- Goal assessor confidence: 78%
+- Summary: Removed dead compute_document_path function (25 lines), unused TEXT_MAX_LENGTH constant, and 8 associated integration tests. Net -83 lines.

--- a/.claude/self-improve-loop-state.md
+++ b/.claude/self-improve-loop-state.md
@@ -21,3 +21,11 @@ max_iterations: 30
 - Expert review: 6/6 approved, no blocks
 - Goal assessor confidence: 78%
 - Summary: Removed dead compute_document_path function (25 lines), unused TEXT_MAX_LENGTH constant, and 8 associated integration tests. Net -83 lines.
+
+## Iteration 3 — PASSED
+- Branch: auto-improve/loop-3-remove-dead-vm-barrel
+- PR: https://github.com/dryotta/mdownreview/pull/47
+- CI: passed (Test Linux, Build macOS-arm64, Build windows-x64)
+- Expert review: 6/6 approved; architect expert noted future iterations should tackle more substantial Rust-ward migration
+- Goal assessor confidence: 90%
+- Summary: Deleted dead vm barrel file (src/lib/vm/index.ts), un-exported UseCommentsResult and UseCommentActionsResult interfaces. Net -6 lines.

--- a/src/lib/vm/index.ts
+++ b/src/lib/vm/index.ts
@@ -1,4 +1,0 @@
-export { useComments } from "./use-comments";
-export type { UseCommentsResult } from "./use-comments";
-export { useCommentActions } from "./use-comment-actions";
-export type { UseCommentActionsResult } from "./use-comment-actions";

--- a/src/lib/vm/use-comment-actions.ts
+++ b/src/lib/vm/use-comment-actions.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/tauri-commands";
 import { error } from "@/logger";
 
-export interface UseCommentActionsResult {
+interface UseCommentActionsResult {
   addComment: (
     filePath: string,
     text: string,

--- a/src/lib/vm/use-comments.ts
+++ b/src/lib/vm/use-comments.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/tauri-commands";
 import { info, error } from "@/logger";
 
-export interface UseCommentsResult {
+interface UseCommentsResult {
   threads: CommentThread[];
   comments: MatchedComment[];
   loading: boolean;


### PR DESCRIPTION
Autonomous improvement iteration 3/30. Goal: Complete architecture refactoring.

Changes:
- Delete dead \src/lib/vm/index.ts\ barrel file (no consumers import from \@/lib/vm\)
- Un-export \UseCommentsResult\ and \UseCommentActionsResult\ interfaces (only used internally as return type annotations)