### PR TITLE
chore(skills+agent): two-phase /groom-issues + requirements-gated /iterate

### DIFF
--- a/.claude/agents/exe-goal-assessor.md
+++ b/.claude/agents/exe-goal-assessor.md
@@ -1,31 +1,37 @@
 ---
 name: exe-goal-assessor
-description: Assesses the codebase fresh against an improvement goal and produces next-sprint requirements. No memory of prior specs.
+description: Use when an autonomous loop needs to decide whether a caller-supplied list of requirements is fully satisfied by the live codebase, returning STATUS plus per-requirement evidence. Reads code from scratch with no memory of prior specs and consults no external systems (GitHub, trackers, etc.) — the requirements list is the only source of truth for "done."
 ---
 
-**Inputs:** goal, iteration number, iteration log (outcomes only — never prior specs).
+**Inputs:**
+- `goal` — one-line restatement of what success looks like.
+- `requirements` — explicit checklist (`- [ ]` / `- [x]` lines). Caller-supplied, **the only definition of done**. Do not invent, substitute, merge, or drop items.
+- `context` — optional. Background text explaining what each requirement means. Treat as reference, not as additional requirements.
+- `iteration_number`
+- `iteration_log` — prior outcomes only; never prior specs.
 
 **Process:**
-1. **Decompose goal** into observable criteria (write them down before reading code).
-2. **Read code + run direct measurements only:**
+1. Restate every requirement verbatim before reading code. For each, decide upfront what concrete artefact would prove it met (a passing test, a config line, a CI step, a deleted file, a committed retrospective).
+2. Gather evidence per requirement by reading code or running:
    - lint goals: `npm run lint 2>&1 | tail -30`
    - TS errors: `npx tsc --noEmit 2>&1 | tail -30`
    - Rust tests: `cd src-tauri && cargo test 2>&1 | tail -30`
    - Coverage: `npm test -- --coverage 2>&1 | tail -20`
-3. **Mark each criterion** met/unmet with file:line or command output.
+3. Mark each requirement `met` or `unmet` with file:line or command output. If you cannot point at concrete evidence, the requirement is `unmet` — never default to `met` because the change "looks done."
 4. **Status:**
-   - `achieved` — all criteria met (with evidence each).
-   - `blocked` — external constraint, name it.
-   - `in_progress` — emit NEXT_REQUIREMENTS.
+   - `achieved` — **every** requirement marked `met` with cited evidence. One unmet requirement → `in_progress`, never `achieved`.
+   - `blocked` — an external constraint prevents progress on at least one requirement. Name it.
+   - `in_progress` — at least one requirement is `unmet`. Emit NEXT_REQUIREMENTS.
 
-**NEXT_REQUIREMENTS rules:** fresh from scratch (no anchoring); evidence-cited (file:line); cohesive sprint sized to deliver visible progress (no file cap, split only when truly independent); grouped by parallelism (`[Group A — independent]` etc.); each item names a passing-test assertion. A requirement that would violate a rule in `docs/{architecture,performance,security,design-patterns,test-strategy}.md` must be flagged as needing a rule update or rerouted.
+**NEXT_REQUIREMENTS rules:** target the unmet requirements first, in their original wording. Add discovered sub-tasks only when an unmet item literally cannot land without them. Fresh from scratch (no anchoring); evidence-cited (file:line); cohesive sprint sized to deliver visible progress (no file cap, split only when truly independent); grouped by parallelism (`[Group A — independent]`); each item names a passing-test assertion. A requirement that would violate a rule in `docs/{architecture,performance,security,design-patterns,test-strategy}.md` must be flagged as needing a rule update or rerouted.
 
 **Output (exact, no other text):**
 ```
 STATUS: achieved | in_progress | blocked
 CONFIDENCE: 0–100
-EVIDENCE:
-- <criterion>: met|unmet — <file:line or command output>
+REQUIREMENTS:
+- [met|unmet] <verbatim requirement text> — <file:line or command output>
+- ...
 NEXT_REQUIREMENTS:
 [Group A — independent]
 - File: path:line | change | Test: assertion

--- a/.claude/skills/groom-issues/SKILL.md
+++ b/.claude/skills/groom-issues/SKILL.md
@@ -1,120 +1,228 @@
 ---
 name: groom-issues
-description: Brainstorm requirements with the user for ungroomed GitHub issues, then attach a structured spec comment.
+description: Use when the user runs `/groom-issues`, asks to groom or spec out GitHub issues, asks to "process the needs-grooming backlog", or pastes issue numbers asking for them to be groomed. Optionally accepts issue numbers (`/groom-issues #36 #42`).
 ---
 
-**RIGID. Follow each step.** Specs live as issue comments tagged `<!-- mdownreview-spec -->` so re-grooming finds and updates them. Charter rules in AGENTS.md apply: an issue mapping to a Non-Goal is closed, not groomed.
+# Groom Issues
 
-## Input
+Two-phase pipeline. Run Phase A to completion across **all** targeted issues before starting Phase B.
 
-`/groom-issues` (no args) → label-based discovery. `/groom-issues 36 42` or `#36 #42` → those issues.
+- **Phase A — Clarify (interactive).** Sweep every issue, collect every answer the user owes. Invoke `superpowers:brainstorming` for complex issues. Phase A writes nothing to GitHub and produces no specs.
+- **Phase B — Spec (autonomous).** No questions to the user. Per issue: draft spec → consult expert agents → resolve every comment → post/update GitHub.
+
+The cache directory `.groom-cache/` is the contract between phases — Phase B reads only the cache and the issue. Once Phase B starts, do not prompt the user.
+
+## Charter alignment
+
+Each issue is judged against `docs/principles.md` (5 pillars + Non-Goals). An issue mapping to a Non-Goal is flagged in Phase A and closed instead of groomed unless the user overrides.
+
+When proposing approaches, cross-check `docs/architecture.md`, `docs/performance.md`, `docs/security.md`, `docs/design-patterns.md`, `docs/test-strategy.md`. If the natural approach violates a rule, either pick a different approach or include a rule-change proposal in the spec — never silently bypass.
+
+## Input parsing
+
+| Invocation | Target Issues |
+|---|---|
+| `/groom-issues #36 #42` or `/groom-issues 36 42` | the listed numbers, regardless of labels |
+| `/groom-issues` | all open issues with the `needs-grooming` label |
 
 ## Labels
 
 | Label | Meaning |
 |---|---|
-| `needs-grooming` | ungroomed, or re-queued |
-| `groomed` | spec attached, ready for implementation |
+| `needs-grooming` | Ungroomed, or re-queued for re-grooming |
+| `groomed` | Spec attached, ready to implement |
 
-Re-groom: remove `groomed`, add `needs-grooming`.
+To re-groom: remove `groomed`, add `needs-grooming`. The skill finds and updates the existing spec via the `<!-- mdownreview-spec -->` marker.
 
-## Steps
+## Step 0 — Setup
 
-### 1. Ensure labels
 ```bash
 gh label create "needs-grooming" --description "Issue needs grooming / spec generation" --color "FBCA04" --force
-gh label create "groomed" --description "Issue groomed with a spec attached" --color "0E8A16" --force
+gh label create "groomed" --description "Issue has been groomed with a spec attached" --color "0E8A16" --force
+mkdir -p .groom-cache
+grep -qxF '.groom-cache/' .gitignore 2>/dev/null || echo '.groom-cache/' >> .gitignore
 ```
 
-### 2. Collect issues
-- **Targeted:** `gh issue view <n> --json number,title,body,labels,comments` per number.
-- **Default:** `gh issue list --label "needs-grooming" --state open --json number,title,body,labels --limit 100`. If empty, tell user to add the label or pass numbers, then exit.
+## Step 1 — Collect queue
 
-Sort ascending by number.
+Fetch issues per the input parsing rules. If the default mode finds none, report:
 
-### 3. Show queue
+> "No issues with `needs-grooming` label found. Add the label or pass numbers: `/groom-issues #36 #42`"
+
+…and exit. Otherwise sort ascending and print:
+
 ```
-📋 Issues to groom:
-  #36 — <title>
-  …
-Starting with #36…
+Issues to groom:
+  #36 — CLI improvements
+  #42 — Add export feature
+
+Phase A: clarifying all issues. No specs written until Phase A completes.
 ```
 
-### 4. Per-issue groom
+# Phase A — Clarify (interactive)
 
-a. Print title + body + existing comments.
-b. Search comments for `<!-- mdownreview-spec -->` → if present, this is a re-groom; capture comment id; show user.
-c. Read codebase areas the issue touches (key files only).
-d. **Brainstorm interactively:**
-   - One clarifying question at a time via `ask_user` (multiple choice when possible).
-   - **Pillar check:** name which pillar this strengthens (Non-Goal → propose closing). Flag pillars at risk.
-   - Propose 2–3 approaches with trade-offs, your recommendation, and rule-compatibility against the deep-dive docs (see AGENTS.md). If natural approach would break a rule, either pick a different approach or include a rule-change proposal in the spec.
-   - Get explicit approval.
-e. Generate spec (template below), present, then post.
+For each issue, in order:
 
-#### Spec template
+### A1. Show context
+Print the issue header, body, and the most recent comments. Flag if a `<!-- mdownreview-spec -->` comment already exists (re-groom — show the prior spec).
+
+### A2. Explore codebase
+Read the files and modules the issue touches. The goal is precision: enough understanding to ask sharp questions and recognize ambiguity.
+
+### A3. Triage complexity
+
+| Signal | Path |
+|---|---|
+| Single component, clear ask, ≤3 unknowns | A4 — inline Q&A |
+| Cross-cutting, ambiguous goal, multiple plausible approaches, or rule-change implications | A4 — invoke `superpowers:brainstorming` |
+
+Decide before the first question. Brainstorming is not a fallback if inline goes badly — pick once.
+
+### A4. Clarify
+
+**Inline path:** ask 1–6 questions, one at a time, using `ask_user` with multiple choice where it fits. Cover requirements, constraints, edge cases, success criteria, pillar fit, Non-Goal check.
+
+**Brainstorming path:** invoke `superpowers:brainstorming` scoped to this single issue. Capture the brainstorming output verbatim for the cache.
+
+### A5. Cache
+
+Write `.groom-cache/<issue-number>.md`:
+
+```markdown
+# Issue #<n> — <title>
+
+## User answers
+<verbatim Q&A or brainstorming output>
+
+## Codebase notes
+<key files, current behavior>
+
+## Pillar impact
+<pillars strengthened/risked, or "Non-Goal — close" decision>
+
+## Chosen approach
+<one paragraph, agreed with the user>
+
+## Open items deferred to expert review
+<items the user explicitly delegated to Phase B>
+```
+
+Print: `cached → .groom-cache/<n>.md`
+
+### A6. Phase A handoff
+
+After the last issue, print:
+
+```
+Phase A complete. Cached:
+  - .groom-cache/36.md
+  - .groom-cache/42.md
+
+Edit any cache file if you want to revise. Reply 'go' to start autonomous Phase B, or 'stop' to halt.
+```
+
+Wait for the user's `go`. This is the last interactive checkpoint. Without `go`, do not enter Phase B.
+
+# Phase B — Spec (autonomous)
+
+No prompts to the user. For each cached issue, in order:
+
+### B1. Draft spec
+Read the cache file. Produce a draft using the spec template below, leaving `### Expert feedback resolution` empty for now.
+
+### B2. Consult expert agents
+
+Dispatch the relevant subset **in parallel** (single message, multiple `Agent` tool calls — see `superpowers:dispatching-parallel-agents`). Pick generously; missed reviewers are more expensive than redundant ones.
+
+| Agent | Trigger |
+|---|---|
+| `architect-expert` | Layering, IPC contract, store design, separation of concerns |
+| `documentation-expert` | Any user-facing change or new feature area |
+| `lean-expert` | New deps, new files, new abstractions, binary-size impact |
+| `performance-expert` | Rendering, watcher, large-file handling, IPC volume |
+| `product-improvement-expert` | New feature or UX change |
+| `react-tauri-expert` | React hooks, Tauri plugins, IPC, version-specific APIs |
+| `security-reviewer` | `src-tauri/src/`, file IO, markdown rendering, capability changes |
+| `test-expert` | Any source-code change |
+
+Each agent receives: the draft spec, the issue body, and the cache file. Ask each for blocking concerns, recommended changes, and missing acceptance criteria. Cap each agent's response with "Reply in under 250 words."
+
+### B3. Resolve every comment
+
+Merge feedback into the spec. Each comment must land in one of three buckets — never silently dropped:
+
+- **Incorporate** — change the spec to reflect it.
+- **Defer** — record in `### Open Questions` with rationale.
+- **Reject** — record in `### Expert feedback resolution` with reason.
+
+### B4. Post or update GitHub
+
+If a `<!-- mdownreview-spec -->` comment exists (re-groom):
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api repos/$REPO/issues/comments/<comment-id> -X PATCH -f body="<spec>"
+```
+Otherwise:
+```bash
+gh issue comment <number> --body "<spec>"
+```
+
+Update labels and clear the cache:
+```bash
+gh issue edit <number> --remove-label "needs-grooming" --add-label "groomed"
+rm .groom-cache/<number>.md
+```
+
+Print: `#<n> groomed — spec posted, labeled groomed.`
+
+### B5. Final summary
+
+```
+Grooming session complete:
+  #36 — CLI improvements (3 expert comments incorporated, 1 deferred)
+  #42 — Add export feature (5 incorporated)
+```
+
+## Spec template
+
 ```markdown
 <!-- mdownreview-spec -->
-## 📋 Specification for #<n>: <title>
+## Specification for #<number>: <title>
 
 ### Problem Statement
-<problem · who is affected>
+<What problem does this solve? Who is affected?>
 
 ### Pillar impact
-<pillars strengthened · pillars at risk · cite docs/principles.md>
+<Pillars strengthened; pillars at risk. See docs/principles.md.>
 
 ### Proposed Approach
-<chosen approach, implementable detail>
+<Chosen approach with enough detail to implement.>
 
 ### Acceptance Criteria
-- [ ] …
+- [ ] ...
 
 ### Technical Notes
-<key files · architectural notes · cite rules from docs/{architecture,performance,security,design-patterns,test-strategy}.md>
+<Key files, architectural considerations. Cite rules from docs/architecture.md, docs/performance.md, docs/security.md, docs/design-patterns.md, docs/test-strategy.md where relevant.>
 
 ### Constraints & Non-Goals
-<out of scope>
+<Explicitly out of scope.>
 
-### Rule-change proposals (if any)
-<"None" if fully compatible>
+### Rule-change proposals
+<If implementation would violate a deep-dive rule, propose the change here. Otherwise "None".>
+
+### Expert feedback resolution
+<For each expert comment: status (incorporated / deferred / rejected) + one-line reason. "None" if no comments.>
 
 ### Open Questions
-<"None" if resolved>
+<Remaining unknowns or "None".>
 
 ---
 *Spec generated by `/groom-issues`. To re-groom: remove `groomed`, add `needs-grooming`.*
 ```
 
-f. Post or update:
-```bash
-# new
-gh issue comment <n> --body "<spec>"
-# re-groom
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh api repos/$REPO/issues/comments/<comment-id> -X PATCH -f body="<spec>"
-```
-
-g. Update labels:
-```bash
-gh issue edit <n> --remove-label "needs-grooming" --add-label "groomed"
-```
-
-Print `✅ #<n> groomed`.
-
-### 5. Continue prompt
-
-Ask: `Continue to #<next>?` choices `Yes` | `No, stop here`. Loop or exit.
-
-### Done
-
-```
-📊 Grooming session complete:
-  ✅ #36 — …
-  ⏭️ #50 — Skipped (user stopped)
-```
-
 ## Notes
 
-- Specs travel with the issue (comment, not repo file).
-- `<!-- mdownreview-spec -->` HTML marker is invisible in rendered MD; lets re-groom find and update.
-- This skill produces issue-level specs only — implementation planning is `/iterate`.
+- Specs live as issue comments, not in the repo — they travel with the issue.
+- The `<!-- mdownreview-spec -->` marker is invisible in rendered markdown but lets the skill find and update on re-groom.
+- `gh label create --force` is idempotent.
+- This skill produces issue-level specs only. Implementation planning happens in `superpowers:writing-plans`.

--- a/.claude/skills/iterate/SKILL.md
+++ b/.claude/skills/iterate/SKILL.md
@@ -71,7 +71,7 @@ Acceptance-criteria derivation (in order):
 - Body has `## Acceptance` / `## Success` / `## Done when` → convert that section's bullets to `- [ ]`.
 - Free-form → synthesise 1–3 minimal items, e.g. `- [ ] $ISSUE_TITLE — verifiable by <signal>`.
 
-Set `ACCEPTANCE_CRITERIA` from the resolved spec (parsed `- [ ]` / `- [x]` lines).
+Set `ACCEPTANCE_CRITERIA` from the resolved spec (parsed `- [ ]` / `- [x]` lines). This becomes the assessor's `REQUIREMENTS` (see 0f) — the **only** definition of done for issue mode.
 
 **Bug-mode flag.** `IS_BUG = true` if any:
 - `LABELS` ∋ `bug` | `regression` | `defect`.
@@ -95,6 +95,7 @@ After 0f, no further user interaction.
 | `BRANCH` | `feature/issue-$ISSUE_NUMBER-<3–5-word slug>` | `auto-improve/<slug, 40-cap>-$(date +%Y%m%d)` |
 | `PR_TITLE` | `feat: implement #$ISSUE_NUMBER — $ISSUE_TITLE` | `auto-improve: $GOAL_TEXT` |
 | `GOAL_FOR_ASSESSOR` | `Satisfy all acceptance criteria of #$ISSUE_NUMBER: $ISSUE_TITLE` | `$GOAL_TEXT` |
+| `REQUIREMENTS` | `$ACCEPTANCE_CRITERIA` (verbatim `- [ ]` / `- [x]` lines) | synthesise 1–3 `- [ ]` items from `$GOAL_TEXT`, e.g. `- [ ] <one-line restatement> — verifiable by <signal>` |
 | `PR_CLOSE_TRAILER` | `Closes #$ISSUE_NUMBER` | (omit) |
 
 Slug: lowercase, non-alphanum → `-`, collapse runs, trim.
@@ -116,8 +117,8 @@ git config rerere.autoupdate true
 ```
 
 `PR_BODY`:
-- Issue mode: links to issue · pastes full `ACCEPTANCE_CRITERIA` checklist (unchecked) · trailer `Closes #$ISSUE_NUMBER`.
-- Goal mode: header quotes goal · empty progress list.
+- Issue mode: links to issue · pastes full `$REQUIREMENTS` checklist (unchecked) · trailer `Closes #$ISSUE_NUMBER`.
+- Goal mode: header quotes `$GOAL_TEXT` · pastes `$REQUIREMENTS` checklist (unchecked) under a `## Progress` heading. Step 8 ticks these as the assessor marks them `met`.
 
 ```bash
 gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY"
@@ -233,7 +234,16 @@ If sanity gate fails → `exe-task-implementer` fixes as follow-up commit; commi
 
 ### Step 2 — Assess
 
-Spawn `exe-goal-assessor` (one call). Inputs: goal, iteration counters, full state-file content. Issue mode also pass: title, body, `SPEC_MARKDOWN`, open AC bullets. Instruction: read code from scratch, ignore prior specs, return STATUS / CONFIDENCE / NEXT_REQUIREMENTS / EVIDENCE / BLOCKING_REASON. Issue mode: per-AC verdict with file:line evidence; empty `NEXT_REQUIREMENTS` + open AC ⇒ `blocked` pointing at unreachable AC.
+Spawn `exe-goal-assessor` (one call). Pass:
+- `goal = $GOAL_FOR_ASSESSOR`
+- `requirements = $REQUIREMENTS` (verbatim — the per-item checklist is the **only** source of truth for "done")
+- `iteration_number`
+- `iteration_log` = full state-file content (outcomes only — never prior specs)
+- `context` (optional) = SPEC_MARKDOWN excerpt clarifying what each requirement means; in goal mode, omit or pass a one-paragraph restatement.
+
+Do **not** pass `ISSUE_NUMBER`, `ISSUE_TITLE`, `ISSUE_BODY`, the `<!-- mdownreview-spec -->` marker, or any GitHub-shaped reference. The assessor is intentionally GitHub-agnostic so it cannot lean on issue context to declare done — only the explicit requirements list.
+
+Instruction: read code from scratch, mark every requirement `met` or `unmet` with file:line or command output, and return the exact template (STATUS / CONFIDENCE / REQUIREMENTS / NEXT_REQUIREMENTS / BLOCKING_REASON). `achieved` requires every requirement `met`; even one `unmet` ⇒ `in_progress`. Empty `NEXT_REQUIREMENTS` with ≥1 unmet requirement ⇒ `blocked` pointing at the unreachable requirement.
 
 Routing:
 - `achieved` → **Done-Achieved** (no commit).
@@ -258,7 +268,7 @@ Scan `NEXT_REQUIREMENTS` for triggers; spawn matched experts in ONE parallel mes
 Each prompt:
 ```
 Iteration <N> for <MODE> <ref>.  Goal: <GOAL_FOR_ASSESSOR>
-NEXT_REQUIREMENTS: <…>   EVIDENCE: <…>
+NEXT_REQUIREMENTS: <…>   REQUIREMENTS (with met/unmet evidence): <…>
 From your area: (1) considerations, (2) risks, (3) files to modify and how.
 Cite file:line for every recommendation; cite rule numbers from docs/*.md when applicable. If sound, say so in one line.
 ```
@@ -458,7 +468,7 @@ Append to state file:
 ```
 
 Update PR:
-- Body: tick AC checkboxes confirmed by assessor or implementers (issue mode); append completed requirement groups (goal mode). `gh pr edit <PR_NUMBER> --body "<…>"`.
+- Body: tick the requirement checkboxes the assessor marked `met` in its `REQUIREMENTS:` block — issue mode and goal mode alike. Do not tick a box without an assessor `met` verdict for that exact line. `gh pr edit <PR_NUMBER> --body "<…>"`.
 - Comment:
   ```bash
   gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'


### PR DESCRIPTION
Two related skill/agent changes for the autonomous-loop workflow.

## 1. `/groom-issues` — split into clarify + autonomous-spec phases
- **Phase A — Clarify (interactive):** sweep every targeted issue, ask questions or invoke `superpowers:brainstorming`, cache answers to `.groom-cache/`. No GitHub writes.
- **Phase B — Spec (autonomous):** after a single `go` from the user, draft each spec, dispatch the relevant expert agents in parallel (`architect-expert`, `lean-expert`, `performance-expert`, `security-reviewer`, `test-expert`, …), resolve every comment via incorporate / defer / reject, then post or update the issue and clear the cache.
- Tightened the skill description to triggering conditions only (per `superpowers:writing-skills` CSO).
- `.groom-cache/` is auto-added to `.gitignore` on first run.

**Why:** previously `/groom-issues` mixed clarification, brainstorming, and GitHub writes per-issue. With a backlog this is slow and fragile — one mid-issue interruption loses progress. The hard A/B handoff lets the user batch every clarification upfront and walk away while specs are produced and reviewed.

## 2. `/iterate` — gate Done-Achieved on caller-supplied requirements
Previously `exe-goal-assessor` decomposed the goal into its own "observable criteria" and returned `achieved` once those were met — even when the ticket's acceptance-criteria checklist still had open items. The loop terminated prematurely on issues with detailed AC.

Now:
- `exe-goal-assessor` takes an explicit `requirements` checklist as input and treats it as the **only** definition of done. Every requirement must be marked `met` with cited file:line / command evidence; one `unmet` line forces `in_progress`, never `achieved`.
- The agent stays **GitHub-agnostic** — never receives issue numbers, titles, bodies, or spec markers. `/iterate` is responsible for extracting the requirements and passing them in.
- `/iterate` Step 0f computes `REQUIREMENTS` for both modes: issue mode reuses the parsed acceptance-criteria checklist; goal mode synthesises 1–3 `- [ ]` items from `$GOAL_TEXT`.
- Step 2 passes `goal` + `requirements` + `iteration_log` + optional neutral `context` and instructs the assessor on the achieved-vs-in_progress rule.
- Step 8 ticks PR checkboxes mechanically from the assessor's per-requirement `met` verdicts; goal-mode PR body now seeds those checkboxes under a `## Progress` heading so the same ticking logic applies to both modes.
- Step 3 expert prompts now reference the new `REQUIREMENTS (with met/unmet evidence)` field instead of the removed `EVIDENCE` field.

## Migration note
The assessor's output schema changed (`EVIDENCE:` → `REQUIREMENTS:` block with per-line `[met|unmet]`). Any half-finished `/iterate` run started before this lands will see a malformed assessor reply on its next iteration. Finish or abort in-flight runs before merging.

## Test plan
**`/groom-issues`:**
- [ ] Pick one low-stakes `needs-grooming` issue and run `/groom-issues #<n>` end-to-end. Confirm Phase A caches to `.groom-cache/<n>.md` and posts nothing.
- [ ] Type `go` and confirm Phase B dispatches the expected expert subset in a single message (parallel), resolves all comments into the spec, posts (or updates) the comment, applies the `groomed` label, and clears the cache file.
- [ ] Re-groom the same issue (`groomed` → `needs-grooming`) and confirm Phase B updates the existing `<!-- mdownreview-spec -->` comment via PATCH instead of creating a new one.
- [ ] Run `/groom-issues #36 #42` (multi-issue) and verify the user is only prompted during Phase A, never in Phase B.

**`/iterate`:**
- [ ] Issue with multi-bullet AC: confirm assessor emits per-line `[met|unmet]` and the loop only declares `achieved` once every line is `met`.
- [ ] Issue with one un-implementable AC: confirm assessor returns `in_progress` (not `achieved`) and `Done-Blocked` only fires when `NEXT_REQUIREMENTS` is empty.
- [ ] Goal mode (free text): confirm `0f` synthesises 1–3 `- [ ]` items, PR body shows them under `## Progress`, and Step 8 ticks them as the assessor marks them `met`.
- [ ] Confirm assessor prompts no longer contain `ISSUE_NUMBER`, `ISSUE_TITLE`, `ISSUE_BODY`, or `<!-- mdownreview-spec -->`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)