### PR TITLE
fix(release-gate): refuse default-branch dispatch + document --pipeline

### DIFF
--- a/.claude/skills/iterate-one-issue/references/release-gate.md
+++ b/.claude/skills/iterate-one-issue/references/release-gate.md
@@ -28,6 +28,20 @@ Pre-conditions: Step 2 returned `achieved`, `DIFF_CLASS=code`, `release_gate.sta
 
 #### 9a.1 — Trigger the workflow
 
+**Refuse to dispatch against the default branch.** `$BRANCH` MUST be the iterate branch (`feature/*`, `fix/*`, `chore/*`, `auto-improve/*`, or a `release/*` mirror). Dispatching with `--ref main` (or empty / non-iterate) causes the gate to validate the wrong tree — its result is meaningless to the PR. Guard locally **before** dispatching:
+
+```bash
+case "$BRANCH" in
+  ''|main|master)
+    echo "[step9a] refusing — \$BRANCH must be an iterate branch, got '$BRANCH'"; exit 1;;
+  feature/*|fix/*|chore/*|auto-improve/*|release/*) ;;
+  *)
+    echo "[step9a] refusing — \$BRANCH '$BRANCH' does not match iterate-branch allowlist (feature|fix|chore|auto-improve|release)"; exit 1;;
+esac
+```
+
+The workflow itself enforces the same rule server-side (`validate-dispatch` job in `.github/workflows/release-gate.yml`) — if you bypass the local check, GitHub fails the run within ~5 s. The local guard exists so we don't burn a runner slot on a guaranteed failure.
+
 Capture the dispatch timestamp **before** triggering, to disambiguate our run from any concurrent workflow_dispatch on the branch (second iterate session, manual UI, prior failed dispatch within the same minute):
 
 ```bash
@@ -36,7 +50,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 gh workflow run release-gate.yml --ref "$BRANCH" -f ref="$BRANCH"
 ```
 
-(`--ref` selects the workflow file revision; `-f ref=…` is the input `actions/checkout` validates against — see `${{ inputs.ref || github.ref }}` in the workflow. Typically match for an iterate branch.)
+**Both** `--ref` and `-f ref=` MUST be `$BRANCH`. `--ref` selects which copy of the workflow file GitHub reads; `-f ref=` is the input `actions/checkout` consumes (see `${{ inputs.ref || github.ref }}` in the workflow). Mismatching them — e.g. `--ref main -f ref=$BRANCH` — runs the main-tip workflow definition against your branch's tree, which silently breaks if the workflow file changed on the iterate branch. Always pass the same value.
 
 `gh workflow run` does not print the run ID. Query with **timestamp + headSha disambiguation**, not blind `--limit 1`:
 
@@ -142,8 +156,13 @@ On FAIL:
    git commit -m "fix(iter-release): <summary>"
    git push
    ```
-4. Re-dispatch against the new tip — same disambiguation as 9a.1:
+4. Re-dispatch against the new tip — same disambiguation **and `$BRANCH` guard** as 9a.1:
    ```bash
+   case "$BRANCH" in
+     ''|main|master) echo "[step9c] refusing — \$BRANCH must be an iterate branch, got '$BRANCH'"; exit 1;;
+     feature/*|fix/*|chore/*|auto-improve/*|release/*) ;;
+     *) echo "[step9c] refusing — \$BRANCH '$BRANCH' does not match iterate-branch allowlist"; exit 1;;
+   esac
    DISPATCHED_AT_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
    HEAD_SHA=$(git rev-parse HEAD)
    gh workflow run release-gate.yml --ref "$BRANCH" -f ref="$BRANCH"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -23,10 +23,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Pre-flight: refuse default-branch / non-iterate workflow_dispatch ────
+  # Server-side guard against `iterate-one-issue` Step 9a dispatching the
+  # release gate against `main` (or empty/non-iterate refs). When that
+  # happens, the gate validates the wrong tree and the PR's "release-gate
+  # dispatched" comment is misleading. This job fails the whole run within
+  # ~5 s so the agent's poller sees a hard failure it cannot misinterpret.
+  #
+  # On `pull_request`, the guard step is a no-op — the job exists only so
+  # downstream jobs have a single `needs:` target on both event types.
+  validate-dispatch:
+    name: Validate dispatch input
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse default-branch / empty / non-iterate dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF: ${{ inputs.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [ -z "$REF" ] || [ "$REF" = "main" ] || [ "$REF" = "master" ] || [ "$REF" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::release-gate refuses to validate '$REF' — workflow_dispatch must target an iterate branch (feature/*, fix/*, chore/*, auto-improve/*, release/*), not the default branch."
+            exit 1
+          fi
+          case "$REF" in
+            feature/*|fix/*|chore/*|auto-improve/*|release/*) ;;
+            *)
+              echo "::error::release-gate input.ref='$REF' does not match the iterate-branch prefix allowlist (feature|fix|chore|auto-improve|release). Refusing to dispatch."
+              exit 1
+              ;;
+          esac
+          echo "OK: dispatching release gate against '$REF'"
+
   # ── Cross-platform tests (Linux, Windows, macOS) ─────────────────────────
-  # All jobs run in parallel — no needs dependencies.
+  # All jobs run in parallel — no needs dependencies between them, but they
+  # all gate on validate-dispatch so a bad workflow_dispatch fails fast.
   test:
     name: Test (${{ matrix.name }})
+    needs: validate-dispatch
     if: startsWith(github.head_ref, 'release/') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -123,6 +157,7 @@ jobs:
   # x64 and macOS builds are already validated in CI.
   build-arm64:
     name: Build (windows-arm64)
+    needs: validate-dispatch
     if: startsWith(github.head_ref, 'release/') || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
 
@@ -171,6 +206,7 @@ jobs:
   # a desktop session, so this works without extra setup.
   native-e2e:
     name: Native E2E (Windows)
+    needs: validate-dispatch
     if: startsWith(github.head_ref, 'release/') || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
 

--- a/AGENTIC_DEVELOPMENT.md
+++ b/AGENTIC_DEVELOPMENT.md
@@ -46,13 +46,15 @@ Two terminals (preferably two git worktrees or separate checkouts). Both loops r
 
 Terminal A (fix loop):
 ```
-/iterate-loop
+/iterate-loop --pipeline
 ```
 
-PRs land in `ready-for-review` for human merge. To have the loop squash-merge each green PR automatically, pass `--auto-merge`:
+`--pipeline` overlaps the previous round's release-gate (~18 min on GitHub) with the next round's local work, saving roughly 18 min of wall-clock per round. Without it the loop sits idle polling release-gate inline. The flag is opt-in because the pipelined scheduler creates a `git worktree` per round; on Windows worktrees occasionally hit `notify`/`dubious-ownership` issues, in which case the loop logs `[iterate-loop] worktree create failed for #N — falling back to sequential for this round` and continues. Omit `--pipeline` only if you're actively debugging worktree behaviour. Spec: [`.claude/skills/iterate-loop/references/pipeline.md`](.claude/skills/iterate-loop/references/pipeline.md).
+
+PRs land in `ready-for-review` for human merge. To have the loop squash-merge each green PR automatically, add `--auto-merge`:
 
 ```
-/iterate-loop --auto-merge
+/iterate-loop --pipeline --auto-merge
 ```
 
 (Choose merge policy up-front — there's no mid-run toggle. `--auto-merge` only fires on `Done-Achieved` rounds; `Done-Blocked`/`Done-TimedOut` PRs are always left for a human.)
@@ -87,7 +89,7 @@ Skills live in `.claude/skills/<name>/SKILL.md`. You invoke skills.
 
 | Skill | Use when |
 |---|---|
-| **`iterate-loop`** | Drain the backlog continuously; pair with `test-exploratory-loop`. Add `--auto-merge` to squash-merge each Done-Achieved PR. |
+| **`iterate-loop`** | Drain the backlog continuously; pair with `test-exploratory-loop`. Add `--pipeline` to overlap each round's release-gate poll (~18 min) with the next round's work. Add `--auto-merge` to squash-merge each Done-Achieved PR. |
 | **`iterate-one-issue`** | One issue, one freeform goal, or `--once` style runs |
 | **`test-exploratory-loop`** | Continuous dogfood, files new bugs (Windows only) |
 | **`test-exploratory-e2e`** | One round of dogfood (Windows only) |


### PR DESCRIPTION
## Summary

Three coupled fixes prompted by a release-gate run that silently validated main instead of the iterate branch tip (#93, run [24971595651](https://github.com/dryotta/mdownreview/actions/runs/24971595651)  head_branch=main, head_sha=33aaf7c, while the actual change was on `feature/issue-93-remove-open-default-app` at `f0cb5ec`).

### 1. Server-side guard (the durable fix)

elease-gate.yml gains a `validate-dispatch` job that fails `workflow_dispatch` runs within ~5 s if `inputs.ref` is empty, equals the default branch, or doesn't match the iterate-branch allowlist (`feature|fix|chore|auto-improve|release`). The three matrix jobs gain `needs: validate-dispatch`. On `pull_request` the guard step is a no-op.

This is the only line of defense the agent cannot misread or skip  earlier skill-text guards relied on the same fidelity that just failed.

### 2. Skill tightening

`iterate-one-issue/references/release-gate.md` 9a.1 + 9c re-dispatch:
- Local `case` guard mirrors the workflow's allowlist so we don't burn a runner slot on a guaranteed failure.
- Line 39's `typically match` hedge is replaced with a hard requirement that `--ref` and `-f ref=` both equal `\`. The hedge was the smoking gun for the original bug.

### 3. Documentation

`AGENTIC_DEVELOPMENT.md` now recommends `/iterate-loop --pipeline` as the default invocation (with the worktree-fallback caveat) and updates the skills table. Without `--pipeline` the loop sits idle polling release-gate (~18 min per round); the flag overlaps that with the next round's local work.

## Why three changes in one PR

They share a single root cause and need to land together: a workflow guard with no skill-text update would still let the agent waste cycles dispatching to `main`; a skill update with no workflow guard relies on the same agent fidelity that just failed; and the `--pipeline` doc nudge is what made me notice the bug (the loop was sequential and burning ~18 min/round).

## Verification

- `yaml.safe_load` parses the workflow.
- `--ref main` would now hit `validate-dispatch`: empty/main/master/default-branch all rejected; non-matching prefixes rejected with a distinct error message.
- `pull_request` runs unaffected  the guard step has `if: github.event_name == 'workflow_dispatch'` so it's a no-op on PRs, but downstream jobs still gate on `needs: validate-dispatch` (which runs successfully on every event).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>