### PR TITLE
feat: complete #71 - Comment UX overhaul (follow-up)

### DIFF
--- a/.claude/retrospectives/feature-issue-71-comment-ux-followup-iter-1.md
+++ b/.claude/retrospectives/feature-issue-71-comment-ux-followup-iter-1.md
@@ -1,0 +1,39 @@
+# Retrospective — iteration 1/30 (PASSED)
+
+## Goal of this iteration
+Implement the only outstanding AC of #71: render file-anchored comment threads inline under `BinaryPlaceholder` and expose a `+ Comment` affordance dispatching `addComment(path, text, { kind: "file" })`.
+
+## What went well
+- Pre-flight assessor was accurate: 22 of 23 ACs already met from prior PR #86, with the single gap (Binary/unsupported inline thread + composer) precisely scoped at `src/components/viewers/BinaryPlaceholder.tsx`.
+- Implementation followed an existing canonical pattern verbatim — `CommentsPanel.tsx:227-236` shows the file-level `CommentInput` shape with `draftKey = ${filePath}::new::${fingerprintAnchor({ kind: "file" })}`, and `LineCommentMargin.tsx:66` shows the `<CommentThread/>` mapping. Replicating those into `BinaryPlaceholder` was a sub-100-line surgical change.
+- Local validation was first-shot green: tsc, lint, vitest 1360/1360, cargo 308/308, e2e 4/4 (after one fix for the `comments-changed` event dispatch in the new e2e — see below).
+- CI green on first push: PR #110 commit `9553e42` — Build (macos-arm64) 5m29s, Build (windows-x64) 10m1s, Test (Linux) 7m8s.
+
+## What did not go well
+- The first run of `BinaryPlaceholder.test.tsx` failed all 11 tests because adding `useComments(path)` triggered an async state update outside `act(...)`, which the global `console.error` spy in `src/test-setup.ts:42` correctly flagged. Required mocking `@/lib/vm/use-comments` and `@/lib/vm/use-comment-actions` in the test (5-line addition).
+- The new e2e test asserting that the saved thread renders inline in `.binary-placeholder-comments` failed initially because `useComments` reloads on `comments-changed` Tauri event, which the IPC mock does not emit after `add_comment`. Worked around by manually dispatching the event from the test via `__DISPATCH_TAURI_EVENT__` — same workaround used by `comment-on-csv.spec.ts`, `comment-on-image.spec.ts`, `comment-on-json.spec.ts`, `comment-on-mermaid.spec.ts`.
+
+## Root causes of friction
+1. **Test-setup eagerness vs. hooks doing IPC at mount time.** The `console.error` strict mode in `src/test-setup.ts:42` makes any newly-IPC-touching component test fail across the board until you remember to mock the VM hook layer. There is no AGENTS.md / docs/test-strategy.md rule that surfaces this trap.
+2. **Recurrent IPC-mock gap: mutation commands don't emit `comments-changed`.** This is already memorialized in repo memory (`Rust mutation commands (add_comment, edit_comment, etc.) do not emit 'comments-changed' events`). Every comment-add e2e re-discovers the workaround. The mock could expose a single helper "save comment + dispatch event" instead of N copies of the same `__DISPATCH_TAURI_EVENT__("comments-changed", {file_path})` snippet.
+
+## Improvement candidates (each must be specifiable)
+
+### Add a docs/test-strategy.md callout for VM-hook mocks in component tests
+- **Category:** test-strategy
+- **Problem (with evidence):** `BinaryPlaceholder.test.tsx` failed 11/11 on first run because `useComments(path)` triggers an async state set outside `act()`. The console.error spy in `src/test-setup.ts:42` (rule `consoleErrorSpy`) flagged it. The lesson — "if a component subscribes to a VM hook that performs IPC at mount, the test must mock the hook" — is not currently in `docs/test-strategy.md`.
+- **Proposed change:** Add a new rule to `docs/test-strategy.md` under the "Component tests" section: "Component tests MUST mock VM hooks (`@/lib/vm/*`) that issue IPC at mount, otherwise the global `console.error` spy will fail every test in the file. Mock shape example: `vi.mock('@/lib/vm/use-comments', () => ({ useComments: () => ({ threads: [], comments: [], loading: false, reload: () => {} }) }))`."
+- **Acceptance signal:** New rule number cited; `BinaryPlaceholder.test.tsx`, `MarkdownViewer.test.tsx`, `SourceView.test.tsx` all referenced as canonical examples.
+- **Estimated size:** xs
+- **Confidence this matters:** medium — caught me here, will catch every contributor adding VM-hook subscribers to existing components.
+
+### Centralize the `comments-changed` IPC-mock workaround into one e2e helper
+- **Category:** test-strategy
+- **Problem (with evidence):** Six e2e specs (`comment-on-file.spec.ts`, `comment-on-csv.spec.ts`, `comment-on-image.spec.ts`, `comment-on-json.spec.ts`, `comment-on-mermaid.spec.ts`, plus the new test in this iteration) each contain a copy-paste of `__DISPATCH_TAURI_EVENT__("comments-changed", { file_path })` after `save`, because the IPC mock does not auto-emit it. Repo memory `architecture: Rust mutation commands (add_comment, edit_comment, etc.) do not emit 'comments-changed' events` confirms this is a pre-existing gap.
+- **Proposed change:** Either (a) make the IPC mock in `src/__mocks__/@tauri-apps/api/core.ts` auto-dispatch `comments-changed` after `add_comment`/`edit_comment`/`delete_comment`/`add_reply`/`resolve_comment`/`move_anchor`, OR (b) add a typed helper `dispatchCommentsChanged(page, filePath)` in `e2e/browser/fixtures/index.ts` and migrate all 6 specs. Option (a) is preferable as it also fixes the underlying contract violation.
+- **Acceptance signal:** Either the IPC mock emits the event automatically (and all six manual dispatches in e2e are deleted), or all six e2e files import a single helper instead of inlining the dispatch.
+- **Estimated size:** s (option b) or m (option a, also requires audit of which Rust commands SHOULD emit but don't — see memory `Rust mutation commands (add_comment, edit_comment, etc.) do not emit 'comments-changed' events`).
+- **Confidence this matters:** high — recurs across 6 files and is a real production gap, not just a test-mock issue.
+
+## Carry-over to next iteration
+_None — all 23 ACs of #71 are now met; iteration 2 is the assessor re-check + release-gate + merge._

--- a/e2e/browser/comment-on-file.spec.ts
+++ b/e2e/browser/comment-on-file.spec.ts
@@ -170,4 +170,42 @@ test.describe("Iter 5 Group B — file-level comment entry points", () => {
     const calls = await readAddCommentCalls(page);
     expect(calls[calls.length - 1].anchor).toEqual({ kind: "file" });
   });
+
+  // #71 Group B (Binary/unsupported) — inline composer rendered *inside*
+  // .binary-placeholder so users never need to leave the viewer surface.
+  test("binary placeholder renders inline composer and the saved thread appears under it", async ({ page }) => {
+    await setupCommentOnFileMocks(page);
+    await page.goto("/");
+
+    await page.locator(".folder-tree").getByText("blob.bin").click();
+    const placeholder = page.locator(".binary-placeholder");
+    await expect(placeholder).toBeVisible();
+
+    // The inline + Comment button lives under .binary-actions (not the
+    // global viewer toolbar).
+    const inlineBtn = placeholder.locator(".binary-actions").getByRole("button", { name: /comment on this file/i });
+    await expect(inlineBtn).toBeVisible();
+    await inlineBtn.click();
+
+    const textarea = placeholder.locator(".binary-placeholder-comment-input .comment-textarea");
+    await expect(textarea).toBeVisible();
+    await textarea.fill("inline binary note");
+    await placeholder.locator(".binary-placeholder-comment-input").getByRole("button", { name: /^save$/i }).click();
+
+    await expect.poll(() => readAddCommentCalls(page).then((c) => c.length)).toBeGreaterThanOrEqual(1);
+    const calls = await readAddCommentCalls(page);
+    expect(calls[calls.length - 1].anchor).toEqual({ kind: "file" });
+
+    // The Rust mutation pipeline emits 'comments-changed' which `useComments`
+    // listens for to reload. The IPC mock doesn't model the emit, so we
+    // dispatch it manually here.
+    await page.evaluate((path) => {
+      (window as Record<string, unknown> & {
+        __DISPATCH_TAURI_EVENT__?: (e: string, p: unknown) => void;
+      }).__DISPATCH_TAURI_EVENT__?.("comments-changed", { file_path: path });
+    }, `${FIXTURES_DIR}/blob.bin`);
+
+    // The saved thread renders inside the placeholder (file-anchored, kind: "file").
+    await expect(placeholder.locator(".binary-placeholder-comments").getByText("inline binary note")).toBeVisible();
+  });
 });

--- a/src/components/viewers/BinaryPlaceholder.tsx
+++ b/src/components/viewers/BinaryPlaceholder.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { basename } from "@/lib/path-utils";
 import {
   getBinaryIconCategory,
@@ -8,6 +8,11 @@ import {
 } from "@/lib/file-types";
 import { copyToClipboard } from "@/lib/tauri-commands";
 import { warn } from "@/logger";
+import { useComments } from "@/lib/vm/use-comments";
+import { useCommentActions } from "@/lib/vm/use-comment-actions";
+import { CommentThread } from "@/components/comments/CommentThread";
+import { CommentInput } from "@/components/comments/CommentInput";
+import { fingerprintAnchor } from "@/lib/anchor-fingerprint";
 import { FileActionsBar } from "./FileActionsBar";
 import { HexView } from "./HexView";
 
@@ -97,10 +102,27 @@ function FileIcon({ category }: { category: BinaryIconCategory }) {
 
 export function BinaryPlaceholder({ path, size }: Props) {
   const [showHex, setShowHex] = useState(false);
+  const [showFileLevelInput, setShowFileLevelInput] = useState(false);
   const name = basename(path);
   const category = getBinaryIconCategory(path);
   const mime = getMimeHint(path);
   const sizeOk = size !== undefined && size < HEX_MAX_BYTES;
+
+  // #71 Group B (Binary/unsupported): render file-anchored threads inline so
+  // the file-level affordance is reachable without opening the comments
+  // pane. Filter to `kind: "file"` so non-file-anchored comments (which are
+  // possible if a sidecar was created with the file at a different type)
+  // remain owned by the comments panel.
+  const { threads } = useComments(path);
+  const fileThreads = useMemo(
+    () => threads.filter((t) => t.root.anchor_kind === "file"),
+    [threads],
+  );
+  const { addComment } = useCommentActions();
+  const handleSaveFileLevel = (text: string) => {
+    addComment(path, text, { kind: "file" }).catch(() => {});
+    setShowFileLevelInput(false);
+  };
 
   const handleCopy = () => {
     void copyToClipboard(path).catch((e) =>
@@ -147,6 +169,35 @@ export function BinaryPlaceholder({ path, size }: Props) {
         >
           Show as hex
         </button>
+        <button
+          type="button"
+          onClick={() => setShowFileLevelInput(true)}
+          disabled={showFileLevelInput}
+          aria-label="Comment on this file"
+          title="Comment on this file"
+        >
+          + Comment
+        </button>
+      </div>
+      <div className="binary-placeholder-comments">
+        {showFileLevelInput && (
+          <div className="binary-placeholder-comment-input">
+            <CommentInput
+              onSave={handleSaveFileLevel}
+              onClose={() => setShowFileLevelInput(false)}
+              placeholder="Comment on this file… (Ctrl+Enter to save, Escape to cancel)"
+              draftKey={`${path}::new::${fingerprintAnchor({ kind: "file" })}`}
+            />
+          </div>
+        )}
+        {fileThreads.map((t) => (
+          <CommentThread
+            key={t.root.id}
+            rootComment={t.root}
+            replies={t.replies}
+            filePath={path}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/viewers/__tests__/BinaryPlaceholder.test.tsx
+++ b/src/components/viewers/__tests__/BinaryPlaceholder.test.tsx
@@ -4,6 +4,13 @@ import { render, screen, fireEvent } from "@testing-library/react";
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
 
+vi.mock("@/lib/vm/use-comments", () => ({
+  useComments: () => ({ threads: [], comments: [], loading: false, reload: () => {} }),
+}));
+vi.mock("@/lib/vm/use-comment-actions", () => ({
+  useCommentActions: () => ({ addComment: vi.fn().mockResolvedValue(undefined) }),
+}));
+
 vi.mock("../HexView", () => ({
   HexView: ({ path }: { path: string }) => (
     <div data-testid="hex-view-mock" data-path={path}>HEX</div>
@@ -25,12 +32,13 @@ beforeEach(() => {
 });
 
 describe("BinaryPlaceholder — Section E", () => {
-  it("renders all four action buttons", () => {
+  it("renders all five action buttons", () => {
     render(<BinaryPlaceholder path="/ws/sample.bin" size={512} />);
     expect(screen.getByRole("button", { name: /open in default app/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reveal in folder/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /copy path/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /show as hex/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /comment on this file/i })).toBeInTheDocument();
   });
 
   it("renders the file name, MIME hint and human-readable size", () => {
@@ -86,5 +94,12 @@ describe("BinaryPlaceholder — Section E", () => {
     fireEvent.click(screen.getByRole("button", { name: /show as hex/i }));
     expect(screen.getByTestId("hex-view-mock")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /open in default app/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Comment on this file' opens the file-level CommentInput", () => {
+    render(<BinaryPlaceholder path="/ws/sample.bin" size={100} />);
+    expect(screen.queryByPlaceholderText(/comment on this file/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /comment on this file/i }));
+    expect(screen.getByPlaceholderText(/comment on this file/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Follow-up to merged PR #86 to complete remaining acceptance criteria of #71.

Closes #71

## Spec
See [#71 issue body](https://github.com/dryotta/mdownreview/issues/71).

## Acceptance criteria (snapshot  to be ticked as the assessor confirms `met`)
- [ ] **Markdown gaps:** wrap `table`, `pre`, `blockquote`, `img`, `hr` via `makeCommentableBlock`; make `td`/`th` cells individually commentable.
- [ ] **HTML preview:** inject helper into iframe via `resolveHtmlAssets` rewrite; helper posts selection/click events back to host. Anchor variants `{ kind: "html-range", selector_path, start_offset, end_offset, selected_text }` (selection wins) and `{ kind: "html-element", selector_path, tag, text_preview }` (click fallback). Sandbox stays single-mode (`allow-same-origin` OR `allow-scripts`, never both).
- [ ] **Image:** click = pin, drag = rect; anchor `{ kind: "image-rect", x_pct, y_pct, w_pct?, h_pct? }` normalized to natural image dimensions. Existing comments overlay as numbered pins / translucent rects; click marker ΓåÆ floating popover.
- [ ] **CSV / JSON hybrid anchors:** store positional + content. CSV cell `{ kind: "csv-cell", row_idx, col_idx, col_header, primary_key_col?, primary_key_value? }` with leftmost-unique-column heuristic. JSON path `{ kind: "json-path", json_path, scalar_text? }` with `users[id=42]`-style predicates when an obvious id field exists. Re-anchor mirrors the existing 4-step line-anchor algorithm.
- [ ] **Mermaid:** map clicked rendered node back to its declaration line in the .mmd source; anchor as the existing `{ line, selected_text }` line variant. File-level fallback when source/render mapping fails.
- [ ] **Binary / unsupported:** file-level affordance only via new `{ kind: "file" }` anchor variant. Threads render under `BinaryPlaceholder`.
- [ ] **Hybrid affordance:** indicator badge always visible on lines/blocks/cells with existing comments (badge doubles as click-to-expand). Bare lines reveal a faint `+` only on hover or focus. Selection toolbar still appears on text selection regardless.
- [ ] **Unified indicator:** single shared `<CommentBadge count maxSeverity resolved />` component used by `FolderTree`, `TabBar`, gutter, and image overlay. Color reflects max unresolved severity (high red, medium amber, low/none neutral, all-resolved gray). Replaces today's `tree-comment-badge` and `tab-badge` CSS classes. Rust core gains `get_max_severity_per_file(workspace_root)` helper; coexists with existing `useUnresolvedCounts`.
- [ ] **Selection toolbar:** prefer `mouseup` cursor coords; fall back to "above end-of-selection caret rect" for keyboard selections. Always clamp to viewport with 4px margin.
- [ ] **Comment input placement:** inline below the clicked block (full viewer width) for text-based viewers ΓÇö replaces the current `left: 24px` hardcode in `MdCommentPopover`. Floating popover anchored to pin/rect/element for non-text viewers.
- [ ] **Overlap & clustering:** stack with offset for 1ΓÇô3 overlapping items; collapse into a `+N` cluster badge for 4+. Click cluster ΓåÆ fan out into a stacked list. Selection toolbar always re-positions to avoid overlapping an open thread. Shared `useCollisionLayout` util.
- [ ] **Comments panel `+`:** new button at panel header ΓåÆ opens input ΓåÆ on save, comment is filed with `{ kind: "file" }` anchor.
- [ ] **Viewer toolbar "Comment on file":** small button next to the file name in `ViewerToolbar`; surfaced on every viewer; same action as panel `+`.
- [ ] **"Move comment" action:** thread-level menu item enters a re-anchor mode (cursor changes; viewer shows hint banner). Reviewer clicks/selects new anchor target ΓåÆ confirms ΓåÆ thread keeps id, replies, history; anchor replaced.
- [ ] **MRSF audit trail:** optional `anchor_history: [Anchor; max 3]` per comment, FIFO. Not exposed in UI but preserved for audit.
- [ ] **F1 ΓÇö Keyboard shortcuts:** `Ctrl/Cmd+Shift+M` = comment on selection; `J`/`K` = next/prev unresolved in active file; `R` = resolve focused thread; `Esc` = close input.
- [ ] **F2 ΓÇö Export review summary:** "Export" button in Comments panel ΓåÆ markdown digest grouped by file with line links and full thread bodies. Designed for paste-back into AI prompts.
- [ ] **F3 ΓÇö Filter / search panel:** filter by type / severity / resolved-state; free-text search across thread bodies; workspace-wide toggle (today only active file).
- [ ] **F4 ΓÇö Quick reactions:** thumbs-up / acknowledged / dismissed buttons on threads. New optional `reactions: [{user, kind, ts}]` array.
- [ ] **F5 ΓÇö Persist drafts:** open input text restored from `localStorage` on app reload. Key for replies: `${filePath}::reply::${commentId}`. Key for new-comment drafts: `${filePath}::new::${pendingAnchorFingerprint}`. Cleared on save/cancel.
- [ ] **F6 ΓÇö Right-click context menu:** "Comment on selection" / "Copy link to line" / "Mark line as discussed". Keyboard reachable via Shift+F10.
- [ ] **F7 ΓÇö Author identity:** settings field for display name (defaults to OS user). Stored in app config; applied to new comments. No auth, no cloud.
- [ ] **F8 ΓÇö Workspace-wide nav:** toolbar button + shortcut to jump to next unresolved comment across the entire workspace, switching tabs/files as needed.

