### PR TITLE
feat: complete #41 - UX overhaul (follow-up)

### DIFF
--- a/.claude/retrospectives/feature-issue-41-ux-overhaul-followup-iter-1.md
+++ b/.claude/retrospectives/feature-issue-41-ux-overhaul-followup-iter-1.md
@@ -1,0 +1,30 @@
+# Retrospective — iteration 1/30 (PASSED)
+
+## Goal of this iteration
+Drop the Settings toolbar button so the top toolbar matches AC's exact enumeration `[Open File] [Open Folder] [Comments]`, while keeping Settings reachable.
+
+## What went well
+- Deviation was discovered immediately by the assessor scan (`src/App.tsx:198–205`, AC line 1) — no wasted iterations.
+- The wire-up pattern (Rust `MenuItem` → `on_menu_event` id-map → `EventPayloads` entry → `useMenuListeners` listen → callback) was already followed 15× in the codebase, so the change followed canonical shape (`src-tauri/src/lib.rs:104-122`, `src/lib/tauri-events.ts:33-49`, `src/hooks/useMenuListeners.ts:30-58`).
+- Browser e2e ux-overhaul.spec.ts F8 added a hard assertion on the toolbar's exact 3-button enumeration, locking the spec in CI.
+
+## What did not go well
+- The first push broke `e2e/browser/settings-author.spec.ts` (commit `1850070`): the test still clicked the now-removed Settings button. CI surfaced it; one forward-fix commit (`f8e385a`) restored green.
+- The assessor over-counted "met" criteria for AC line 1 in the original PR #83 (the toolbar button was visibly extra) — same root cause as #36 → #105 retro candidate. The assessor in this iteration *did* catch it on first re-evaluation, suggesting #105's intervention point will help.
+
+## Root causes of friction
+- Toolbar button → e2e dependency was implicit. No grep-or-die step searches for click-by-name dependencies before deleting UI elements (would have caught `getByRole("button", { name: "Open settings" })` in `settings-author.spec.ts:55,74`).
+- The original PR #83 assessor did not enumerate the toolbar's three accessible names against the AC's literal list. This is the same class of over-claim as #105.
+
+## Improvement candidates
+
+### Add pre-delete grep for accessible-name selectors
+- **Category:** process
+- **Problem (with evidence):** Removing the Settings toolbar button broke `e2e/browser/settings-author.spec.ts:55,74` (`getByRole("button", { name: "Open settings" })`). One CI cycle was spent re-discovering this. A grep for `name: "Open settings"` and `aria-label="Open settings"` before the delete would have surfaced both call sites instantly.
+- **Proposed change:** Add a checklist step in the iterate skill or in a CONTRIBUTING note: "Before deleting a UI control, grep for its label/title/aria-label across `src/`, `e2e/`, and tests."
+- **Acceptance signal:** A documented step exists; future UI-removal commits cite it in their commit body.
+- **Estimated size:** xs
+- **Confidence this matters:** medium (one occurrence here; recurs whenever UI is deleted).
+
+## Carry-over to next iteration
+None — all 13 ACs verified met after this iteration's commits.

--- a/e2e/browser/settings-author.spec.ts
+++ b/e2e/browser/settings-author.spec.ts
@@ -50,9 +50,14 @@ test("author identity round-trips through set_author / get_author", async ({ pag
   await page.goto("/");
   await expect(page.locator(".app-layout")).toBeVisible();
 
-  // Open Settings and verify the OS-user fallback is pre-filled (proving
-  // the launch-time `useAuthor` hydration ran).
-  await page.getByRole("button", { name: "Open settings" }).click();
+  // Open Settings via the native menu event (toolbar button removed in #41 —
+  // Settings is reachable via File → Settings… (Cmd/Ctrl+,) which dispatches
+  // the `menu-open-settings` Tauri event).
+  await page.evaluate(() => {
+    (window as unknown as {
+      __DISPATCH_TAURI_EVENT__?: (event: string, payload: unknown) => void;
+    }).__DISPATCH_TAURI_EVENT__?.("menu-open-settings", null);
+  });
   const input = page.getByLabel("Display name");
   await expect(input).toBeVisible();
   await expect(input).toHaveValue("OS-Default-User");
@@ -71,7 +76,11 @@ test("author identity round-trips through set_author / get_author", async ({ pag
 
   // Re-open Settings — the input now reflects the persisted value via
   // `useAuthor` reading the Zustand cache that was updated on save.
-  await page.getByRole("button", { name: "Open settings" }).click();
+  await page.evaluate(() => {
+    (window as unknown as {
+      __DISPATCH_TAURI_EVENT__?: (event: string, payload: unknown) => void;
+    }).__DISPATCH_TAURI_EVENT__?.("menu-open-settings", null);
+  });
   await expect(page.getByLabel("Display name")).toHaveValue("Reviewer-2");
 });
 

--- a/e2e/browser/ux-overhaul.spec.ts
+++ b/e2e/browser/ux-overhaul.spec.ts
@@ -359,3 +359,26 @@ test.describe("UX overhaul (#41) — hover-stable close button", () => {
     expect(closeBoxAfter.h).toBe(closeBoxBefore.h);
   });
 });
+
+test.describe("UX overhaul (#41) — toolbar enumeration", () => {
+  test("F8 — top toolbar exposes exactly [Open File, Open Folder, Comments]", async ({ page }) => {
+    await installMock(page, makeFiles(0));
+    await page.goto("/");
+
+    // Wait for the toolbar to mount
+    const group = page.locator(".toolbar .toolbar-btn-group");
+    await expect(group).toBeVisible();
+
+    // Exactly three buttons in the left button group.
+    await expect(group.locator("button")).toHaveCount(3);
+
+    // Order matters per AC.
+    const buttonTexts = await group.locator("button").allInnerTexts();
+    expect(buttonTexts.map((t) => t.trim())).toEqual(["Open File", "Open Folder", "Comments"]);
+
+    // No Settings/Theme/About buttons anywhere in the top toolbar.
+    await expect(page.locator(".toolbar button", { hasText: "Settings" })).toHaveCount(0);
+    await expect(page.locator(".toolbar button", { hasText: "Theme" })).toHaveCount(0);
+    await expect(page.locator(".toolbar button", { hasText: "About" })).toHaveCount(0);
+  });
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,13 @@ pub fn run() {
                 true,
                 Some("CmdOrCtrl+Shift+W"),
             )?;
+            let open_settings = MenuItem::with_id(
+                app,
+                "open-settings",
+                "Settings…",
+                true,
+                Some("CmdOrCtrl+,"),
+            )?;
             let file_menu = SubmenuBuilder::new(app, "File")
                 .item(&open_file)
                 .item(&open_folder)
@@ -116,6 +123,8 @@ pub fn run() {
                 .separator()
                 .item(&close_tab)
                 .item(&close_all_tabs)
+                .separator()
+                .item(&open_settings)
                 .separator()
                 .quit()
                 .build()?;
@@ -198,6 +207,7 @@ pub fn run() {
                     "theme-light" => "menu-theme-light",
                     "theme-dark" => "menu-theme-dark",
                     "about" => "menu-about",
+                    "open-settings" => "menu-open-settings",
                     "check-updates" => "menu-check-updates",
                     "help-welcome" => "menu-help-welcome",
                     "help-setup" => "menu-help-setup",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { WelcomeView } from "@/components/WelcomeView";
 import { getFileCategory } from "@/lib/file-types";
-import { IconFile, IconFolder, IconComment, IconSettings } from "@/components/Icons";
+import { IconFile, IconFolder, IconComment } from "@/components/Icons";
 import "@/styles/app.css";
 
 export default function App() {
@@ -106,6 +106,7 @@ export default function App() {
     toggleCommentsPane,
     setTheme,
     setAboutOpen,
+    setSettingsOpen,
     checkForUpdate,
     startCommentOnSelection,
   };
@@ -194,14 +195,6 @@ export default function App() {
             title="Toggle comments pane (Ctrl+Shift+C)"
           >
             <IconComment /> Comments
-          </button>
-          <button
-            className="toolbar-btn"
-            onClick={() => setSettingsOpen(true)}
-            title="Settings"
-            aria-label="Open settings"
-          >
-            <IconSettings /> Settings
           </button>
         </div>
         <ErrorBoundary>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -100,7 +100,6 @@ vi.mock("@/components/Icons", () => ({
   IconFile: () => <span data-testid="icon-file" />,
   IconFolder: () => <span data-testid="icon-folder" />,
   IconComment: () => <span data-testid="icon-comment" />,
-  IconSettings: () => <span data-testid="icon-settings" />,
 }));
 
 import { showOpenDialog } from "@/lib/tauri-commands";

--- a/src/hooks/__tests__/useMenuListeners.test.ts
+++ b/src/hooks/__tests__/useMenuListeners.test.ts
@@ -29,12 +29,13 @@ describe("useMenuListeners", () => {
     toggleCommentsPane: vi.fn(),
     setTheme: vi.fn(),
     setAboutOpen: vi.fn(),
+    setSettingsOpen: vi.fn(),
     checkForUpdate: vi.fn(),
   };
 
-  it("subscribes to all 15 menu events", () => {
+  it("subscribes to all 16 menu events", () => {
     renderHook(() => useMenuListeners(callbacks));
-    expect(listeners.size).toBe(15);
+    expect(listeners.size).toBe(16);
     expect(listeners.has("menu-open-file")).toBe(true);
     expect(listeners.has("menu-open-folder")).toBe(true);
     expect(listeners.has("menu-close-folder")).toBe(true);
@@ -47,6 +48,7 @@ describe("useMenuListeners", () => {
     expect(listeners.has("menu-theme-light")).toBe(true);
     expect(listeners.has("menu-theme-dark")).toBe(true);
     expect(listeners.has("menu-about")).toBe(true);
+    expect(listeners.has("menu-open-settings")).toBe(true);
     expect(listeners.has("menu-check-updates")).toBe(true);
     expect(listeners.has("menu-help-welcome")).toBe(true);
     expect(listeners.has("menu-help-setup")).toBe(true);
@@ -86,6 +88,12 @@ describe("useMenuListeners", () => {
     expect(callbacks.setAboutOpen).toHaveBeenCalledWith(true);
   });
 
+  it("calls setSettingsOpen(true) on menu-open-settings event", () => {
+    renderHook(() => useMenuListeners(callbacks));
+    listeners.get("menu-open-settings")?.();
+    expect(callbacks.setSettingsOpen).toHaveBeenCalledWith(true);
+  });
+
   it("calls checkForUpdate on menu-check-updates event", () => {
     renderHook(() => useMenuListeners(callbacks));
     listeners.get("menu-check-updates")?.();
@@ -112,7 +120,7 @@ describe("useMenuListeners", () => {
     const { unmount } = renderHook(() => useMenuListeners(callbacks));
     unmount();
     await vi.waitFor(() => {
-      expect(mockUnlisten).toHaveBeenCalledTimes(15);
+      expect(mockUnlisten).toHaveBeenCalledTimes(16);
     });
   });
 });

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -8,6 +8,7 @@ interface MenuListenerCallbacks {
   toggleCommentsPane: () => void;
   setTheme: (theme: "system" | "light" | "dark") => void;
   setAboutOpen: (open: boolean) => void;
+  setSettingsOpen: (open: boolean) => void;
   checkForUpdate: () => void;
   /**
    * F1 — accepted so callers can share a single callbacks object with
@@ -24,6 +25,7 @@ export function useMenuListeners({
   toggleCommentsPane,
   setTheme,
   setAboutOpen,
+  setSettingsOpen,
   checkForUpdate,
 }: MenuListenerCallbacks) {
   useEffect(() => {
@@ -53,6 +55,7 @@ export function useMenuListeners({
       listenEvent("menu-theme-light", () => setTheme("light")),
       listenEvent("menu-theme-dark", () => setTheme("dark")),
       listenEvent("menu-about", () => setAboutOpen(true)),
+      listenEvent("menu-open-settings", () => setSettingsOpen(true)),
       listenEvent("menu-check-updates", () => { checkForUpdate(); }),
       listenEvent("menu-help-welcome", () => useStore.getState().openWelcome()),
       listenEvent("menu-help-setup", () => useStore.getState().openSetup()),
@@ -60,5 +63,5 @@ export function useMenuListeners({
     return () => {
       pending.forEach((p) => p.then((fn) => fn()).catch(() => {}));
     };
-  }, [handleOpenFile, handleOpenFolder, toggleCommentsPane, setTheme, setAboutOpen, checkForUpdate]);
+  }, [handleOpenFile, handleOpenFolder, toggleCommentsPane, setTheme, setAboutOpen, setSettingsOpen, checkForUpdate]);
 }

--- a/src/lib/tauri-events.ts
+++ b/src/lib/tauri-events.ts
@@ -43,6 +43,7 @@ export interface EventPayloads {
   "menu-theme-light": void;
   "menu-theme-dark": void;
   "menu-about": void;
+  "menu-open-settings": void;
   "menu-check-updates": void;
   "menu-help-welcome": void;
   "menu-help-setup": void;


### PR DESCRIPTION
 All 13 acceptance criteria of #41 verified met.

Closes #41

Iter-1 fix: removed the extra Settings toolbar button (which violated AC's exact toolbar enumeration). Settings is now reachable via File  Settings (Cmd/Ctrl+,) using the same canonical menu-event pattern already used by 15 other menu items.

Original implementation landed in PR #83; this follow-up loop completed AC #1 (toolbar enumeration) end-to-end:
- 1359 unit/component tests pass (incl. updated useMenuListeners + new menu-open-settings test)
- 308 Rust unit tests pass
- ux-overhaul.spec.ts (8 e2e tests, incl. new F8 toolbar enumeration assertion) pass
- Release Gate (Windows x64/arm64, macOS, Linux, Native E2E Windows)  all green on commit f8e385a.

Ready for review  goal achieved, release gate passed.
