### PR TITLE
chore: redesign self-improve-loop — single branch/PR with parallel CI+local validation

### DIFF
--- a/.claude/agents/goal-assessor.md
+++ b/.claude/agents/goal-assessor.md
@@ -70,7 +70,7 @@ For each criterion from Step 1, determine: **met** or **unmet**, with evidence (
 Write requirement specs for the **next meaningful sprint** toward the goal — a coherent body of work that delivers visible progress, not just the smallest possible next step. Rules:
 - **Fresh from scratch** — do not copy from prior iterations or cached backlogs
 - **Evidence-based** — every requirement cites the specific file:line that needs to change
-- **Sprint-sized** — target 3–8 files worth of changes. If a complete feature slice requires Rust + TypeScript + tests + e2e, include all of it. Do not split work that naturally belongs together across iterations.
+- **Cohesive, not capped** — include everything that naturally belongs together to deliver a complete, coherent improvement. There is no file limit. A large refactor touching 20 files is one sprint if those files form a single logical change. Split only when the work is genuinely independent and can ship separately without leaving the codebase in a half-finished state.
 - **Parallelisable** — group requirements by which can be implemented independently so parallel agents can work on them simultaneously. Label each group: `[Group A — independent]`, `[Group B — depends on A]`, etc.
 - **Testable** — each requirement includes what a passing test would assert
 

--- a/.claude/agents/goal-assessor.md
+++ b/.claude/agents/goal-assessor.md
@@ -67,17 +67,24 @@ For each criterion from Step 1, determine: **met** or **unmet**, with evidence (
 
 ## Step 5 — Write NEXT_REQUIREMENTS (only for in_progress)
 
-Write requirement specs for **one focused implementation step** — the highest-leverage change that moves toward the goal. Rules:
+Write requirement specs for the **next meaningful sprint** toward the goal — a coherent body of work that delivers visible progress, not just the smallest possible next step. Rules:
 - **Fresh from scratch** — do not copy from prior iterations or cached backlogs
 - **Evidence-based** — every requirement cites the specific file:line that needs to change
-- **Scoped** — one step an implementer can complete in a single session, not the entire goal
+- **Sprint-sized** — target 3–8 files worth of changes. If a complete feature slice requires Rust + TypeScript + tests + e2e, include all of it. Do not split work that naturally belongs together across iterations.
+- **Parallelisable** — group requirements by which can be implemented independently so parallel agents can work on them simultaneously. Label each group: `[Group A — independent]`, `[Group B — depends on A]`, etc.
 - **Testable** — each requirement includes what a passing test would assert
 
 Format:
 ```
 NEXT_REQUIREMENTS:
+[Group A — independent]
 - [File: path:line] [What to change] [Test: what a test asserts]
-- ...
+
+[Group B — independent]
+- [File: path:line] [What to change] [Test: what a test asserts]
+
+[Group C — depends on A]
+- [File: path:line] [What to change] [Test: what a test asserts]
 ```
 
 ---

--- a/.claude/skills/self-improve-loop/SKILL.md
+++ b/.claude/skills/self-improve-loop/SKILL.md
@@ -94,7 +94,7 @@ This is the diff baseline for this iteration's expert review.
 
 Spawn **`goal-assessor`**. Pass: goal, iteration number, passed\_count, the Iteration Log from the state file.
 
-Instruction: `"Read the codebase from scratch. Ignore prior specs. Assess whether the goal is fully achieved and, if not, write requirement specs for the next implementation step."`
+Instruction: `"Read the codebase from scratch. Ignore prior specs. Assess whether the goal is fully achieved and, if not, write requirement specs for the next meaningful sprint — a coherent body of work that delivers visible progress toward the goal, not just the smallest possible next step. Group requirements by what can be implemented in parallel."`
 
 Returns:
 ```
@@ -117,7 +117,9 @@ Spawn **`general-purpose`**. Pass: goal, NEXT\_REQUIREMENTS, EVIDENCE.
 
 Prompt:
 ```
-Produce a focused implementation plan. For each changed file: exact changes, tests to write.
+Produce a comprehensive sprint plan. Identify ALL changes needed to make a meaningful step toward the goal — do not artificially limit scope. Use the group structure from NEXT_REQUIREMENTS to organise the plan: independent groups can be implemented in parallel, dependent groups run after their dependencies.
+
+For each group: files to change · exact changes · tests to write · dependencies on other groups.
 Rate overall risk: low | medium | high.
 
 Non-negotiable completeness rules:
@@ -129,15 +131,30 @@ Non-negotiable completeness rules:
 
 Save the plan.
 
-**If risk=high**: log `SKIPPED — high risk: [reason]`, increment `iteration`, continue loop.
+**If risk=high**: spawn `architect-expert` with the full plan and prompt: `"Identify the specific risks in this plan and propose concrete mitigations so it can proceed safely."` Incorporate the architect's mitigations into a revised plan and continue. Only log `SKIPPED — architect rejected: [reason]` and increment `iteration` if the architect judges the approach fundamentally unsound.
 
 ---
 
-### Step C — Implement
+### Step C — Implement (parallel by plan group)
 
-Spawn **`task-implementer`** (or multiple in parallel for independent tasks). Pass: plan, goal, `"Write tests first for any bug fix. Return Implementation Summary."`
+For each **independent group** in the plan, spawn one **`task-implementer`** — send all independent groups in **one parallel message**. For groups that depend on prior groups, wait for their dependencies to finish first, then spawn them.
 
-**If implementer reports no changes or failure**: log `FAILED — implementer: [reason]`, increment `iteration`, continue loop (no commits to push, nothing to clean up).
+Each `task-implementer` prompt:
+```
+Implement this group of changes for mdownreview:
+
+Goal: [goal]
+Group: [group name and dependency note]
+Files: [file list for this group]
+Changes: [exact changes from plan]
+Tests: [tests to write — unit + e2e if UI-visible]
+
+Do not touch files outside this group. Return Implementation Summary: files modified · tests written · decisions · concerns.
+```
+
+Wait for each dependency wave before spawning the next. Collect all Implementation Summaries.
+
+**If any implementer reports no changes or failure**: log `FAILED — implementer [group]: [reason]`, increment `iteration`, continue loop (no commits to push).
 
 ---
 

--- a/.claude/skills/self-improve-loop/SKILL.md
+++ b/.claude/skills/self-improve-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-improve-loop
-description: Autonomous improvement loop for mdownreview. Takes a user goal, runs up to 10 review→plan→implement→validate iterations until the goal is achieved or the limit is reached. Experts re-assess from scratch each iteration to avoid anchoring bias.
+description: Autonomous improvement loop for mdownreview. Takes a user goal, runs up to 10 review→plan→implement→validate iterations on a single branch until the goal is achieved or the limit is reached. All iterations share one branch and one PR. CI and all local tests must be green before each iteration advances.
 ---
 
 # Self-Improve Loop
@@ -17,35 +17,55 @@ Example: `/self-improve-loop eliminate all ESLint warnings in the codebase`
 ### 0a. Capture the goal
 The goal is the text typed after the skill name. If empty, ask:
 > "What improvement goal should I work toward?"
-Wait for the user to provide it before continuing.
+Wait for the user's answer before continuing.
 
-### 0b. Pre-flight checks
+### 0b. Pre-flight
 Run in parallel:
 ```bash
 git status --porcelain
 git branch --show-current
 git rev-parse HEAD
-cat .claude/self-improve-loop-state.md 2>/dev/null || echo "no prior state"
 ```
-
-- **If dirty working tree**: stop — "Commit or stash changes first, then retry."
-- **If not on `main`**: stop — "Switch to main before starting the loop."
+- **Dirty working tree**: STOP — "Commit or stash changes first, then retry."
+- **Not on `main`**: STOP — "Switch to main before starting the loop."
 
 ### 0c. Clarification (max 3 questions, one message)
-Read the goal. If any of the following are genuinely unclear, ask them all in one message — then wait for answers before proceeding:
+If any of the following are genuinely unclear, ask them all in one message then wait:
 1. **Success criteria** — how will you know the goal is fully achieved?
-2. **Scope** — which areas of the codebase are in bounds? (ask only if ambiguous)
+2. **Scope** — which areas are in bounds? (only if ambiguous)
 3. **Constraints** — any files or behaviours that must not change?
 
-If the goal is self-evident (e.g., "fix TypeScript errors", "move X to Rust"), state your assumptions and proceed without asking.
+If the goal is self-evident, state your assumptions and proceed.
 
-### 0d. Initialise state file
+### 0d. Create the loop branch
+```bash
+SLUG=$(echo "[goal text]" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-40)
+DATE=$(date +%Y%m%d)
+BRANCH="auto-improve/${SLUG}-${DATE}"
+git checkout -b "$BRANCH"
+git commit --allow-empty -m "chore: start self-improve loop — [goal]"
+git push -u origin HEAD
+```
+
+### 0e. Open a single draft PR
+```bash
+gh pr create \
+  --title "auto-improve: [goal]" \
+  --body "Autonomous improvement loop. Goal: [goal]
+
+This PR accumulates commits from up to 10 iterations. Each iteration's changes are pushed incrementally. Do not merge until the loop completes and you have reviewed the full diff." \
+  --draft
+```
+Save the PR number and URL.
+
+### 0f. Initialise state file
 Write `.claude/self-improve-loop-state.md`:
 ```markdown
 ---
 goal: "[goal text]"
 started_at: [ISO datetime]
-head_sha: [HEAD SHA]
+branch: [branch name]
+pr: [PR URL]
 max_iterations: 10
 ---
 # Iteration Log
@@ -54,130 +74,155 @@ max_iterations: 10
 Print:
 ```
 [self-improve-loop] Goal: [goal]
+Branch: [branch] | PR: [PR URL]
 Starting autonomous loop — max 10 iterations. No further interaction needed.
 ```
 
 ---
 
-## Phase 1 — Iteration Loop (repeat steps A–G up to 10 times)
+## Phase 1 — Iteration Loop (repeat steps A–F up to 10 times)
 
-Track: `iteration=1`, `passed_count=0`. Loop while `iteration ≤ 10`.
+Track: `iteration=1`, `passed_count=0`. Before each iteration, record:
+```bash
+ITER_BASE_SHA=$(git rev-parse HEAD)
+```
+This is the diff baseline for this iteration's expert review.
 
 ---
 
 ### Step A — Goal Assessment
 
-Spawn a **`goal-assessor`** agent. Pass:
-- The goal verbatim
-- Current iteration number and `passed_count`
-- The Iteration Log section from `.claude/self-improve-loop-state.md`
-- `"Read the codebase from scratch. Ignore any prior requirement specs. Assess whether the goal is fully achieved and, if not, write the requirement spec for the next implementation step."`
+Spawn **`goal-assessor`**. Pass: goal, iteration number, passed\_count, the Iteration Log from the state file.
 
-The agent returns a structured block:
+Instruction: `"Read the codebase from scratch. Ignore prior specs. Assess whether the goal is fully achieved and, if not, write requirement specs for the next implementation step."`
+
+Returns:
 ```
 STATUS: achieved | in_progress | blocked
 CONFIDENCE: 0–100
-NEXT_REQUIREMENTS: [bulleted spec — omit if achieved or blocked]
-EVIDENCE: [file:line citations showing current state vs. goal]
-BLOCKING_REASON: [if blocked only]
+NEXT_REQUIREMENTS: [bulleted spec]
+EVIDENCE: [file:line citations]
+BLOCKING_REASON: [if blocked]
 ```
 
-- **STATUS=achieved**: append final iteration to state file, jump to **Done — Achieved**.
-- **STATUS=blocked**: append to state file, jump to **Done — Blocked**.
-- **STATUS=in_progress**: continue to Step B.
+- **achieved** → append to state file, jump to **Done — Achieved**
+- **blocked** → append to state file, jump to **Done — Blocked**
+- **in_progress** → continue to Step B
 
 ---
 
 ### Step B — Implementation Plan
 
-Spawn a **`general-purpose`** agent. Pass:
-- The goal
-- NEXT_REQUIREMENTS from Step A
-- EVIDENCE from Step A
-- `"Produce a focused implementation plan: specific files to change, what to add/remove/modify in each, which tests to write. Rate overall risk: low | medium | high. Be concise — one plan section per changed file.
+Spawn **`general-purpose`**. Pass: goal, NEXT\_REQUIREMENTS, EVIDENCE.
 
-Non-negotiable completeness rules for the plan:
-- Every unit-level change gets a unit test. Every UI-visible behaviour change also gets a browser e2e test in e2e/browser/.
-- Every new Tauri command must update: commands.rs + tauri-commands.ts + the IPC mock in src/__mocks__/@tauri-apps/api/core.ts.
-- Any code made obsolete by this change (replaced functions, dead imports, superseded patterns) must be deleted in the same plan step — not left as cleanup for later.
-- No TODO comments, no half-wired code, no workarounds. If the complete solution requires touching something risky, rate the plan high risk instead of cutting corners."`
+Prompt:
+```
+Produce a focused implementation plan. For each changed file: exact changes, tests to write.
+Rate overall risk: low | medium | high.
 
-Save the plan output.
+Non-negotiable completeness rules:
+- Every UI-visible behaviour change gets a browser e2e test in e2e/browser/ AND a native e2e test in e2e/native/ if the scenario requires real file I/O or IPC
+- Every new Tauri command: update commands.rs + tauri-commands.ts + IPC mock in src/__mocks__/@tauri-apps/api/core.ts
+- Delete any code made obsolete by this change in the same step
+- No TODO comments, no half-wired code, no workarounds
+```
+
+Save the plan.
 
 **If risk=high**: log `SKIPPED — high risk: [reason]`, increment `iteration`, continue loop.
 
 ---
 
-### Step C — Branch + Implement
+### Step C — Implement
 
-Create a branch:
-```bash
-git checkout -b auto-improve/loop-[N]-[3-word-slug-from-plan]
-```
+Spawn **`task-implementer`** (or multiple in parallel for independent tasks). Pass: plan, goal, `"Write tests first for any bug fix. Return Implementation Summary."`
 
-Spawn a **`task-implementer`** agent. Pass:
-- The implementation plan from Step B
-- The goal
-- `"Write tests for every behavioural change before implementing it. Return an Implementation Summary listing all changed files and test names."`
-
-**If implementer reports no changes or failure**: log `FAILED — implementer: [reason]`, clean up branch:
-```bash
-git checkout main && git branch -D [branch]
-```
-Increment `iteration`, continue loop.
+**If implementer reports no changes or failure**: log `FAILED — implementer: [reason]`, increment `iteration`, continue loop (no commits to push, nothing to clean up).
 
 ---
 
-### Step D — Local Validation
+### Step D — Push then Validate (race CI against local tests)
 
-Spawn an **`implementation-validator`** agent. Pass:
-- The list of changed files from Step C
-- `"Run: lint, TypeScript type-check, Rust cargo test (if Rust files changed), Vitest unit tests, Playwright browser e2e tests. Return PASS or FAIL with full output."`
-
-**If FAIL**: log `FAILED — local validation: [summary]`, clean up:
+**D1 — Push immediately** to trigger CI:
 ```bash
-git checkout main && git branch -D [branch]
+git add -A  # implementer already staged only relevant files; verify first
+git commit -m "auto-improve: iteration [N] — [one-line summary from plan]"
+git push
 ```
-Increment `iteration`, continue loop.
+
+**D2 — Spawn local validation and poll CI in parallel** (one message, two agents):
+
+**Agent 1** — `implementation-validator`:
+```
+Run the full local test suite in order:
+1. npm run lint
+2. npx tsc --noEmit
+3. cd src-tauri && cargo test
+4. npm test
+5. npm run test:e2e
+6. npm run test:e2e:native
+
+Return PASS or FAIL with full output for every check.
+```
+
+**Agent 2** — `general-purpose` (CI poller):
+```
+Poll CI status for PR [PR-number] until all checks are complete or 30 minutes elapse.
+Poll interval: 30 seconds.
+  gh pr checks [PR-number]
+Stop when no check shows "pending" or "in_progress".
+Return: PASS (all checks green) or FAIL (list of failed check names and their logs).
+```
+
+Wait for both agents.
+
+**D3 — Evaluate results:**
+
+| Local | CI | Action |
+|---|---|---|
+| PASS | PASS | Proceed to Step E |
+| FAIL | any | Enter fix loop (Step D-Fix) |
+| PASS | FAIL | Enter fix loop (Step D-Fix) |
 
 ---
 
-### Step E — CI Validation
+### Step D-Fix — Forward Fix Loop (max 5 attempts)
 
-Push the branch and open a draft PR:
-```bash
-git push -u origin HEAD
-gh pr create \
-  --title "auto-improve: [goal slug] — iteration [N]" \
-  --body "Autonomous improvement iteration [N]/10. Goal: [goal]" \
-  --draft
-```
-Save the PR number.
+Repeat until both local and CI pass, or 5 attempts exhausted:
 
-Poll CI until all checks complete or 20 minutes elapse (poll every 30 s):
-```bash
-gh pr checks [PR-number]
-```
-Stop polling when output contains no `pending` or `in_progress` lines.
+1. Spawn **`task-implementer`** with the combined failure output:
+   ```
+   Fix the following failures. Do not revert — make a forward fix.
+   Local failures: [full local output]
+   CI failures: [failed check names and logs]
+   Make the minimal change needed to resolve each failure.
+   Return Implementation Summary of what you changed.
+   ```
 
-**If any check failed or timed out**: log `FAILED — CI: [failed check names]`, close and clean up:
-```bash
-gh pr close [PR-number] --delete-branch
-git checkout main
-```
-Increment `iteration`, continue loop.
+2. Commit and push the fix:
+   ```bash
+   git add <specific files from implementer>
+   git commit -m "auto-improve: fix iteration [N] — [one-line fix description]"
+   git push
+   ```
+
+3. Re-run local validation + CI poll in parallel (same as Step D2).
+
+4. If both pass: exit fix loop, proceed to Step E.
+
+5. If still failing after attempt 5: log `FAILED — could not fix after 5 attempts: [summary]`, increment `iteration`, continue loop. **Do not revert commits** — they stay on the branch for manual review.
 
 ---
 
-### Step F — Expert Diff Review (parallel)
+### Step E — Expert Diff Review (parallel)
 
-Capture the diff:
+Capture only this iteration's changes:
 ```bash
-git diff main --stat
-git diff main
+git diff $ITER_BASE_SHA HEAD --stat
+git diff $ITER_BASE_SHA HEAD
 ```
 
-Spawn **all 6 expert agents in a single message** (one Agent call each, all in parallel):
+Spawn **all 6 expert agents in one message**:
 - `product-improvement-expert`
 - `performance-expert`
 - `architect-expert`
@@ -185,50 +230,42 @@ Spawn **all 6 expert agents in a single message** (one Agent call each, all in p
 - `ux-expert`
 - `bug-hunter`
 
-Each agent receives the same prompt:
+Each receives:
 ```
-Review this diff for mdownreview.
-Goal: [goal]
-Iteration: [N]/10
+Review this iteration's diff for mdownreview.
+Goal: [goal] | Iteration: [N]/10
 
 [DIFF STAT]
-
 [FULL DIFF]
 
-From your area of expertise, answer all of these — BLOCK on any "no":
-1. Does this change make progress toward the goal?
-2. Does it introduce any new bugs, regressions, or architectural problems?
-3. Is every UI-visible behaviour change covered by a browser e2e test in e2e/browser/ (not just unit tests)?
-4. Is there any dead code, unused import, replaced function, or obsolete pattern that was NOT deleted?
-5. Does this change introduce technical debt — TODO comments, half-wired code, bypassed safety checks, or workarounds?
+BLOCK on any of these — APPROVE otherwise:
+1. Does this make progress toward the goal?
+2. New bugs, regressions, or architectural problems?
+3. UI-visible change without a browser e2e test in e2e/browser/?
+4. Dead code, unused import, or replaced pattern not deleted?
+5. Technical debt — TODO comments, half-wired code, bypassed checks?
 
-Return: APPROVE or BLOCK, then a one-paragraph explanation with file:line evidence for any BLOCK.
+Return: APPROVE or BLOCK with file:line evidence for every BLOCK.
 ```
 
 Wait for all 6.
 
-**If any agent returns BLOCK**: log `FAILED — expert review blocked by [agents]: [reasons]`, close PR:
-```bash
-gh pr close [PR-number] --delete-branch
-git checkout main
-```
-Increment `iteration`, continue loop.
-
-**If all 6 return APPROVE (or only flag minor suggestions)**: record suggestions, continue to Step G.
+**If any BLOCK**: spawn **`task-implementer`** with all blocking issues, commit + push the fix, re-run local validation + CI poll (same parallel pattern as D2), then re-run expert review once. If experts still BLOCK after one fix: log `FAILED — expert review: [issues]`, increment `iteration`, continue loop.
 
 ---
 
-### Step G — Record Outcome
+### Step F — Record Outcome
 
 Append to `.claude/self-improve-loop-state.md`:
 ```markdown
 ## Iteration [N] — PASSED
-- Branch: [branch]
-- PR: [URL]
+- Commits: [list of SHAs from ITER_BASE_SHA to HEAD]
 - CI: passed
+- Local tests: all 6 suites passed
 - Expert review: [N/6 approved, suggestions: [list or none]]
 - Goal assessor confidence: [%]
-- Summary: [one sentence from expert consensus]
+- Fix attempts: [N]
+- Summary: [one sentence]
 ```
 
 Increment `passed_count` and `iteration`. Continue loop.
@@ -242,23 +279,22 @@ Increment `passed_count` and `iteration`. Continue loop.
 Goal: [goal]
 Evidence: [EVIDENCE from final goal-assessor]
 
-Open PRs ready to review and merge:
-[list of PR URLs from all PASSED iterations]
+PR ready to review and merge: [PR URL]
+All [N] iterations are on branch [branch]. CI is green.
 ```
 
 ---
 
-## Done — Timed Out (iteration 10 complete, goal not yet achieved)
+## Done — Timed Out
 
 ```
 [self-improve-loop] Limit reached — 10 iterations complete.
 Goal: [goal]
-Progress: [passed_count] iterations passed, [goal-assessor confidence]% of goal achieved.
+Progress: [passed_count] passed, last confidence: [%]
 
-Open PRs (partial progress — review before merging):
-[list of PR URLs]
+PR (partial progress — review before merging): [PR URL]
 
-Remaining work (from last goal-assessor NEXT_REQUIREMENTS):
+Remaining work (from last NEXT_REQUIREMENTS):
 [bulleted list]
 ```
 
@@ -267,11 +303,12 @@ Remaining work (from last goal-assessor NEXT_REQUIREMENTS):
 ## Done — Blocked
 
 ```
-[self-improve-loop] Loop blocked at iteration [N].
+[self-improve-loop] Blocked at iteration [N].
 Goal: [goal]
-Reason: [BLOCKING_REASON from goal-assessor]
+Reason: [BLOCKING_REASON]
 
-Resolve the blocker manually, then restart: /self-improve-loop [goal]
+PR so far: [PR URL]
+Resolve the blocker then restart: /self-improve-loop [goal]
 ```
 
 ---
@@ -279,10 +316,6 @@ Resolve the blocker manually, then restart: /self-improve-loop [goal]
 ## Failure Recovery
 
 If interrupted mid-loop:
-1. Read `.claude/self-improve-loop-state.md` for the last iteration in progress.
-2. If on an `auto-improve/loop-*` branch, clean up:
-   ```bash
-   gh pr close --delete-branch 2>/dev/null || true
-   git checkout main
-   ```
-3. Restart: `/self-improve-loop [goal]` — the state file lets the goal-assessor pick up where progress left off.
+1. Read `.claude/self-improve-loop-state.md` for the branch, PR, and last iteration.
+2. Check out the loop branch: `git checkout [branch]`
+3. Restart: `/self-improve-loop [goal]` — the goal-assessor reads the current code state fresh, so progress already committed is automatically accounted for.


### PR DESCRIPTION
## Problem

The previous design created a new branch and PR per iteration, both starting from `main`. This meant:
- Iteration 2 couldn't see iteration 1's changes until the user manually merged PR 1
- CI could be running on iteration N while iteration N+1 had already started
- No automated handling of CI or test failures

## Solution: Single branch, single PR, parallel validation, forward-fix loop

### What changed

**One branch + one draft PR for the entire loop run (Phase 0)**
- Created at setup, before any iteration starts
- All iterations commit to the same branch incrementally
- User reviews and merges one PR at the end — no babysitting required, loop never merges itself

**CI triggered before local tests (Step D)**
- Push commit immediately after implementation to start CI
- Local validation (all 6 suites) runs in parallel while CI is running
- Wait for both to complete before advancing

**Full local test suite — all 6 suites required to pass**
1. `npm run lint`
2. `npx tsc --noEmit`
3. `cargo test`
4. `npm test` (Vitest)
5. `npm run test:e2e` (Playwright browser)
6. `npm run test:e2e:native` (Playwright native binary)

**Forward-fix loop instead of revert (Step D-Fix)**
- On any local or CI failure: spawn `task-implementer` with the full failure output
- Commit the fix, push (re-triggers CI), re-run local tests in parallel
- Repeat up to 5 times until both green
- If still failing after 5 attempts: mark iteration FAILED, leave commits on branch, continue to next iteration

**Iteration-scoped expert review (Step E)**
- Uses `git diff $ITER_BASE_SHA HEAD` to review only this iteration's changes
- Experts can BLOCK; one fix attempt then re-review before marking FAILED

**Failure recovery**
- Interrupted loops: check out the existing branch, restart the skill — goal-assessor reads current code state fresh so committed progress is automatically included

## Test plan
- [ ] Verify single branch/PR is created in Phase 0 before the loop starts
- [ ] Verify `ITER_BASE_SHA` is captured before each iteration and used in Step E diff
- [ ] Verify local validation includes all 6 suites including native e2e
- [ ] Verify push happens before local validation starts (parallel, not sequential)
- [ ] Verify forward-fix loop retries up to 5 times before marking FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)