### PR TITLE
fix(#140): validator must classify missing-prerequisite native artifact as SKIPPED, not FAIL

### DIFF
--- a/.claude/agents/exe-implementation-validator.md
+++ b/.claude/agents/exe-implementation-validator.md
@@ -10,6 +10,20 @@ description: Validation gate — runs checks in order, reports verbatim output, 
 - `src-tauri/src/` touched but `cargo test` skipped → invalid.
 - Report verbatim command output (no paraphrase).
 
+**Classification: PASS | FAIL | SKIPPED (issue #140).**
+
+A failing exit code is NOT automatically `FAIL`. Reclassify as `SKIPPED` when ALL of the following hold:
+1. The failure root cause is a **missing-prerequisite artifact** that the iterate runner does not build (e.g. NSIS installer bundle for `e2e/native/installer.spec.ts`, signed `.app` for `e2e/native/macos-*.spec.ts`, missing CLI shim binary). Look for verbatim error tokens like `No NSIS bundle dir found`, `Could not find packaged binary`, `bundle artifact not present`, `signed binary missing`, `app bundle not built`.
+2. The diff under test does NOT touch any of the relevant source paths for that artifact:
+   - NSIS installer ⇒ `src-tauri/installer/**`, `src-tauri/tauri.conf.json` `bundle.nsis.*`
+   - macOS DMG/app ⇒ `src-tauri/dmg/**`, `src-tauri/tauri.conf.json` `bundle.macOS.*`
+   - CLI shim ⇒ `src-tauri/src/commands/cli_shim*`, `src-tauri/binaries/**`
+3. The check that produced the failing exit code passed everything else (e.g. `13 passed, 1 failed` where the 1 failed is the prerequisite-error case above). Use the test-runner's per-test breakdown, not the overall exit code, to decide.
+
+When all three hold, report `SKIPPED — <command> — missing prerequisite artifact <X>; diff does not touch <Y>` and DO NOT mark the overall verdict `FAIL` for that check alone. Cite the exact stderr token that triggered the classification so the orchestrator can audit the decision.
+
+NEVER emit a hedging payload like `summary: "exit 1 — 13 passed, 1 failed"` paired with `note: "treat as SKIPPED if installer artifact is out of scope"` — the validator IS the chokepoint that makes that determination; do not push the choice upstream. If you can't confidently classify, mark `FAIL` and explain why the criteria above don't match.
+
 **Sequence (stop at first FAIL):**
 1. `npx tsc --noEmit 2>&1` — any error = FAIL.
 2. `cargo test --manifest-path src-tauri/Cargo.toml 2>&1` (only if `.rs` changed).

--- a/src/__tests__/validator-skipped-classification.test.ts
+++ b/src/__tests__/validator-skipped-classification.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Issue #140 — contract test: exe-implementation-validator must classify
+ * a failing exit code as SKIPPED (not FAIL) when the only failing check
+ * is a missing-prerequisite artifact (NSIS bundle, signed .app, CLI shim
+ * binary) AND the diff under test doesn't touch the relevant installer
+ * source paths.
+ *
+ * Motivating regression: feature-issue-90-sticky-viewer-toolbar-iter-1
+ * retro shows the validator emitting the contradictory payload
+ *   summary: "exit 1 — 13 passed, 1 failed"
+ *   note:    "treat as SKIPPED if installer artifact is out of scope"
+ * — pushing the classification choice upstream and forcing the
+ * orchestrator skill to re-derive ground truth on every iterate run.
+ */
+
+const VALIDATOR_PATH = resolve(
+  __dirname,
+  "../../.claude/agents/exe-implementation-validator.md",
+);
+const VALIDATOR = readFileSync(VALIDATOR_PATH, "utf8");
+
+describe("exe-implementation-validator SKIPPED classification (issue #140)", () => {
+  it("declares an explicit Classification: PASS | FAIL | SKIPPED section", () => {
+    expect(VALIDATOR).toMatch(
+      /Classification:\s*PASS\s*\|\s*FAIL\s*\|\s*SKIPPED.*#140/,
+    );
+  });
+
+  it("rules out the 'failing exit code = FAIL' shortcut", () => {
+    expect(VALIDATOR).toMatch(/failing exit code is NOT automatically `?FAIL`?/);
+  });
+
+  it("names the prerequisite-artifact failure modes (NSIS, signed .app, CLI shim)", () => {
+    expect(VALIDATOR.toLowerCase()).toContain("nsis");
+    expect(VALIDATOR.toLowerCase()).toContain("signed");
+    expect(VALIDATOR.toLowerCase()).toContain("cli shim");
+  });
+
+  it("cites the verbatim error tokens the validator should grep for", () => {
+    // The retro pinpoints "No NSIS bundle dir found" — that exact token must
+    // appear so a future validator agent grep matches the runtime output.
+    expect(VALIDATOR).toContain("No NSIS bundle dir found");
+  });
+
+  it("requires the diff to NOT touch the installer source paths to qualify", () => {
+    expect(VALIDATOR).toContain("src-tauri/installer/");
+    expect(VALIDATOR).toMatch(/src-tauri\/dmg\/|bundle\.macOS/);
+    expect(VALIDATOR).toMatch(/cli_shim/);
+  });
+
+  it("requires the per-test breakdown (not just exit code) to drive classification", () => {
+    expect(VALIDATOR).toMatch(/per-test breakdown/i);
+    expect(VALIDATOR).toMatch(/13 passed, 1 failed|passed.*failed/);
+  });
+
+  it("forbids the hedging-payload anti-pattern called out in the retro", () => {
+    expect(VALIDATOR.toLowerCase()).toContain("never emit a hedging payload");
+    expect(VALIDATOR).toContain("treat as SKIPPED if installer artifact is out of scope");
+    expect(VALIDATOR.toLowerCase()).toContain("do not push the choice upstream");
+  });
+
+  it("requires citing the exact stderr token that triggered SKIPPED so the orchestrator can audit", () => {
+    expect(VALIDATOR.toLowerCase()).toContain("cite the exact stderr token");
+  });
+});


### PR DESCRIPTION
Resolves #140.

pre-flight: n/a -- no new IPC surface (this PR only edits the exe-implementation-validator agent prompt + adds contract test).