### PR TITLE
chore: gitignore iterate-loop run artefacts and retrospectives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ src-tauri/binaries/mdownreview-cli-*
 .claude/test-exploratory-e2e/known-findings.json
 .claude/test-exploratory-loop/runs/
 
+# iterate-loop / iterate-one-issue skill runtime artefacts
+.claude/iterate-loop/runs/
+.claude/retrospectives/
+


### PR DESCRIPTION
Matches the existing `test-exploratory-loop/runs/` pattern so prior loop run digests and per-issue retrospectives don't show up as a dirty tree at the start of the next `/iterate-loop` session.

No source change.