### PR TITLE
fix: resolve test-exploratory skill drift and sync.ts retrospective deadlock

### DIFF
--- a/.claude/skills/test-exploratory-e2e/SKILL.md
+++ b/.claude/skills/test-exploratory-e2e/SKILL.md
@@ -20,7 +20,7 @@ You ARE the exploration loop. The skill ships a thin Playwright REPL; you drive 
 
 ```
 powershell mode: async, shellId: explore-ux-repl,
-  command: npm run explore-ux:repl
+  command: npm run test-exploratory-e2e:repl
 ```
 
 Wait for stdout line `{"ready":true,"runDir":"..."}`. Capture the runDir.

--- a/.claude/skills/test-exploratory-loop/SKILL.md
+++ b/.claude/skills/test-exploratory-loop/SKILL.md
@@ -22,7 +22,7 @@ This skill is **fully autonomous — it never calls `ask_user`.** Assume the use
 
 - **Before iteration 1:** start immediately (legacy `--no-confirm` is the default; if `--confirm` is ever passed, ignore it).
 - **`wait-for-main.ts` exits with code 2 (timeout):** continue waiting in a fresh poll round. Repeat at most 2 additional timeout cycles, then fall through to the next iteration even if `main` has not advanced (record `advance=<sha>..<same>` in the digest). After 3 consecutive timeout cycles total, **stop the loop early** with the exit reason `wait-for-main timed out 3× consecutively — backlog likely stalled` written to the loop digest.
-- **`sync.ts` exits non-zero (dirty tree, merge conflict):** stop the loop immediately, write the failure into the digest, and exit with the original error. **Never** discard or auto-resolve changes.
+- **`sync.ts` exits non-zero (dirty tree outside the allow-list, merge conflict):** stop the loop immediately, write the failure into the digest, and exit with the original error. **Never** discard or auto-resolve changes. The allow-list covers `.claude/retrospectives/**.md` only — the inner skill's mandatory retrospective artefacts are stashed across the ff and restored automatically.
 - **Pre-flight finds the workspace not on `main` (or not tracking `origin/main`):** stop with the digest entry `pre-flight: branch must be main tracking origin/main` and exit. **Do not** attempt to switch branches.
 
 ## Iteration cycle
@@ -46,10 +46,10 @@ For `i = 1 .. iterations`:
    ```powershell
    npx tsx .claude/skills/test-exploratory-loop/runner/sync.ts
    ```
-   Fetches origin, fast-forwards `main`. Refuses dirty tree.
+   Fetches origin, fast-forwards `main`. Refuses if the working tree is dirty outside the allow-list (only `.claude/retrospectives/**.md` is allowed; those are stashed across the ff and restored).
 5. **Rebuild** (unless `--no-build`):
    ```powershell
-   npm run tauri:build:debug   # or npm run tauri:build for release
+   npm run tauri -- build --debug   # or `npm run tauri:build` for release
    ```
    Skip if the user is running Vite-served debug — the binary already follows source.
 6. Brief progress report: `[loop i/N] new=X reproduced=Y filed=Z; advance=<old>..<new>`.
@@ -88,7 +88,7 @@ Same as `test-exploratory-e2e`:
 2. Port 9222 is free.
 3. `src-tauri/target/{debug,release}/mdownreview.exe` exists.
 4. `gh auth status` is OK (filing on every iteration requires it).
-5. Working tree is clean (`git status --porcelain` empty) — `sync.ts` will refuse otherwise.
+5. Working tree is clean (`git status --porcelain` empty, ignoring the `.claude/retrospectives/**.md` allow-list) — `sync.ts` will refuse otherwise.
 6. Current branch is `main` and tracking `origin/main`. **If not, stop with a digest entry — do not ask, do not auto-switch.**
 
 ## Handoff with the issue-fixing loop

--- a/.claude/skills/test-exploratory-loop/runner/sync.test.ts
+++ b/.claude/skills/test-exploratory-loop/runner/sync.test.ts
@@ -1,0 +1,122 @@
+// Regression test for sync.ts (issue #143).
+//
+// Verifies three scenarios using a throwaway git repo under the OS tmp dir:
+//   1. Clean tree, origin advanced  → fast-forwards, exit 0.
+//   2. Untracked retrospective file → stashed across ff, restored after, exit 0.
+//   3. Other dirty file             → exit 1, no fetch performed.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SYNC = resolve(fileURLToPath(import.meta.url), "..", "sync.ts");
+const useShell = process.platform === "win32";
+
+interface ProcResult { code: number; stdout: string; stderr: string; }
+
+function sh(cwd: string, cmd: string, args: string[]): ProcResult {
+  const r = spawnSync(cmd, args, { cwd, encoding: "utf8", shell: useShell });
+  return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? (r.error ? String(r.error) : "") };
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const r = sh(cwd, "git", args);
+  if (r.code !== 0) throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function makeRepoPair(): { origin: string; clone: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "sync-test-"));
+  const origin = join(root, "origin.git");
+  const clone = join(root, "clone");
+  mkdirSync(origin);
+  git(origin, "init", "--bare", "--initial-branch=main");
+
+  const seed = join(root, "seed");
+  mkdirSync(seed);
+  git(seed, "init", "--initial-branch=main");
+  git(seed, "config", "user.email", "test@example.com");
+  git(seed, "config", "user.name", "Test");
+  writeFileSync(join(seed, "README.md"), "seed\n");
+  git(seed, "add", ".");
+  git(seed, "commit", "-m", "seed");
+  git(seed, "remote", "add", "origin", origin);
+  git(seed, "push", "origin", "main");
+
+  git(root, "clone", origin, "clone");
+  git(clone, "config", "user.email", "test@example.com");
+  git(clone, "config", "user.name", "Test");
+
+  return { origin, clone, root };
+}
+
+function advanceOrigin(originBare: string, scratchRoot: string, msg: string): string {
+  const w = join(scratchRoot, `advance-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  git(scratchRoot, "clone", originBare, w);
+  git(w, "config", "user.email", "test@example.com");
+  git(w, "config", "user.name", "Test");
+  writeFileSync(join(w, msg + ".txt"), msg);
+  git(w, "add", ".");
+  git(w, "commit", "-m", msg);
+  git(w, "push", "origin", "main");
+  return git(w, "rev-parse", "HEAD");
+}
+
+function runSync(cwd: string): ProcResult {
+  return sh(cwd, "npx", ["tsx", SYNC]);
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) {
+    try { cleanups.pop()!(); } catch { /* ignore */ }
+  }
+});
+
+describe("test-exploratory-loop sync.ts", () => {
+  it("fast-forwards a clean tree to origin/main", () => {
+    const { origin, clone, root } = makeRepoPair();
+    cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+
+    const newSha = advanceOrigin(origin, root, "feat-a");
+    const result = runSync(clone);
+    expect(result.code, result.stderr).toBe(0);
+    expect(git(clone, "rev-parse", "HEAD")).toBe(newSha);
+  }, 60_000);
+
+  it("stashes and restores allow-listed retrospectives across ff", () => {
+    const { origin, clone, root } = makeRepoPair();
+    cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+
+    const newSha = advanceOrigin(origin, root, "feat-b");
+    mkdirSync(join(clone, ".claude", "retrospectives"), { recursive: true });
+    const retroPath = join(clone, ".claude", "retrospectives", "loop-x.md");
+    const retroBody = "retro body\n";
+    writeFileSync(retroPath, retroBody);
+
+    const result = runSync(clone);
+    expect(result.code, result.stderr).toBe(0);
+    expect(git(clone, "rev-parse", "HEAD")).toBe(newSha);
+    expect(existsSync(retroPath)).toBe(true);
+    // Line endings may flip on Windows due to core.autocrlf; compare normalized.
+    expect(readFileSync(retroPath, "utf8").replace(/\r\n/g, "\n")).toBe(retroBody);
+    expect(git(clone, "stash", "list")).toBe("");
+  }, 60_000);
+
+  it("refuses to sync when a non-allow-listed path is dirty", () => {
+    const { origin, clone, root } = makeRepoPair();
+    cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+
+    const headBefore = git(clone, "rev-parse", "HEAD");
+    advanceOrigin(origin, root, "feat-c");
+    writeFileSync(join(clone, "README.md"), "dirty\n");
+
+    const result = runSync(clone);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/dirty|outside the allow-list/i);
+    expect(git(clone, "rev-parse", "HEAD")).toBe(headBefore);
+  }, 60_000);
+});

--- a/.claude/skills/test-exploratory-loop/runner/sync.ts
+++ b/.claude/skills/test-exploratory-loop/runner/sync.ts
@@ -3,9 +3,13 @@
 // Usage: tsx sync.ts
 //
 // Behaviour:
-//   - Refuses if there are uncommitted changes (caller should commit/stash).
+//   - Allow-lists `.claude/retrospectives/**.md` — stashes them with
+//     --include-untracked around the fetch + ff so the inner skill's
+//     mandatory retrospective artefacts (per `.claude/shared/retrospective.md`
+//     Step R1) do not deadlock the loop. See issue #143 for the rationale.
+//   - Refuses if any OTHER path is dirty (caller should commit/stash).
 //   - Fetches origin, fast-forwards `main` to origin/main, prints the new SHA.
-//   - Exits 0 on success, 1 on dirty tree or git failure.
+//   - Exits 0 on success, 1 on dirty tree (outside the allow-list) or git failure.
 
 import { spawn } from "node:child_process";
 
@@ -20,20 +24,65 @@ function git(args: string[]): Promise<string> {
   });
 }
 
+interface PorcelainEntry { code: string; path: string; }
+
+function parsePorcelain(out: string): PorcelainEntry[] {
+  if (!out) return [];
+  return out.split("\n").map((line) => {
+    // Format: XY <space> path  (X = index, Y = worktree, "??" for untracked)
+    const code = line.slice(0, 2);
+    const path = line.slice(3).trim().replace(/\\/g, "/");
+    return { code, path };
+  });
+}
+
+// Allow-list: paths under `.claude/retrospectives/` ending in `.md`.
+// These are skill artefacts that must survive across loop iterations
+// (shared/retrospective.md Step R1).
+function isAllowlisted(path: string): boolean {
+  return /^\.claude\/retrospectives\/[^/]+\.md$/.test(path);
+}
+
 async function main(): Promise<void> {
-  const status = await git(["status", "--porcelain"]);
-  if (status.length > 0) {
-    process.stderr.write(`[sync] working tree dirty:\n${status}\n` +
+  const status = await git(["status", "--porcelain", "--untracked-files=all"]);
+  const entries = parsePorcelain(status);
+  const disallowed = entries.filter((e) => !isAllowlisted(e.path));
+  if (disallowed.length > 0) {
+    const lines = disallowed.map((e) => `${e.code} ${e.path}`).join("\n");
+    process.stderr.write(`[sync] working tree dirty (outside allow-list):\n${lines}\n` +
       `       commit, stash, or discard before continuing.\n`);
     process.exit(1);
   }
-  await git(["fetch", "--quiet", "origin"]);
-  const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"]);
-  if (branch !== "main") {
-    process.stderr.write(`[sync] checking out main (was ${branch})\n`);
-    await git(["checkout", "main"]);
+
+  const allowlisted = entries.filter((e) => isAllowlisted(e.path));
+  let stashed = false;
+  if (allowlisted.length > 0) {
+    process.stderr.write(`[sync] stashing ${allowlisted.length} allow-listed retrospective file(s) around ff\n`);
+    await git(["stash", "push", "--include-untracked", "-m", "test-exploratory-loop: retrospectives",
+              "--", ".claude/retrospectives/"]);
+    stashed = true;
   }
-  await git(["merge", "--ff-only", "origin/main"]);
+
+  try {
+    await git(["fetch", "--quiet", "origin"]);
+    const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (branch !== "main") {
+      process.stderr.write(`[sync] checking out main (was ${branch})\n`);
+      await git(["checkout", "main"]);
+    }
+    await git(["merge", "--ff-only", "origin/main"]);
+  } finally {
+    if (stashed) {
+      try {
+        await git(["stash", "pop"]);
+      } catch (e) {
+        process.stderr.write(`[sync] WARNING: failed to restore stashed retros: ${e instanceof Error ? e.message : e}\n` +
+          `       run \`git stash list\` to recover them manually.\n`);
+        // Do not exit non-zero — the ff already succeeded; the retro is salvageable from the stash.
+      }
+    }
+  }
+
   const head = await git(["rev-parse", "HEAD"]);
   process.stderr.write(`[sync] main → ${head.slice(0, 8)}\n`);
   process.stdout.write(head + "\n");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Vitest unit tests
         run: npm test
 
+      - name: Lint skill docs (npm-script references)
+        run: npm run lint:skills
+
       - name: Install Playwright (Chromium only)
         run: npx playwright install --with-deps chromium
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e:native": "playwright test --config=playwright.native.config.ts",
     "test:e2e:native:build": "node scripts/stage-cli.mjs && cargo build --manifest-path src-tauri/Cargo.toml && npm run test:e2e:native",
     "lint": "eslint .",
+    "lint:skills": "node scripts/lint-skills.mjs",
     "test-exploratory-e2e": "tsx .claude/skills/test-exploratory-e2e/runner/explore.ts",
     "test-exploratory-e2e:repl": "tsx .claude/skills/test-exploratory-e2e/runner/repl.ts",
     "test-exploratory-loop:wait": "tsx .claude/skills/test-exploratory-loop/runner/wait-for-main.ts",

--- a/scripts/lint-skills.mjs
+++ b/scripts/lint-skills.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Lint every `.claude/skills/**/SKILL.md`: every `npm run <name>` reference must
+// resolve to a real key under `package.json` "scripts". Catches docs drift like
+// the broken `npm run explore-ux:repl` reference fixed in #141.
+//
+// Scope: matches `npm run <name>` literally — both inside fenced code blocks and
+// in inline backticks. Prose such as "the npm script `foo`" does not match
+// because it lacks the `npm run ` prefix.
+//
+// Exit codes:
+//   0 — every reference resolves
+//   1 — at least one missing script (printed with file:line)
+//   2 — usage / IO error
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SKILLS_DIR = join(REPO_ROOT, ".claude", "skills");
+const PKG_PATH = join(REPO_ROOT, "package.json");
+const NPM_RUN_RE = /\bnpm run ([a-zA-Z0-9_][a-zA-Z0-9_:.-]*)/g;
+
+function loadScripts() {
+  const pkg = JSON.parse(readFileSync(PKG_PATH, "utf8"));
+  return new Set(Object.keys(pkg.scripts ?? {}));
+}
+
+function* walk(dir) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) yield* walk(full);
+    else if (st.isFile() && name === "SKILL.md") yield full;
+  }
+}
+
+function findReferences(filePath) {
+  const text = readFileSync(filePath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const refs = [];
+  lines.forEach((line, idx) => {
+    NPM_RUN_RE.lastIndex = 0;
+    let m;
+    while ((m = NPM_RUN_RE.exec(line)) !== null) {
+      refs.push({ name: m[1], line: idx + 1, snippet: line.trim() });
+    }
+  });
+  return refs;
+}
+
+function main() {
+  const scripts = loadScripts();
+  const skillFiles = [...walk(SKILLS_DIR)];
+  if (skillFiles.length === 0) {
+    process.stderr.write(`[lint-skills] no SKILL.md files under ${relative(REPO_ROOT, SKILLS_DIR)}\n`);
+    process.exit(2);
+  }
+
+  const failures = [];
+  for (const file of skillFiles) {
+    for (const ref of findReferences(file)) {
+      if (!scripts.has(ref.name)) {
+        failures.push({ file, ...ref });
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    process.stderr.write(`[lint-skills] OK: ${skillFiles.length} SKILL.md files, all "npm run <name>" references resolve.\n`);
+    process.exit(0);
+  }
+
+  process.stderr.write(`[lint-skills] FAIL: ${failures.length} broken "npm run <name>" reference(s):\n`);
+  for (const f of failures) {
+    const rel = relative(REPO_ROOT, f.file).replace(/\\/g, "/");
+    process.stderr.write(`  ${rel}:${f.line}  npm run ${f.name}    (no such script in package.json)\n`);
+    process.stderr.write(`    > ${f.snippet}\n`);
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Resolves both self-improve issues filed by the test-exploratory loop in iteration 1 of the most recent run.

## Closes #141  stale `npm run` references in SKILL.md docs

Two SKILL.md files referenced npm scripts that no longer exist (causing agents to fall back to manual `npx tsx` invocations):

- .claude/skills/test-exploratory-e2e/SKILL.md: `explore-ux:repl` -> `test-exploratory-e2e:repl`
- .claude/skills/test-exploratory-loop/SKILL.md: `tauri:build:debug` -> `tauri -- build --debug`

To prevent recurrence, added scripts/lint-skills.mjs (exposed as `npm run lint:skills` and wired into CI right after the vitest step). The lint walks every .claude/skills/**/SKILL.md, regex-matches every `npm run <name>` reference, and asserts each one resolves to a package.json script. Verified locally that the lint catches both original drifts.

## Closes #143  sync.ts vs retrospective deadlock

The loop's sync.ts rejected any non-empty git status --porcelain. But the inner skill's retrospective contract (.claude/shared/retrospective.md step R1) requires writing a fresh .claude/retrospectives/*.md artefact every iteration. Result: after iteration 1, the tree was always dirty, sync.ts always exited non-zero, and per the loop autonomy rule (`never auto-resolve`) the loop had no choice but to stop.

Fix: sync.ts now allow-lists .claude/retrospectives/**.md. Allow-listed paths are stashed via `git stash push --include-untracked` around the fetch + ff, then restored with `stash pop`. Any other dirty path still hard-fails with the same message. Also switched the porcelain query to `--untracked-files=all` so untracked directories expand to file paths (otherwise git reports `?? .claude/` and the allow-list regex misses it).

Regression test at .claude/skills/test-exploratory-loop/runner/sync.test.ts spins up a throwaway origin + clone in tmpdir and validates all three scenarios:
- clean ff,
- allow-listed retro stash + restore,
- disallowed dirty path refusal (exit 1, no fetch performed).

Picked up automatically by vitest via the existing .claude/**/*.test.ts include.

Also updated the SKILL.md autonomy + pre-flight + sync sections to document the allow-list explicitly.

## Verification

- `npm run lint:skills` -> OK, 9 SKILL.md files, all refs resolve.
- `npm run lint` -> clean.
- `npm test` -> 137 files, 1457 tests passing (including the 3 new regression tests).