### PR TITLE
feat: explicit macOS ad-hoc signing + CI verify (phase 1 of #55)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,21 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Verify macOS ad-hoc signature
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          app_bundle=$(ls -d ${{ matrix.target_dir }}/bundle/macos/*.app 2>/dev/null | head -1)
+          [ -z "$app_bundle" ] && { echo "::error::.app bundle not found for codesign verify"; exit 1; }
+          echo "Verifying signature on: $app_bundle"
+          output=$(codesign -dv --verbose=4 "$app_bundle" 2>&1)
+          echo "$output"
+          if ! echo "$output" | grep -q "^Signature=adhoc$"; then
+            echo "::error::.app is not ad-hoc signed (expected 'Signature=adhoc' in codesign output)"
+            exit 1
+          fi
+          echo "OK: .app is ad-hoc signed"
+
       - name: Build CLI binary
         shell: bash
         run: |

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,9 @@
       "nsis": {
         "installMode": "currentUser"
       }
+    },
+    "macOS": {
+      "signingIdentity": "-"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

Phase 1 of #55 — the smallest, independently-shippable slice from the spec's 13-PR phasing plan.

- `src-tauri/tauri.conf.json`: add `bundle.macOS.signingIdentity: "-"` to make ad-hoc signing explicit (removes ambiguity vs Tauri's default and protects against future default changes).
- `.github/workflows/release.yml`: after the macOS Tauri build, run `codesign -dv --verbose=4` on the `.app` and fail the job unless `Signature=adhoc` is reported.

No runtime code changes; no impact on Windows builds, updater, bundle size, or existing signing secrets.

## Tests

Config-only change:
- `npm run lint` passes
- `npx tsc --noEmit` passes
- `npm test` — 57 files / 536 tests pass
- YAML/JSON parsed cleanly

The new `codesign` verify step runs on real release builds and will fail the job on regression. No feasible way to unit-test this locally on non-mac runners.

## Acceptance Criteria covered (subset from #55)

- [x] `tauri.conf.json` has explicit `bundle.macOS.signingIdentity: "-"`
- [x] Release CI verifies the `.app` is ad-hoc signed after build (fails on missing/incorrect signature)

## Not in this PR (subsequent phases of #55)

Per the spec's explicit phasing ("single issue, many PRs, each independently shippable"):
- PR 2 — CLI embedded in .app and NSIS install dir
- PR 3 — NSIS PATH update
- PR 4 — `install_cli_shim` / `remove_cli_shim` / `cli_shim_status`
- PR 5–10 — onboarding state persistence, section primitives, FirstRunPanel, SetupPanel, default handler, folder context menu
- PR 11 — `install.sh` xattr strip + CLI symlink
- PR 12 — DMG background + README.txt
- PR 13 — site redesign + README rewrite

This PR intentionally does **not** close #55; the issue stays open until all phases land.

Refs #55