### PR TITLE
validate-release: feat: implement #90  Viewer toolbar gets collapsed after continuing scrolling the page

### DIFF
--- a/.claude/retrospectives/feature-issue-90-sticky-viewer-toolbar-iter-1.md
+++ b/.claude/retrospectives/feature-issue-90-sticky-viewer-toolbar-iter-1.md
@@ -1,0 +1,62 @@
+# Retrospective — iterate-one-issue feature-issue-90-sticky-viewer-toolbar-iter-1 (PASSED)
+
+<!-- retro-meta:
+skill: iterate-one-issue
+run:   feature-issue-90-sticky-viewer-toolbar-iter-1
+outcome: PASSED
+started: 2026-04-26T19:21:00Z
+ended:   2026-04-26T19:55:00Z
+-->
+
+## Goal of this run
+Satisfy all acceptance criteria of #90 — viewer toolbar must remain pinned to `.viewer-scroll-region` for the entire scroll length (rect-equality ±1 px at 5 checkpoints across markdown / source / mermaid modes; CSS-only fix; new browser Playwright spec; existing unit test still passes).
+
+## What went well
+- Groomed spec (issue #90 comment, post bug+performance+react+test panel revision) carried full RCA and unambiguous Direction A choice — implementation needed zero design decisions from the autonomous loop.
+- Three-line CSS edit (commit 22d53fd) plus one focused browser spec covered all 5 acceptance criteria in a single iteration.
+- Local validator caught the wrong mermaid selector (`pre.mermaid, .mermaid` → `.mermaid-view`) before CI did — saved a CI cycle. Fixed in 58f67b3.
+- Local re-run of the spec also caught a per-test timeout from a too-large mermaid fixture (~9000 lines + react-markdown parse). Slim fixture in b0a7028 brought run time from 30s timeout to 26s for all 3 cases.
+- Expert panel (8/8) returned APPROVE with concrete confirmation per area: bug-expert verified pre-fix CSS would have failed the test; architect-expert validated Direction A as lower-coupling than Direction B; test-expert verified all 11 canonical init commands explicitly mocked.
+- CI was green on the third push (b0a7028) — Build (macos-arm64), Build (windows-x64), Test (Linux) all passed.
+
+## What did not go well
+- First spec author (this loop) guessed `pre.mermaid` as the mermaid selector instead of grepping for the actual class first. Cost one extra commit + one local validator run.
+- First mermaid fixture was the same as the markdown fixture (`TALL_MD + block + TALL_MD` ≈ 9000 lines). The 30s page.evaluate timeout failure was vague enough that diagnosing "too much react-markdown to parse" required one round of local re-run.
+- The validator agent reported the pre-existing native installer test failure (no NSIS bundle built) as `FAIL`; the skill rule says "if the binary required isn't built, report SKIPPED". Not blocking — but the validator's output schema and the rule wording diverge.
+
+## Root causes of friction
+- **Selector guessing instead of source lookup.** No skill-level guard requires the implementer to grep for a class before writing a selector-based assertion. This is a recurring pattern (cf. earlier exploratory tests).
+- **Per-test budget for react-markdown is implicit.** No documented "max safe fixture size for a `MarkdownViewer` test" exists in `docs/test-strategy.md` or `docs/performance.md`. Authors discover the limit empirically.
+- **Validator schema vs rule wording.** The exe-implementation-validator returns `PASS|FAIL|SKIPPED` per check, but the prompt rule "if binary not built, report SKIPPED" describes a specific *failure mode* and the validator's instinct is to mark the run FAIL because exit code was 1.
+
+## Improvement candidates (each must be specifiable)
+
+### Document maximum safe inline-generated markdown fixture size for browser specs
+- **Category:** test-strategy
+- **Problem (with evidence):** First mermaid case used a ~9000-line markdown fixture and hit the 30s `page.evaluate` timeout (`e2e/browser/viewer-toolbar-sticky.spec.ts:89`, "Test timeout of 30000ms exceeded"). Slimming to ~1600 lines fixed it. `docs/test-strategy.md` and `docs/performance.md` contain no rule about "fixture size budget for react-markdown specs", so authors discover the limit empirically each time.
+- **Proposed change:** Add a rule under `docs/test-strategy.md` "Browser test patterns" along the lines of: *"Inline-generated markdown fixtures used to exercise scroll/sticky/layout behaviour SHOULD stay below ~3000 lines (≈ 350 KB rendered HTML) per `page.evaluate`-bound assertion. Larger fixtures risk hitting the 30s per-test budget on slow CI runners during react-markdown's initial parse pass. If a larger document is genuinely required, raise per-test timeout via `test.slow()` and document why."*
+- **Acceptance signal:** Rule cited from `docs/test-strategy.md` in any future browser spec that uses `Array.from({ length: N })` markdown generation; new spec authors no longer rediscover the limit empirically.
+- **Estimated size:** xs
+- **Confidence this matters:** medium — react-markdown render cost is the documented gap in `docs/performance.md` ("MarkdownViewer re-parses…"), so a bounded recommendation aligned with it is cheap insurance for future browser specs.
+
+### Tighten exe-implementation-validator → SKIPPED contract for missing native build artifact
+- **Category:** agent
+- **Problem (with evidence):** Validator iter-1 reported `playwright_native: FAIL` for the NSIS installer test (`e2e/native/installer.spec.ts:35`) even though the underlying error is "No NSIS bundle dir found" — i.e., the prerequisite artifact wasn't built. The skill instruction was *"if the binary required isn't built, report SKIPPED — don't try to build it from scratch unless the npm script does so itself"*, but the validator's `details` payload split the difference: `"summary": "exit 1 — 13 passed, 1 failed"` then `"note": "Reporting overall as FAIL because the run exit code was 1; treat as SKIPPED if installer artifact is out of scope."`
+- **Proposed change:** Update the `exe-implementation-validator` agent definition (in `.claude/agents/exe-implementation-validator.md`) to define a precise rule: *"For each suite step, if the only failures are explicitly attributed to a missing prerequisite artifact (e.g. 'no NSIS bundle dir found', 'binary not present'), classify the step as SKIPPED with the missing-prerequisite reason in `details`, NOT FAIL. Failures from inside an artifact that exists remain FAIL."* Provide the NSIS case as an example.
+- **Acceptance signal:** Future `iterate-one-issue` runs whose diff doesn't touch installer/CLI shim see `playwright_native: SKIPPED` in the validator output, not `FAIL`. This avoids the dispatcher having to manually decide whether the failure is in scope.
+- **Estimated size:** xs
+- **Confidence this matters:** medium — recurring noise pollutes the forward-fix loop's signal: the skill currently has to override the validator's verdict via `if the binary required isn't built, report SKIPPED` reasoning, and that happens every iter on every PR.
+
+### Selector-source-of-truth lookup before authoring DOM assertions
+- **Category:** skill
+- **Problem (with evidence):** First mermaid-test attempt used `pre.mermaid, .mermaid` based on guess (commit 22d53fd), not on the actual mounted React component. Real selector is `.mermaid-view` (from `src/components/viewers/MermaidView.tsx:297`). The mistake cost one validator run + one fix commit (58f67b3). Same class of failure exists across other browser specs that hard-code class names without grepping first.
+- **Proposed change:** Add a step to `iterate-one-issue` Step 5 (Implement) for any *new* browser spec: *"For each DOM selector used in a Playwright assertion, verify the class/test-id exists in the source by `grep -rn 'classname'` in `src/components/`. Cite the source line in a comment beside the selector."* Either as a Step-5 sub-bullet, or as a check the implementer agent performs and reports.
+- **Acceptance signal:** New browser specs include source-citation comments for every assertion selector; selector-mismatch failures during validation drop near zero.
+- **Estimated size:** s
+- **Confidence this matters:** low/medium — the selector-guess pattern is real but rare; cost is one extra validator round when it happens. Worth fixing if it recurs in the next 2-3 runs.
+
+## Carry-over to the next run
+- None. Iteration 1 satisfied all 5 acceptance criteria; iteration 2 should re-assess to `achieved` and trigger Done-Achieved.
+
+## BUG_RCA
+The full root-cause analysis was already performed during issue grooming (post-bug-expert + post-perf-expert revision visible in the spec body of issue #90). The autonomous loop did not re-run `bug-expert` for iteration 1 because the spec carried the verbatim RCA and Direction A vs B trade-off. Pre-loop assessment matched the spec's diagnosis exactly: sticky containing block (`.enhanced-viewer`/`.markdown-viewer`/`.source-view`) was capped at one viewport of `.viewer-scroll-region` via `height: 100%`, so once content overflowed, the containing block scrolled past `top: 0` and the sticky toolbar followed. Fix: `min-height: 100%` on those three selectors. Regression test fails on pre-fix CSS at every checkpoint where `ratio > 0`.

--- a/e2e/browser/viewer-toolbar-sticky.spec.ts
+++ b/e2e/browser/viewer-toolbar-sticky.spec.ts
@@ -152,8 +152,10 @@ test.describe("Viewer toolbar sticky positioning (#90)", () => {
     // stacking-context-heavy DOM. We do not require the SVG to fully
     // render; the markdown body alone (≥ 4500 lines) is what makes the
     // page scrollable, and the mermaid wrapper is enough to introduce
-    // additional stacking contexts above it.
-    await expect(page.locator("pre.mermaid, .mermaid").first()).toBeAttached();
+    // additional stacking contexts above it. Embedded mermaid blocks
+    // render through `MermaidView` whose root element has class
+    // `.mermaid-view` (see src/components/viewers/MermaidView.tsx).
+    await expect(page.locator(".mermaid-view").first()).toBeAttached();
     await assertStickyAtCheckpoints(page, "mermaid-md");
   });
 });

--- a/e2e/browser/viewer-toolbar-sticky.spec.ts
+++ b/e2e/browser/viewer-toolbar-sticky.spec.ts
@@ -29,13 +29,19 @@ const TALL_TS = Array.from({ length: 5000 }, (_, i) =>
   `// Line ${i}: const value_${i} = ${i}; // padding text to force a wide-enough single line so wrap is irrelevant`,
 ).join("\n");
 
-// Stacking-context-heavy variant: same tall markdown body interleaved
-// with mermaid code blocks. Mermaid renders SVGs that establish their
-// own stacking contexts via transforms; we want to confirm the sticky
-// bar still pins despite those.
+// Stacking-context-heavy variant: a moderate-sized tall markdown body
+// (still > 1 viewport so the scroll case is real) interleaved with a
+// mermaid code block. Mermaid renders SVGs that establish their own
+// stacking contexts via transforms; we want to confirm the sticky bar
+// still pins despite those. Kept smaller than `TALL_MD` so the
+// react-markdown parse + mermaid lazy-mount stays well under the
+// per-test timeout.
+const TALL_MD_MEDIUM = Array.from({ length: 800 }, (_, i) =>
+  `## Heading ${i}\n\nParagraph ${i} with sufficient text to give this section vertical height when rendered through react-markdown.\n`,
+).join("\n");
 const MERMAID_BLOCK =
   "\n```mermaid\nflowchart TD\n  A[Start] --> B[End]\n```\n\n";
-const TALL_MERMAID_MD = TALL_MD + MERMAID_BLOCK + TALL_MD;
+const TALL_MERMAID_MD = TALL_MD_MEDIUM + MERMAID_BLOCK + TALL_MD_MEDIUM;
 
 interface FileSeed { name: string; content: string }
 

--- a/e2e/browser/viewer-toolbar-sticky.spec.ts
+++ b/e2e/browser/viewer-toolbar-sticky.spec.ts
@@ -1,0 +1,159 @@
+// Issue #90 — viewer toolbar must remain pinned to the top of
+// `.viewer-scroll-region` for the entire scroll length, not just the
+// first viewport. Previously `.enhanced-viewer`/`.markdown-viewer`/
+// `.source-view` were `height: 100%`, capping the sticky containing
+// block at one viewport so the toolbar followed it off-screen.
+//
+// jsdom cannot compute `position: sticky`, so this is a browser-level
+// Playwright spec. We assert
+// `toolbar.getBoundingClientRect().top === scrollRegion.getBoundingClientRect().top`
+// (within 1 px) at five scroll checkpoints (0, ¼, ½, ¾, end) for:
+//   - Markdown visual mode      (default)
+//   - Source mode               (toggled via toolbar)
+//   - Markdown with mermaid     (stacking-context-heavy case)
+
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+const FIXTURES_DIR = "/e2e/fixtures";
+
+// ≥ 4000 lines / ~150 KB tall markdown body. Generated rather than
+// stored as a binary fixture so the e2e suite stays self-contained.
+const TALL_MD = Array.from({ length: 4500 }, (_, i) =>
+  `## Heading ${i}\n\nParagraph ${i} with sufficient text to give this section vertical height when rendered through react-markdown.\n`,
+).join("\n");
+
+// Source-mode equivalent: a long .ts file. The toolbar's source-mode
+// branch renders `SourceView` whose root is `.source-view`.
+const TALL_TS = Array.from({ length: 5000 }, (_, i) =>
+  `// Line ${i}: const value_${i} = ${i}; // padding text to force a wide-enough single line so wrap is irrelevant`,
+).join("\n");
+
+// Stacking-context-heavy variant: same tall markdown body interleaved
+// with mermaid code blocks. Mermaid renders SVGs that establish their
+// own stacking contexts via transforms; we want to confirm the sticky
+// bar still pins despite those.
+const MERMAID_BLOCK =
+  "\n```mermaid\nflowchart TD\n  A[Start] --> B[End]\n```\n\n";
+const TALL_MERMAID_MD = TALL_MD + MERMAID_BLOCK + TALL_MD;
+
+interface FileSeed { name: string; content: string }
+
+async function setupStickyMocks(page: Page, files: FileSeed[]): Promise<void> {
+  await page.addInitScript(({ dir, files }: { dir: string; files: FileSeed[] }) => {
+    const fileMap: Record<string, string> = {};
+    const dirEntries = files.map((f) => {
+      const path = `${dir}/${f.name}`;
+      fileMap[path] = f.content;
+      return { name: f.name, path, is_dir: false };
+    });
+
+    window.__TAURI_IPC_MOCK__ = async (cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "get_launch_args") return { files: [], folders: [dir] };
+      if (cmd === "read_dir") return dirEntries;
+      if (cmd === "read_text_file") {
+        const p = (args as { path: string }).path;
+        return fileMap[p] ?? "";
+      }
+      if (cmd === "load_review_comments") return null;
+      if (cmd === "save_review_comments") return null;
+      if (cmd === "check_path_exists") return "file";
+      if (cmd === "get_log_path") return "/mock/log.log";
+      if (cmd === "get_file_comments") return [];
+      if (cmd === "get_file_badges") return [];
+      if (cmd === "scan_review_files") return [];
+      if (cmd === "update_watched_files") return undefined;
+      return null;
+    };
+  }, { dir: FIXTURES_DIR, files });
+}
+
+interface CheckpointResult {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  toolbarTop: number;
+  scrollRegionTop: number;
+}
+
+/**
+ * Scrolls `.viewer-scroll-region` to `targetRatio` of its scrollable
+ * range and returns the relevant rects in the same evaluate call so
+ * sticky-update races are avoided (the browser flushes sticky
+ * positioning before returning from `scrollTo`).
+ */
+async function scrollAndMeasure(
+  page: Page,
+  targetRatio: number,
+): Promise<CheckpointResult> {
+  return page.evaluate((ratio) => {
+    const scroll = document.querySelector(".viewer-scroll-region") as HTMLElement | null;
+    const toolbar = document.querySelector(".viewer-toolbar") as HTMLElement | null;
+    if (!scroll || !toolbar) {
+      throw new Error("scroll region or toolbar not in DOM");
+    }
+    const max = scroll.scrollHeight - scroll.clientHeight;
+    const target = Math.round(max * ratio);
+    scroll.scrollTo(0, target);
+    return {
+      scrollTop: scroll.scrollTop,
+      scrollHeight: scroll.scrollHeight,
+      clientHeight: scroll.clientHeight,
+      toolbarTop: toolbar.getBoundingClientRect().top,
+      scrollRegionTop: scroll.getBoundingClientRect().top,
+    };
+  }, targetRatio);
+}
+
+const CHECKPOINTS = [0, 0.25, 0.5, 0.75, 1];
+
+async function assertStickyAtCheckpoints(page: Page, label: string): Promise<void> {
+  for (const ratio of CHECKPOINTS) {
+    const m = await scrollAndMeasure(page, ratio);
+    // Sanity: there must be real scroll to test against (otherwise the
+    // bug is unreachable and the test is meaningless).
+    expect(
+      m.scrollHeight,
+      `${label} @ ${ratio}: viewer must overflow viewport (got ${m.scrollHeight} vs ${m.clientHeight})`,
+    ).toBeGreaterThan(m.clientHeight + 100);
+    expect(
+      Math.abs(m.toolbarTop - m.scrollRegionTop),
+      `${label} @ ratio ${ratio}: toolbar.top=${m.toolbarTop} expected to equal scrollRegion.top=${m.scrollRegionTop} (±1px)`,
+    ).toBeLessThanOrEqual(1);
+  }
+}
+
+test.describe("Viewer toolbar sticky positioning (#90)", () => {
+  test("markdown visual mode — toolbar stays pinned to scroll region top", async ({ page }) => {
+    await setupStickyMocks(page, [{ name: "tall.md", content: TALL_MD }]);
+    await page.goto("/");
+    await page.locator(".folder-tree").getByText("tall.md").click();
+    await expect(page.locator(".markdown-viewer")).toBeVisible();
+    await expect(page.locator(".viewer-toolbar").first()).toBeVisible();
+    await assertStickyAtCheckpoints(page, "markdown");
+  });
+
+  test("source mode — toolbar stays pinned to scroll region top", async ({ page }) => {
+    await setupStickyMocks(page, [{ name: "tall.ts", content: TALL_TS }]);
+    await page.goto("/");
+    await page.locator(".folder-tree").getByText("tall.ts").click();
+    await expect(page.locator(".source-view")).toBeVisible();
+    await expect(page.locator(".viewer-toolbar").first()).toBeVisible();
+    await assertStickyAtCheckpoints(page, "source");
+  });
+
+  test("markdown with mermaid (stacking-context-heavy) — toolbar stays pinned", async ({ page }) => {
+    await setupStickyMocks(page, [{ name: "tall-mermaid.md", content: TALL_MERMAID_MD }]);
+    await page.goto("/");
+    await page.locator(".folder-tree").getByText("tall-mermaid.md").click();
+    await expect(page.locator(".markdown-viewer")).toBeVisible();
+    await expect(page.locator(".viewer-toolbar").first()).toBeVisible();
+    // Wait for the mermaid container to appear so we are exercising the
+    // stacking-context-heavy DOM. We do not require the SVG to fully
+    // render; the markdown body alone (≥ 4500 lines) is what makes the
+    // page scrollable, and the mermaid wrapper is enough to introduce
+    // additional stacking contexts above it.
+    await expect(page.locator("pre.mermaid, .mermaid").first()).toBeAttached();
+    await assertStickyAtCheckpoints(page, "mermaid-md");
+  });
+});

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,6 +1,11 @@
 .markdown-viewer {
   padding: 20px 28px;
-  height: 100%;
+  /* min-height (not height) so this element — which is the sticky
+     containing block for `.viewer-toolbar` inside `EnhancedViewer` —
+     grows with content. With `height: 100%` the containing block is
+     capped at one viewport, so the toolbar follows it off-screen
+     once the user scrolls past the first viewport (#90). */
+  min-height: 100%;
 }
 
 .size-warning {

--- a/src/styles/source-viewer.css
+++ b/src/styles/source-viewer.css
@@ -49,7 +49,10 @@
 /* ── SourceView line-based layout ────────────────────────────────── */
 
 .source-view {
-  height: 100%;
+  /* See `.markdown-viewer` in markdown.css — `min-height` keeps the
+     sticky containing block growing with content so `.viewer-toolbar`
+     does not collapse on continued scroll (#90). */
+  min-height: 100%;
   background: var(--color-bg);
 }
 

--- a/src/styles/viewer-toolbar.css
+++ b/src/styles/viewer-toolbar.css
@@ -178,11 +178,16 @@
 }
 
 /* L1 — `EnhancedViewer` flex column. The toolbar (with FileActionsBar in
-   its `trailing` slot) is the single sticky element inside it. */
+   its `trailing` slot) is the single sticky element inside it.
+   `min-height: 100%` (not `height: 100%`) so the sticky containing
+   block grows with the viewer body. With a fixed `height: 100%` the
+   containing block is capped at one viewport of `.viewer-scroll-region`,
+   and once the user scrolls past it the sticky toolbar follows it
+   off-screen — the bug behind #90. */
 .enhanced-viewer {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100%;
 }
 
 /* L5 — shared scroll/error containers used by `ViewerRouter`. */


### PR DESCRIPTION
Release-gate validation for #136. Close with --delete-branch after validation.