### PR TITLE
docs: add mermaid diagrams to clarify flows and architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,34 @@ Unique to architecture. Rust-First is a charter meta-principle — see [`docs/pr
 4. **Commands Mutate, Events Notify.** Tauri commands do imperative work and return typed results. Events notify async change. Events can fire before React's first `useEffect`, so deterministic bootstrap uses commands.
 5. **Layer Directionality.** Dependencies flow inward only: `components/` → `hooks/` → `lib/` → `store/`. `lib/vm/` is the single seam where `lib/` may read `@/store`. `lib/` never imports `components/` or `hooks/`.
 
+```mermaid
+flowchart LR
+    Components["src/components/<br/>(View — JSX)"]
+    Hooks["src/hooks/<br/>(wires)"]
+    Lib["src/lib/<br/>(typed IPC, pure utils)"]
+    Store[("src/store/<br/>Zustand slices")]
+    LibVM["src/lib/vm/<br/>(only seam reading store)"]
+    Components --> Hooks
+    Components --> Store
+    Hooks --> Lib
+    Hooks --> Store
+    LibVM --> Store
+    Lib -.->|"forbidden"| Components
+    Lib -.->|"forbidden"| Hooks
+```
+
 ## Rules
 
 ### IPC & logging chokepoints
+
+```mermaid
+flowchart LR
+    Comp["component / hook"] --> Wrapper["src/lib/tauri-commands.ts<br/>(typed wrapper — only<br/>non-test invoke importer)"]
+    Wrapper -- "invoke()" --> Cmd["src-tauri/src/commands.rs<br/>(registered in shared_commands!)"]
+    Cmd --> Core["core/ — sidecar, matching,<br/>anchors, scanner, …"]
+    Cmd -. "emit_to('main', …)" .-> Listener["useFileWatcher /<br/>App.tsx listeners"]
+```
+
 1. Every Tauri IPC call goes through a typed wrapper in `src/lib/tauri-commands.ts`; production code never imports `invoke` directly. (`src/lib/tauri-commands.ts:1` is the only non-test `invoke` importer.)
 2. Every new Rust command ships with a matching typed TS wrapper; the wrapper's return type matches the Rust `Result<T, String>` unwrapped `T`. (`commands.rs:107` ↔ `tauri-commands.ts:50`.)
 3. Every Rust command is registered in `shared_commands!` in `src-tauri/src/lib.rs:222-251`.
@@ -95,6 +120,19 @@ Canonical implementation: `src-tauri/src/core/matching.rs:12`.
 2. **Line fallback** — if the original line number is still in bounds, anchor there.
 3. **Fuzzy match** — Levenshtein similarity ≥ 0.6, prefer closest to original line.
 4. **Orphan** — all strategies failed; comment displays with an orphan banner.
+
+```mermaid
+flowchart TD
+    Start(["comment.selected_text +<br/>original line"]) --> S1{"exact match at<br/>original line?"}
+    S1 -- "yes" --> A1(["anchored — original line"])
+    S1 -- "no" --> S1b{"exact match elsewhere<br/>in document?"}
+    S1b -- "yes" --> A2(["anchored — closest match"])
+    S1b -- "no" --> S2{"original line still<br/>in document bounds?"}
+    S2 -- "yes" --> A3(["line fallback —<br/>anchored at same line"])
+    S2 -- "no" --> S3{"Levenshtein<br/>similarity ≥ 0.6?"}
+    S3 -- "yes" --> A4(["fuzzy match — nearest<br/>candidate to original line"])
+    S3 -- "no" --> Orphan(["orphan banner —<br/>preserved, never lost"])
+```
 
 ### Surviving AI refactoring
 Layered defenses: (1) 4-step re-anchoring; (2) sidecars travel alongside source files; (3) ghost entries surface deleted-source sidecars; (4) the Rust watcher auto-reloads content and comments. Debounce/save-loop windows: rules 4-6 in [`docs/performance.md`](performance.md).

--- a/docs/features/cli-and-associations.md
+++ b/docs/features/cli-and-associations.md
@@ -12,6 +12,19 @@ Launch-time arguments are read inside the app through `get_launch_args` — the 
 
 Path handling crosses an OS boundary and is therefore canonicalized on entry (rule in [`docs/security.md`](../security.md)). CLI mode is symmetric with double-click: the same command, the same argv shape, the same tab-reuse logic.
 
+```mermaid
+flowchart TD
+    Launch(["mdownreview &lt;path&gt;<br/>(CLI / Finder / Explorer)"]) --> SI{"single-instance plugin:<br/>is another instance running?"}
+    SI -- "no" --> Spawn["start new process"]
+    SI -- "yes" --> Forward["forward argv to running instance"]
+    Spawn --> Init["Tauri setup hook<br/>parse + canonicalize argv"]
+    Forward --> ArgsEvt["emit args-received<br/>to existing window"]
+    Init --> First["first useEffect calls<br/>get_launch_args (consumed once via .take())"]
+    ArgsEvt --> Listener["useLaunchArgsBootstrap listener"]
+    First --> Open["open or focus tab<br/>for canonical path"]
+    Listener --> Open
+```
+
 ## Key source
 
 - **Entry points:** `src-tauri/src/main.rs`, `src-tauri/src/lib.rs` (plugin registration, setup hook, panic hook)

--- a/docs/features/comments.md
+++ b/docs/features/comments.md
@@ -12,6 +12,25 @@ Anchoring survives file edits through a 4-step algorithm — exact match at orig
 
 The UI surface is a selection toolbar that appears on text selection, a comment input, a threaded reply view, and an aggregated panel that summarises unresolved counts across the workspace. Line-gutter indicators in `SourceView` make every anchored comment discoverable at a glance.
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant UI as CommentInput / Thread
+    participant VM as useCommentActions
+    participant TC as lib/tauri-commands.ts
+    participant Cmd as Rust commands.rs
+    participant SC as MRSF sidecar (.review.yaml)
+    participant W as watcher / listeners
+    UI->>VM: addComment / editComment / addReply
+    VM->>TC: typed wrapper
+    TC->>Cmd: invoke("add_comment")
+    Cmd->>Cmd: with_sidecar_mut<br/>load → mutate → re-anchor
+    Cmd->>SC: temp-write + atomic rename
+    Cmd-->>TC: Result<Comment, String>
+    Cmd--)W: emit_to("main", "comments-changed")
+    W-->>UI: useComments re-fetch via get_file_comments
+```
+
 ## Key source
 
 - **UI components:** `src/components/comments/{CommentInput,CommentThread,CommentsPanel,LineCommentMargin,SelectionToolbar}.tsx`

--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -12,6 +12,27 @@ A panic hook installed in `lib.rs` converts Rust panics into logged error events
 
 The log file lives in the OS-appropriate per-user location; users retrieve it via `get_log_path`. There is no in-app log viewer and no network log upload — both are Non-Goals in [`docs/principles.md`](../principles.md).
 
+```mermaid
+flowchart LR
+    subgraph Rust["Rust side"]
+      Tracing["tracing::* / log::*"]
+      Panic["panic hook<br/>(lib.rs setup)"]
+    end
+    subgraph Front["Frontend side"]
+      Logger["src/logger.ts<br/>(prefixes [web])"]
+      EB["ErrorBoundary"]
+      WinErr["window.onerror /<br/>unhandledrejection<br/>(installed pre-createRoot)"]
+      Console["WebView console.warn / .error<br/>(release: forwarded only)"]
+    end
+    Panic --> Tracing
+    Tracing --> Plugin["tauri-plugin-log"]
+    Logger --> Plugin
+    EB --> Logger
+    WinErr --> Logger
+    Console --> Plugin
+    Plugin --> File[("rotating log file<br/>5 MB cap, kept across rotations<br/>retrieved via get_log_path")]
+```
+
 ## Key source
 
 - **Rust:** `src-tauri/src/lib.rs` (plugin registration, panic hook), any `tracing::*` calls throughout `src-tauri/src/`

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -12,6 +12,20 @@ Check logic is offline-tolerant: a failed check logs and backs off; it never blo
 
 Release CI produces one installer per channel per platform; the GitHub release that matches the current channel is the update source.
 
+```mermaid
+flowchart TD
+    Start(["app startup"]) --> Detect["detect channel<br/>from pre-release suffix<br/>(stable / canary)"]
+    Detect --> Check{"check signed release<br/>for current channel"}
+    Check -- "offline / network error" --> Backoff["log + back off<br/>never modal, never blocks UI"]
+    Check -- "up to date" --> Idle["updateSlice idle<br/>About dialog shows OK"]
+    Check -- "newer signed build" --> Notify["updateSlice → status bar<br/>+ About dialog announce"]
+    Notify --> Action{"user clicks install?"}
+    Action -- "no" --> Idle
+    Action -- "yes" --> DL["download artifact<br/>verify minisign signature"]
+    DL --> Install["install + restart"]
+    Backoff --> Idle
+```
+
 ## Key source
 
 - **Rust:** `src-tauri/src/update.rs`, `src-tauri/src/lib.rs` (plugin registration)

--- a/docs/features/viewer.md
+++ b/docs/features/viewer.md
@@ -12,6 +12,20 @@ Markdown goes through `react-markdown` + `remark-gfm` + `@shikijs/rehype` + `reh
 
 A single Shiki highlighter instance is shared across viewers — see the Shiki singleton rule in [`docs/design-patterns.md`](../design-patterns.md). The table of contents, selection toolbar, and viewer toolbar are composable overlays, not viewer-specific code.
 
+```mermaid
+flowchart TD
+    File["selected file<br/>(path + watcher status)"] --> Router{"ViewerRouter"}
+    Router -- "ghost: deleted on disk,<br/>orphaned comments" --> DV["DeletedFileViewer"]
+    Router -- ".md / .mdx" --> MV["MarkdownViewer<br/>(react-markdown + Shiki)"]
+    Router -- "Mermaid block / file" --> MM["MermaidView<br/>(lazy-loaded, securityLevel: strict)"]
+    Router -- ".json" --> JT["JsonTreeView"]
+    Router -- ".csv" --> CT["CsvTableView"]
+    Router -- ".html" --> HV["HtmlPreviewView"]
+    Router -- "image" --> IV["ImageViewer<br/>(via convertFileSrc)"]
+    Router -- "other text<br/>(.ts, .rs, .py, …)" --> SV["SourceView<br/>(line anchors + folding + search)"]
+    Router -- "binary or > 10 MB" --> BP["BinaryPlaceholder"]
+```
+
 ## Key source
 
 - **Router:** `src/components/viewers/ViewerRouter.tsx`

--- a/docs/features/watcher.md
+++ b/docs/features/watcher.md
@@ -12,6 +12,25 @@ On the React side, `useFileWatcher` installs one listener per visible tab and cl
 
 Two debounce windows matter: the save-loop debounce (avoid re-triggering the watcher on our own sidecar writes) and the ghost-entry rescan (coalesce bursts of `deleted` events into one `scan_review_files`). Both windows are canonical in [`docs/performance.md`](../performance.md) and covered by isolation tests (rules 19 + 20 in [`docs/test-strategy.md`](../test-strategy.md)).
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FS as Filesystem
+    participant W as Rust watcher<br/>(notify-debouncer-mini)
+    participant Cmd as commands.rs
+    participant Hook as useFileWatcher
+    participant Bus as window CustomEvent<br/>(mdownreview:file-changed)
+    participant Tab as useFileContent
+    FS->>W: write / rename / delete
+    Note over W: 300 ms debounce<br/>(rule 4 perf.md)
+    W->>Hook: emit_to("main", "file-changed")<br/>kind: content / review / deleted
+    Hook->>Hook: save-loop check<br/>(< 1500 ms since local save? drop)
+    Hook->>Bus: dispatch CustomEvent
+    Bus->>Tab: reload via read_text_file
+    Note over Hook: deleted bursts coalesced<br/>at 500 ms → scan_review_files
+    Hook->>Cmd: scan_review_files (ghost rescan)
+```
+
 ## Key source
 
 - **Rust watcher:** `src-tauri/src/watcher.rs`

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -37,6 +37,32 @@ The app is built as a strict MVVM (Model–ViewModel–View) stack. The boundari
 - **ViewModel — `src/lib/vm/` + `src/hooks/` + `src/store/`.** Bridges the Model to the View. Cancellation, loading states, debounce, derived values live here. No DOM, no JSX, no raw `invoke()` (uses `src/lib/tauri-commands.ts`).
 - **View — `src/components/`.** Renders ViewModel state and dispatches user actions. No IPC calls, no business rules, no file-path manipulation.
 
+```mermaid
+flowchart TB
+    subgraph View["View — src/components/"]
+      Comp["React components<br/>JSX, user events"]
+    end
+    subgraph VM["ViewModel — src/lib/vm + src/hooks + src/store"]
+      Hooks["hooks/ — wires<br/>(useFileContent, useFileWatcher, …)"]
+      Store["store/ — Zustand<br/>(reactive UI state)"]
+      LibVM["lib/vm/ — only seam<br/>that may read store"]
+      TC["lib/tauri-commands.ts<br/>(typed invoke wrappers)"]
+    end
+    subgraph Model["Model — src-tauri/"]
+      Cmd["commands.rs<br/>(Tauri command handlers)"]
+      Core["core/ — file I/O,<br/>MRSF, anchoring, hashing"]
+    end
+    Comp --> Hooks
+    Comp --> Store
+    Hooks --> Store
+    Hooks --> LibVM
+    Hooks --> TC
+    LibVM --> TC
+    LibVM --> Store
+    TC -- "invoke()" --> Cmd
+    Cmd --> Core
+```
+
 When adding a feature: *what does the Model own? what hook in the ViewModel exposes it? what component renders it?* A component that calls `invoke()` or holds business state is a layering violation and does not merge. A hook that serializes YAML or computes anchors is a Rust-First violation and does not merge.
 
 ### 2. Never Increase Engineering Debt

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -12,6 +12,17 @@ Canonical for test layering, coverage floors, and mock hygiene. Cite violations 
 
 ## Three-layer pyramid
 
+```mermaid
+flowchart TB
+    Native["Native E2E — real Tauri binary, real OS events<br/>(~4 specs · release-only · slowest)"]
+    Browser["Browser integration — Playwright + Vite + IPC mock<br/>(~10 specs · 100+ assertions · fast)"]
+    Unit["Unit / component — Vitest + React Testing Library + Rust #[cfg(test)]<br/>(700+ tests · runs in milliseconds)"]
+    Native --> Browser
+    Browser --> Unit
+```
+
+Tests pick the lowest layer that can prove the claim — the pyramid widens downward by design.
+
 | Layer | Where | What it tests | What it does NOT |
 |---|---|---|---|
 | **Unit / component** | `src/**/__tests__/`, `src-tauri/src/core/*.rs #[cfg(test)]`, `src-tauri/tests/` | Pure functions, store slices, React components in isolation, Rust core, hooks via `renderHook` | No IPC, no file I/O, no network |


### PR DESCRIPTION
## Summary

Adds nine mermaid diagrams to docs where prose-only sections were harder to scan than they needed to be. No rules, code blocks, or feature areas were added or removed, so the doc taxonomy in `.claude/agents/documentation-expert.md` is unchanged.

## Diagrams added

- **`docs/principles.md`** — MVVM stack (View / ViewModel / Model dependency arrows, including the `lib/vm` seam)
- **`docs/architecture.md`** — layer directionality, IPC chokepoint flow (`tauri-commands.ts` -> `commands.rs` -> `core/`), 4-step re-anchoring decision tree
- **`docs/test-strategy.md`** — three-layer pyramid sketch above the existing table
- **`docs/features/viewer.md`** — `ViewerRouter` dispatch by file type
- **`docs/features/comments.md`** — comment write-path sequence (UI -> `useCommentActions` -> wrapper -> Rust command -> sidecar -> `comments-changed`)
- **`docs/features/watcher.md`** — watcher event sequence showing 300 ms debounce + 1500 ms save-loop window + 500 ms ghost rescan
- **`docs/features/cli-and-associations.md`** — single-instance / `get_launch_args` vs `args-received` flow
- **`docs/features/logging.md`** — Rust `tracing` + panic hook + frontend `logger.ts` + `ErrorBoundary` + `window.onerror` all funneling through `tauri-plugin-log` to one rotating file
- **`docs/features/updates.md`** — startup check / channel detection / signed install state machine

## Compatibility

All diagrams use only mermaid built-ins that render under both:

- The in-app `MermaidView` (`securityLevel: "strict"` -- so only `<br/>` HTML, no raw `<b>` / `<i>` tags).
- GitHub's mermaid markdown renderer.

## Skipped intentionally

`performance.md` (numeric tables already clearer), `security.md` (rule-list shape), `design-patterns.md` (numbered idioms).

## Test plan

- [ ] Open each touched doc in mdownreview itself and confirm every diagram renders (validates the in-app `MermaidView` strict-mode path).
- [ ] Open this PR's Files Changed tab on GitHub and confirm GitHub renders every diagram.
- [ ] Skim each affected `docs/features/*.md` to confirm diagram placement reads naturally between "How it works" and "Key source".

Generated with [Claude Code](https://claude.com/claude-code).