### PR TITLE
chore(skills): rebase self-improve-loop onto main each iteration

### DIFF
--- a/.claude/skills/self-improve-loop/SKILL.md
+++ b/.claude/skills/self-improve-loop/SKILL.md
@@ -54,6 +54,11 @@ BRANCH="auto-improve/${SLUG}-${DATE}"
 git checkout -b "$BRANCH"
 git commit --allow-empty -m "chore: start self-improve loop — [goal]"
 git push -u origin HEAD
+
+# Enable rerere so conflict resolutions are remembered and auto-replayed
+# across future rebases — critical for autonomous drift management.
+git config rerere.enabled true
+git config rerere.autoupdate true
 ```
 
 ### 0e. Open a single draft PR
@@ -89,13 +94,124 @@ Starting autonomous loop — max 10 iterations. No further interaction needed.
 
 ---
 
-## Phase 1 — Iteration Loop (repeat steps A–F up to 10 times)
+## Phase 1 — Iteration Loop (repeat steps 0 + A–F up to 10 times)
 
-Track: `iteration=1`, `passed_count=0`. Before each iteration, record:
+Track: `iteration=1`, `passed_count=0`.
+
+---
+
+### Step 0 — Sync with main (rebase, optimized for automatic resolution)
+
+Rebase onto the latest `origin/main` **at the start of every iteration** so drift is caught while conflicts are still trivial. Do this BEFORE Step A so the goal-assessor reads a tree that reflects current main.
+
+Strategy — maximise auto-resolution in this order: (1) rerere replay of known resolutions, (2) git's own merge drivers, (3) parallel per-file `task-implementer` agents with multiple retries, (4) `architect-expert` last-resort. Only abort if all four fail.
+
 ```bash
+git fetch origin main
+
+# Fast-forward no-op shortcut: branch already contains main.
+if git merge-base --is-ancestor origin/main HEAD; then
+  echo "[sync] branch already contains origin/main — no rebase needed"
+else
+  # Use recursive strategy with diff3 markers — diff3 gives the implementer
+  # the common ancestor, which dramatically improves resolution quality.
+  git rebase --strategy=recursive --strategy-option=diff3 origin/main
+fi
+```
+
+**If the rebase completes cleanly** (exit 0, `git status` reports clean working tree): skip to the "After successful rebase" block below.
+
+**If the rebase pauses with conflicts**, run this auto-resolution loop. Each iteration of the loop is one paused rebase commit; `rerere` will auto-resolve any conflict whose exact hunks have been resolved before on this branch.
+
+```
+attempt = 0                        # retries for the CURRENT paused commit
+max_attempts_per_commit = 3
+max_total_commits = 20             # abort if rebase has to replay more than this
+commits_replayed = 0
+```
+
+Loop while a rebase is in progress (`.git/rebase-merge` or `.git/rebase-apply` exists):
+
+1. **Detect the current state** in parallel:
+   ```bash
+   CONFLICTED=$(git diff --name-only --diff-filter=U)
+   HAS_MARKERS=$(git grep -lE '^<<<<<<< ' -- . 2>/dev/null || true)
+   ```
+
+2. **Empty-commit skip**: if `CONFLICTED` is empty AND `HAS_MARKERS` is empty (rerere fully resolved it, or the commit became empty after rebase):
+   ```bash
+   git add -A
+   git -c core.editor=true rebase --continue 2>/dev/null || git rebase --skip
+   ```
+   `commits_replayed += 1`, `attempt = 0`. Continue loop.
+
+3. **Auto-resolve in parallel** — one `task-implementer` per conflicted file, dispatched in a single message:
+   ```
+   Resolve merge conflicts in [FILE] from rebasing the auto-improve branch onto main.
+
+   Context:
+   - Goal of this auto-improve branch: [goal]
+   - Iteration: [N] | Attempt: [attempt+1]/[max_attempts_per_commit]
+   - Conflict markers use diff3 format: <<< ours === |||||||  base === >>> theirs
+     * ours = auto-improve work
+     * base = common ancestor
+     * theirs = incoming main
+   - git rerere is enabled — your resolution will be cached and auto-replayed on future rebases. Prefer consistent, principled resolutions over one-off hacks.
+
+   Rules:
+   - Preserve the intent of BOTH sides. If main refactored/renamed/moved code that ours also touched, adapt ours to main's new shape — do NOT revert main.
+   - Remove ALL conflict markers.
+   - Do NOT run `git add` or `git rebase --continue`. Just write the resolved file.
+   - If the conflict is semantically impossible to merge (e.g., main deleted a feature ours extended), state so explicitly and leave the markers in place — the loop will escalate.
+
+   Return: file path, one-paragraph summary of the resolution, and a confidence 0–100.
+   ```
+
+4. **Stage and attempt to continue**:
+   ```bash
+   git add -A
+   git -c core.editor=true rebase --continue
+   RC=$?
+   ```
+
+5. **Outcome**:
+   - Exit 0 and no new conflicts → `commits_replayed += 1`, `attempt = 0`, continue loop.
+   - Exit 0 and rebase complete → break out of loop.
+   - Exit non-zero (still conflicts in same commit):
+     - `attempt += 1`
+     - If `attempt < max_attempts_per_commit`: re-run step 3 with an augmented prompt that includes the previous attempt's resolution and the specific markers that are still present.
+     - If `attempt == max_attempts_per_commit`: escalate once — spawn `architect-expert` with the full file contents, the diff from main, the diff from ours, and all prior implementer summaries, asking for a principled resolution. Apply its output, run step 4 once more.
+     - If still conflicts after the architect escalation, OR if `commits_replayed > max_total_commits`: abort.
+
+6. **Abort path** (only if all auto-resolution failed):
+   ```bash
+   git rebase --abort
+   ```
+   Append to state file:
+   ```markdown
+   ## Iteration [N] — BLOCKED (merge conflict)
+   - Conflicted commit: [current HEAD of paused rebase]
+   - Files: [list]
+   - Attempts: [implementer retries + 1 architect]
+   - Summary of last resolution attempt: [text]
+   ```
+   Jump to **Done — Blocked** with reason `merge conflict against main at iteration [N] — human resolution required`.
+
+**After a successful rebase**, sync the remote branch and capture the iteration baseline:
+
+```bash
+git push --force-with-lease
 ITER_BASE_SHA=$(git rev-parse HEAD)
 ```
-This is the diff baseline for this iteration's expert review.
+
+`ITER_BASE_SHA` is the diff baseline for this iteration's expert review (Step E). Capturing it AFTER the rebase means Step E reviews only this iteration's NEW work, not the rebase replay.
+
+**Post-rebase sanity check** (fast, catches subtle resolution errors before running the full test suite in Step D):
+```bash
+npx tsc --noEmit
+cd src-tauri && cargo check
+```
+If either fails, treat the rebase as broken: escalate by spawning `task-implementer` with the compile/type errors and instructions to fix them as a follow-up commit. Commit + push. Only proceed to Step A once the tree compiles.
 
 ---
 
@@ -345,4 +461,10 @@ Resolve the blocker then restart: /self-improve-loop [goal]
 If interrupted mid-loop:
 1. Read `.claude/self-improve-loop-state.md` for the branch, PR, and last iteration.
 2. Check out the loop branch: `git checkout [branch]`
-3. Restart: `/self-improve-loop [goal]` — the goal-assessor reads the current code state fresh, so progress already committed is automatically accounted for.
+3. If a rebase is in progress (`.git/rebase-merge` or `.git/rebase-apply` exists), either complete or abort it before restarting — the loop assumes a clean working tree.
+4. Ensure rerere is enabled on the branch (idempotent):
+   ```bash
+   git config rerere.enabled true
+   git config rerere.autoupdate true
+   ```
+5. Restart: `/self-improve-loop [goal]` — Step 0 will rebase onto the latest main before the goal-assessor runs, so progress already committed is automatically accounted for AND the branch catches up with any main-side changes.


### PR DESCRIPTION
## Summary
- Adds **Step 0 — Sync with main** to `.claude/skills/self-improve-loop/SKILL.md` so the auto-improve branch rebases onto `origin/main` at the start of every iteration. Drift is caught while conflicts are still trivial instead of accumulating over 10 iterations.
- Optimised for automatic resolution, so the loop stays autonomous:
  - Phase 0 enables `git rerere` on the branch (auto-replays cached resolutions on subsequent rebases).
  - Uses `--strategy-option=diff3` so conflict markers include the common ancestor — much higher implementer resolution quality.
  - Conflict path dispatches **parallel per-file `task-implementer` agents**, up to 3 retries per paused commit, with an `architect-expert` escalation before aborting.
  - Post-rebase sanity check (`tsc --noEmit` + `cargo check`) catches subtle mis-merges before running the full test suite in Step D.
  - `ITER_BASE_SHA` is captured **after** the rebase so Step E's expert review sees only this iteration's new work, not the rebase replay.
- Failure-recovery section updated: detect an in-progress rebase on restart and re-enable `rerere` idempotently for branches created before this change.

## Test plan
- [ ] Next `/self-improve-loop` run logs `[sync] branch already contains origin/main` or performs a clean rebase before Step A.
- [ ] If a conflict is induced (e.g., main touches a file ours is also editing), the loop resolves it via parallel implementers without human intervention.
- [ ] `git config --get rerere.enabled` returns `true` on the auto-improve branch after Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)