### PR TITLE
feat: canary release pipeline with client-side channel switching

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,250 @@
+name: Canary Build
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'site/**'
+      - '*.md'
+      - '.github/workflows/pages.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: canary
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute canary version
+        id: version
+        run: |
+          BASE=$(node -p "require('./package.json').version")
+          VERSION="${BASE}-canary.${GITHUB_RUN_NUMBER}"
+          TAG="canary-${GITHUB_RUN_NUMBER}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Canary version: ${VERSION} (tag: ${TAG})"
+
+  build:
+    needs: prepare
+    name: Build (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows-x64
+            rust_target: x86_64-pc-windows-msvc
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+          - os: windows-latest
+            name: windows-arm64
+            rust_target: aarch64-pc-windows-msvc
+            target_dir: src-tauri/target/aarch64-pc-windows-msvc/release
+            tauri_args: "--target aarch64-pc-windows-msvc"
+          - os: macos-latest
+            name: macos-arm64
+            rust_target: aarch64-apple-darwin
+            target_dir: src-tauri/target/release
+            tauri_args: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Patch canary version
+        shell: bash
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          # tauri.conf.json
+          node -e "
+            const fs = require('fs');
+            const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+            conf.version = '${VERSION}';
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
+          "
+          # Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" src-tauri/Cargo.toml
+          rm -f src-tauri/Cargo.toml.bak
+          echo "Patched version to ${VERSION}"
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clean stale bundles from cache
+        shell: bash
+        run: rm -rf src-tauri/target/release/bundle src-tauri/target/*/release/bundle 2>/dev/null || true
+
+      - name: Build Tauri app
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.tauri_args }}" ]; then
+            npm run tauri:build -- ${{ matrix.tauri_args }}
+          else
+            npm run tauri:build
+          fi
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Rename and upload artifacts
+        shell: bash
+        run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
+          VERSION="${{ needs.prepare.outputs.version }}"
+          NAME="mdownreview-${VERSION}-${{ matrix.name }}"
+
+          # Create the immutable canary release if it doesn't exist
+          gh release view "$TAG" &>/dev/null 2>&1 || \
+          gh release create "$TAG" \
+            --prerelease \
+            --title "Canary Build #${GITHUB_RUN_NUMBER} (${GITHUB_SHA::7})" \
+            --notes "Canary build from main at \`${GITHUB_SHA::7}\`."
+
+          if [[ "${{ matrix.name }}" == windows-* ]]; then
+            nsis_zip=$(ls -t ${{ matrix.target_dir }}/bundle/nsis/*.nsis.zip 2>/dev/null | head -1)
+            [ -z "$nsis_zip" ] && { echo "::error::NSIS zip not found"; exit 1; }
+            cp "$nsis_zip" "${NAME}.zip"
+            gh release upload "$TAG" "${NAME}.zip" --clobber
+
+            sig="${nsis_zip}.sig"
+            if [ -f "$sig" ]; then
+              cp "$sig" "${NAME}.zip.sig"
+              gh release upload "$TAG" "${NAME}.zip.sig" --clobber
+            fi
+          else
+            dmg=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
+            [ -z "$dmg" ] && { echo "::error::DMG not found"; exit 1; }
+            cp "$dmg" "${NAME}.dmg"
+            gh release upload "$TAG" "${NAME}.dmg" --clobber
+
+            app_tar=$(ls -t ${{ matrix.target_dir }}/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+            if [ -n "$app_tar" ]; then
+              cp "$app_tar" "${NAME}.app.tar.gz"
+              gh release upload "$TAG" "${NAME}.app.tar.gz" --clobber
+              sig="${app_tar}.sig"
+              if [ -f "$sig" ]; then
+                cp "$sig" "${NAME}.app.tar.gz.sig"
+                gh release upload "$TAG" "${NAME}.app.tar.gz.sig" --clobber
+              fi
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-canary-manifest:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and publish canary-latest.json
+        shell: bash
+        run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
+          VERSION="${{ needs.prepare.outputs.version }}"
+          BASE_URL="https://github.com/dryotta/mdownreview/releases/download/${TAG}"
+          NAME="mdownreview-${VERSION}"
+
+          mkdir -p /tmp/sigs
+
+          read_sig() {
+            local asset_name="$1"
+            gh release download "$TAG" --pattern "${asset_name}" --dir /tmp/sigs 2>/dev/null || true
+            cat "/tmp/sigs/${asset_name}" 2>/dev/null || echo ""
+          }
+
+          # Verify all updater assets exist
+          for asset in "${NAME}-windows-x64.zip" "${NAME}-windows-arm64.zip" "${NAME}-macos-arm64.app.tar.gz"; do
+            gh release view "$TAG" --json assets --jq ".assets[].name" | grep -q "^${asset}$" || \
+              { echo "::error::Required updater asset not found: $asset"; exit 1; }
+          done
+
+          WIN_X64_SIG=$(read_sig "${NAME}-windows-x64.zip.sig")
+          WIN_ARM64_SIG=$(read_sig "${NAME}-windows-arm64.zip.sig")
+          MAC_ARM64_SIG=$(read_sig "${NAME}-macos-arm64.app.tar.gz.sig")
+
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          cat > /tmp/canary-latest.json <<EOF
+          {
+            "version": "${VERSION}",
+            "notes": "Canary build from main (${GITHUB_SHA::7})",
+            "pub_date": "${PUB_DATE}",
+            "platforms": {
+              "windows-x86_64": {
+                "signature": "${WIN_X64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-x64.zip"
+              },
+              "windows-aarch64": {
+                "signature": "${WIN_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-windows-arm64.zip"
+              },
+              "darwin-aarch64": {
+                "signature": "${MAC_ARM64_SIG}",
+                "url": "${BASE_URL}/${NAME}-macos-arm64.app.tar.gz"
+              }
+            }
+          }
+          EOF
+
+          # Update the mutable "canary" release (manifest pointer only)
+          gh release delete canary --yes 2>/dev/null || true
+          git tag -f canary
+          git push origin canary --force
+          gh release create canary \
+            --prerelease \
+            --title "Canary (latest)" \
+            --notes "Points to the latest canary build. Auto-updated on each main push."
+          gh release upload canary /tmp/canary-latest.json --clobber
+
+          echo "Published canary-latest.json pointing to ${TAG}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up old canary releases (keep last 5)
+        shell: bash
+        run: |
+          # List canary-N releases sorted by creation date (oldest first)
+          RELEASES=$(gh release list --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("canary-"))] | sort_by(.createdAt) | .[].tagName')
+
+          COUNT=$(echo "$RELEASES" | wc -l)
+          KEEP=5
+
+          if [ "$COUNT" -gt "$KEEP" ]; then
+            DELETE_COUNT=$((COUNT - KEEP))
+            echo "Cleaning up ${DELETE_COUNT} old canary releases (keeping last ${KEEP})"
+            echo "$RELEASES" | head -n "$DELETE_COUNT" | while read -r tag; do
+              echo "Deleting release: $tag"
+              gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+            done
+          else
+            echo "Only ${COUNT} canary releases, nothing to clean up"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/e2e/browser/fixtures/error-tracking.ts
+++ b/e2e/browser/fixtures/error-tracking.ts
@@ -55,6 +55,8 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
               if (cmd === "get_file_comments") return [];
               if (cmd === "scan_review_files") return [];
               if (cmd === "update_watched_files") return undefined;
+              if (cmd === "check_update") return null;
+              if (cmd === "install_update") return null;
             }
             return result;
           }
@@ -63,6 +65,8 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
           if (cmd === "get_file_comments") return [];
           if (cmd === "scan_review_files") return [];
           if (cmd === "update_watched_files") return undefined;
+          if (cmd === "check_update") return null;
+          if (cmd === "install_update") return null;
           return null;
         },
       };

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "walkdir",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 uuid = { version = "1", features = ["v4"] }
+url = "2"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod core;
+pub mod update;
 pub mod watcher;
 
 use commands::LaunchArgsState;
@@ -102,6 +103,7 @@ pub fn run() {
             })
         )
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .manage(update::PendingUpdate(std::sync::Mutex::new(None)))
         .manage(watcher::WatcherState::new(sync_tx))
         .manage(watcher::SyncRx(std::sync::Mutex::new(Some(sync_rx))))
         .setup(|app| {
@@ -236,6 +238,8 @@ pub fn run() {
                 commands::compute_anchor_hash,
                 commands::get_unresolved_counts,
                 watcher::update_watched_files,
+                update::check_update,
+                update::install_update,
                 $($extra),*
             ]
         };

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,0 +1,123 @@
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+const STABLE_ENDPOINT: &str =
+    "https://github.com/dryotta/mdownreview/releases/latest/download/latest.json";
+const CANARY_ENDPOINT: &str =
+    "https://github.com/dryotta/mdownreview/releases/download/canary/canary-latest.json";
+
+/// Holds the Update object between check and install so the frontend
+/// can show a banner and the user can decide when to install.
+pub struct PendingUpdate(pub Mutex<Option<Update>>);
+
+#[derive(serde::Serialize, Clone)]
+pub struct UpdateInfo {
+    pub version: String,
+    pub body: Option<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct UpdateProgressEvent {
+    event: String,
+    content_length: Option<u64>,
+    chunk_length: usize,
+}
+
+fn endpoint_for_channel(channel: &str) -> &'static str {
+    match channel {
+        "canary" => CANARY_ENDPOINT,
+        _ => STABLE_ENDPOINT,
+    }
+}
+
+/// Derive the installed channel from the current app version string.
+fn installed_channel(app: &AppHandle) -> &'static str {
+    let version = app.config().version.clone().unwrap_or_default();
+    if version.contains("-canary") {
+        "canary"
+    } else {
+        "stable"
+    }
+}
+
+/// Check for an update on the given channel.
+/// For cross-channel switches the version comparator is overridden
+/// to accept any different version (enabling "downgrades").
+#[tauri::command]
+pub async fn check_update(
+    app: AppHandle,
+    channel: String,
+) -> Result<Option<UpdateInfo>, String> {
+    let endpoint = endpoint_for_channel(&channel);
+    let cross_channel = installed_channel(&app) != channel.as_str();
+
+    let url: url::Url = endpoint.parse().map_err(|e: url::ParseError| e.to_string())?;
+    let mut builder = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?;
+
+    if cross_channel {
+        builder = builder.version_comparator(|_current, _remote| true);
+    }
+
+    let updater = builder.build().map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| e.to_string())?;
+
+    match update {
+        Some(u) => {
+            let info = UpdateInfo {
+                version: u.version.clone(),
+                body: u.body.clone(),
+            };
+            let state = app.state::<PendingUpdate>();
+            *state.0.lock().unwrap() = Some(u);
+            Ok(Some(info))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Download and install the pending update. Emits "update-progress"
+/// events so the frontend can show a progress bar.
+#[tauri::command]
+pub async fn install_update(app: AppHandle) -> Result<(), String> {
+    let update = {
+        let state = app.state::<PendingUpdate>();
+        let taken = state.0.lock().unwrap().take();
+        taken
+    };
+
+    let update = update.ok_or_else(|| "No pending update to install".to_string())?;
+    let app_handle = app.clone();
+    let app_finish = app.clone();
+
+    update
+        .download_and_install(
+            move |chunk_length, content_length| {
+                let payload = UpdateProgressEvent {
+                    event: if content_length.is_some() && chunk_length == 0 {
+                        "Started".into()
+                    } else {
+                        "Progress".into()
+                    },
+                    content_length,
+                    chunk_length,
+                };
+                let _ = app_handle.emit("update-progress", payload);
+            },
+            move || {
+                let payload = UpdateProgressEvent {
+                    event: "Finished".into(),
+                    content_length: None,
+                    chunk_length: 0,
+                };
+                let _ = app_finish.emit("update-progress", payload);
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useState } from "react";
 import { useStore, openFilesFromArgs } from "@/store";
 import { useShallow } from "zustand/shallow";
-import { getLaunchArgs } from "@/lib/tauri-commands";
+import { getLaunchArgs, checkUpdate } from "@/lib/tauri-commands";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
@@ -14,7 +14,6 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { WelcomeView } from "@/components/WelcomeView";
 import { getFileCategory } from "@/lib/file-types";
-import type { Update } from "@tauri-apps/plugin-updater";
 import "@/styles/app.css";
 
 type Theme = "system" | "light" | "dark";
@@ -68,8 +67,7 @@ export default function App() {
   const addRecentItem = useStore((s) => s.addRecentItem);
 
   const [aboutOpen, setAboutOpen] = useState(false);
-  const [pendingUpdate, setPendingUpdate] = useState<Update | null>(null);
-  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const dragRef= useRef<{ startX: number; startWidth: number } | null>(null);
 
   // Connect Rust file watcher to frontend event pipeline
   useFileWatcher();
@@ -186,14 +184,12 @@ export default function App() {
   }, [handleOpenFile, handleOpenFolder, toggleCommentsPane]);
 
   const triggerUpdateCheck = useCallback(async () => {
-    const { setUpdateStatus, setUpdateVersion } = useStore.getState();
+    const { setUpdateStatus, setUpdateVersion, updateChannel } = useStore.getState();
     try {
       setUpdateStatus("checking");
-      const { check } = await import("@tauri-apps/plugin-updater");
-      const update = await check();
-      if (update) {
-        setPendingUpdate(update);
-        setUpdateVersion(update.version);
+      const info = await checkUpdate(updateChannel);
+      if (info) {
+        setUpdateVersion(info.version);
         setUpdateStatus("available");
       } else {
         setUpdateStatus("idle");
@@ -302,7 +298,7 @@ export default function App() {
         </div>
       </div>
 
-      <UpdateBanner update={pendingUpdate} />
+      <UpdateBanner />
       </ErrorBoundary>
 
       <div className="main-area">

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import { getAppVersion, getLogPath } from "@/lib/tauri-commands";
+import { getAppVersion, getLogPath, checkUpdate } from "@/lib/tauri-commands";
+import { useStore, type UpdateChannel } from "@/store";
+import { useShallow } from "zustand/shallow";
 import "@/styles/about-dialog.css";
 
 interface Props {
@@ -11,6 +13,13 @@ export function AboutDialog({ onClose }: Props) {
   const [version, setVersion] = useState<string>("");
   const [logPath, setLogPath] = useState<string>("");
   const [copied, setCopied] = useState(false);
+
+  const { updateChannel, setUpdateChannel } = useStore(
+    useShallow((s) => ({
+      updateChannel: s.updateChannel,
+      setUpdateChannel: s.setUpdateChannel,
+    }))
+  );
 
   useEffect(() => {
     getAppVersion()
@@ -27,6 +36,26 @@ export function AboutDialog({ onClose }: Props) {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const handleChannelChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const channel = e.target.value as UpdateChannel;
+    setUpdateChannel(channel);
+    const { setUpdateStatus, setUpdateVersion } = useStore.getState();
+    try {
+      setUpdateStatus("checking");
+      const info = await checkUpdate(channel);
+      if (info) {
+        setUpdateVersion(info.version);
+        setUpdateStatus("available");
+      } else {
+        setUpdateStatus("idle");
+      }
+    } catch {
+      setUpdateStatus("idle");
+    }
+  };
+
+  const isCanary = version.includes("-canary");
+
   return (
     <div className="dialog-overlay" onClick={onClose} role="dialog" aria-modal="true">
       <div className="dialog-box" onClick={(e) => e.stopPropagation()}>
@@ -35,7 +64,27 @@ export function AboutDialog({ onClose }: Props) {
           <button className="dialog-close" onClick={onClose}>×</button>
         </div>
         <div className="dialog-body">
-          <p className="dialog-version">Version {version || "…"}</p>
+          <p className="dialog-version">
+            Version {version || "…"}
+            {isCanary && <span className="canary-badge">canary</span>}
+          </p>
+          <div className="dialog-channel-section">
+            <label className="dialog-label" htmlFor="update-channel">Update channel</label>
+            <select
+              id="update-channel"
+              className="dialog-channel-select"
+              value={updateChannel}
+              onChange={handleChannelChange}
+            >
+              <option value="stable">Stable</option>
+              <option value="canary">Canary</option>
+            </select>
+            {updateChannel === "canary" && (
+              <p className="dialog-channel-warning">
+                ⚠ Canary builds are untested pre-releases from every main commit.
+              </p>
+            )}
+          </div>
           <div className="dialog-log-section">
             <label className="dialog-label">Log file</label>
             <div className="dialog-log-path">

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -15,40 +15,40 @@ beforeEach(() => {
 
 describe("UpdateBanner", () => {
   it("renders nothing when status is idle", () => {
-    const { container } = render(<UpdateBanner update={null} />);
+    const { container } = render(<UpdateBanner />);
     expect(container.firstChild).toBeNull();
   });
 
   it("renders nothing when status is checking", () => {
     useStore.setState({ updateStatus: "checking" });
-    const { container } = render(<UpdateBanner update={null} />);
+    const { container } = render(<UpdateBanner />);
     expect(container.firstChild).toBeNull();
   });
 
   it("shows version and Install button when update is available", () => {
     useStore.setState({ updateStatus: "available", updateVersion: "1.2.3" });
-    render(<UpdateBanner update={null} />);
+    render(<UpdateBanner />);
     expect(screen.getByText("v1.2.3 available")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Install" })).toBeInTheDocument();
   });
 
   it("shows download progress bar when downloading", () => {
     useStore.setState({ updateStatus: "downloading", updateProgress: 42 });
-    render(<UpdateBanner update={null} />);
+    render(<UpdateBanner />);
     expect(screen.getByText("Downloading update… 42%")).toBeInTheDocument();
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
   it("shows restart button when ready", () => {
     useStore.setState({ updateStatus: "ready" });
-    render(<UpdateBanner update={null} />);
+    render(<UpdateBanner />);
     expect(screen.getByText("Restart to apply update")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restart Now" })).toBeInTheDocument();
   });
 
   it("dismiss button resets status to idle", async () => {
     useStore.setState({ updateStatus: "available", updateVersion: "1.2.3" });
-    render(<UpdateBanner update={null} />);
+    render(<UpdateBanner />);
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Dismiss update" }));
     expect(useStore.getState().updateStatus).toBe("idle");

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -1,10 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { UpdateBanner } from "./UpdateBanner";
 import { useStore } from "@/store";
 
-// Reset store state before each test
+vi.mock("@tauri-apps/api/core");
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+vi.mock("@/logger");
+vi.mock("@/lib/tauri-commands", () => ({
+  installUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+
 beforeEach(() => {
   useStore.setState({
     updateStatus: "idle",

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,12 +1,16 @@
-import type { Update } from "@tauri-apps/plugin-updater";
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { installUpdate } from "@/lib/tauri-commands";
 import { useUpdateState } from "@/store";
 import "@/styles/update-banner.css";
 
-interface UpdateBannerProps {
-  update: Update | null;
+interface ProgressPayload {
+  event: "Started" | "Progress" | "Finished";
+  content_length: number | null;
+  chunk_length: number;
 }
 
-export function UpdateBanner({ update }: UpdateBannerProps) {
+export function UpdateBanner() {
   const {
     updateStatus,
     updateVersion,
@@ -16,26 +20,34 @@ export function UpdateBanner({ update }: UpdateBannerProps) {
     dismissUpdate,
   } = useUpdateState();
 
+  // Listen for progress events from Rust install_update command
+  useEffect(() => {
+    let downloaded = 0;
+    let total = 0;
+    const unlisten = listen<ProgressPayload>("update-progress", (event) => {
+      const { payload } = event;
+      if (payload.event === "Started") {
+        total = payload.content_length ?? 0;
+      } else if (payload.event === "Progress") {
+        downloaded += payload.chunk_length;
+        if (total > 0) setUpdateProgress(Math.min(Math.round((downloaded / total) * 100), 100));
+      } else if (payload.event === "Finished") {
+        setUpdateStatus("ready");
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn()).catch(() => {});
+    };
+  }, [setUpdateProgress, setUpdateStatus]);
+
   if (updateStatus === "idle" || updateStatus === "checking" || updateStatus === "error") {
     return null;
   }
 
   const handleInstall = async () => {
-    if (!update) return;
     setUpdateStatus("downloading");
     try {
-      let downloaded = 0;
-      let total = 0;
-      await update.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          total = event.data.contentLength ?? 0;
-        } else if (event.event === "Progress") {
-          downloaded += event.data.chunkLength;
-          if (total > 0) setUpdateProgress(Math.min(Math.round((downloaded / total) * 100), 100));
-        } else if (event.event === "Finished") {
-          setUpdateStatus("ready");
-        }
-      });
+      await installUpdate();
     } catch {
       setUpdateProgress(0);
       setUpdateStatus("available");

--- a/src/components/__tests__/AboutDialog.test.tsx
+++ b/src/components/__tests__/AboutDialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { AboutDialog } from "../AboutDialog";
+import { useStore } from "@/store";
 
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
@@ -9,6 +10,7 @@ vi.mock("@/logger");
 vi.mock("@/lib/tauri-commands", () => ({
   getLogPath: vi.fn(),
   getAppVersion: vi.fn(),
+  checkUpdate: vi.fn().mockResolvedValue(null),
 }));
 
 import { getLogPath, getAppVersion } from "@/lib/tauri-commands";
@@ -112,5 +114,43 @@ describe("14.4 – AboutDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "×" }));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders update channel dropdown defaulting to stable", async () => {
+    useStore.setState({ updateChannel: "stable" });
+    await act(async () => {
+      render(<AboutDialog onClose={vi.fn()} />);
+    });
+
+    const select = screen.getByLabelText("Update channel") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe("stable");
+  });
+
+  it("shows canary warning when canary is selected", async () => {
+    useStore.setState({ updateChannel: "canary" });
+    await act(async () => {
+      render(<AboutDialog onClose={vi.fn()} />);
+    });
+
+    expect(screen.getByText(/Canary builds are untested/)).toBeInTheDocument();
+  });
+
+  it("does not show canary warning when stable is selected", async () => {
+    useStore.setState({ updateChannel: "stable" });
+    await act(async () => {
+      render(<AboutDialog onClose={vi.fn()} />);
+    });
+
+    expect(screen.queryByText(/Canary builds are untested/)).not.toBeInTheDocument();
+  });
+
+  it("shows canary badge when version contains -canary", async () => {
+    mockGetAppVersion.mockResolvedValue("0.3.4-canary.42");
+    await act(async () => {
+      render(<AboutDialog onClose={vi.fn()} />);
+    });
+
+    expect(screen.getByText("canary")).toBeInTheDocument();
   });
 });

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -153,3 +153,16 @@ export const computeAnchorHash = (text: string): Promise<string> =>
 export const getUnresolvedCounts = (filePaths: string[]): Promise<Record<string, number>> =>
   invoke<Record<string, number>>("get_unresolved_counts", { filePaths });
 
+// ── Update channel commands ───────────────────────────────────────────────
+
+export interface UpdateInfo {
+  version: string;
+  body: string | null;
+}
+
+export const checkUpdate = (channel: string): Promise<UpdateInfo | null> =>
+  invoke<UpdateInfo | null>("check_update", { channel });
+
+export const installUpdate = (): Promise<void> =>
+  invoke<void>("install_update");
+

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -78,14 +78,17 @@ interface WatcherSlice {
 
 // "error" is treated identically to "idle" by the banner (silent fallback); reserved for future telemetry
 export type UpdateStatus = "idle" | "checking" | "available" | "downloading" | "ready" | "error";
+export type UpdateChannel = "stable" | "canary";
 
 interface UpdateSlice {
   updateStatus: UpdateStatus;
   updateVersion: string | null;
   updateProgress: number; // 0–100 during download
+  updateChannel: UpdateChannel;
   setUpdateStatus: (status: UpdateStatus) => void;
   setUpdateVersion: (version: string | null) => void;
   setUpdateProgress: (progress: number) => void;
+  setUpdateChannel: (channel: UpdateChannel) => void;
   dismissUpdate: () => void;
 }
 
@@ -203,9 +206,11 @@ export const useStore = create<Store>()(
       updateStatus: "idle",
       updateVersion: null,
       updateProgress: 0,
+      updateChannel: "stable" as UpdateChannel,
       setUpdateStatus: (status) => set({ updateStatus: status }),
       setUpdateVersion: (version) => set({ updateVersion: version }),
       setUpdateProgress: (progress) => set({ updateProgress: progress }),
+      setUpdateChannel: (channel) => set({ updateChannel: channel }),
       dismissUpdate: () => set({ updateStatus: "idle", updateVersion: null, updateProgress: 0 }),
 
       // Recent items
@@ -232,6 +237,7 @@ export const useStore = create<Store>()(
         recentItems: state.recentItems,
         tabs: state.tabs,
         activeTabPath: state.activeTabPath,
+        updateChannel: state.updateChannel,
       }),
       onRehydrateStorage: () => () => {
         queueMicrotask(() => {
@@ -270,8 +276,10 @@ export function useUpdateState() {
       updateStatus: s.updateStatus,
       updateVersion: s.updateVersion,
       updateProgress: s.updateProgress,
+      updateChannel: s.updateChannel,
       setUpdateStatus: s.setUpdateStatus,
       setUpdateProgress: s.setUpdateProgress,
+      setUpdateChannel: s.setUpdateChannel,
       dismissUpdate: s.dismissUpdate,
     }))
   );

--- a/src/styles/about-dialog.css
+++ b/src/styles/about-dialog.css
@@ -82,3 +82,46 @@
   border-radius: 4px;
   flex: 1;
 }
+
+.dialog-channel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dialog-channel-select {
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 13px;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.dialog-channel-select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.dialog-channel-warning {
+  font-size: 12px;
+  color: var(--color-warning, #d4a017);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.canary-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--color-warning, #d4a017);
+  color: #000;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Adds canary build pipeline + client-side channel switching between stable/canary update streams.

- Canary CI workflow builds all 3 platforms on every main push
- Rust update module with channel-aware check/install commands
- About dialog dropdown for channel switching
- All tests pass (lint, cargo test, 535 unit, 40 e2e)