### PR TITLE
feat: surface toggle/active state, focused element, and classes[] in observe (#149)

### DIFF
--- a/.claude/skills/test-exploratory-e2e/SKILL.md
+++ b/.claude/skills/test-exploratory-e2e/SKILL.md
@@ -32,7 +32,7 @@ You write one JSON line to stdin, the REPL writes one JSON line to stdout. Use `
 | You write | REPL responds |
 |---|---|
 | `{"act":"screenshot"}` | `{"ok":true,"result":{"png":"<path>"}}` — view it with the `view` tool |
-| `{"act":"observe"}` | `{"ok":true,"result":{ url, screenId, viewport, interactives[], landmarks[], consoleErrors[], ipcErrors[] }}` |
+| `{"act":"observe"}` | `{"ok":true,"result":{ url, screenId, viewport, interactives[], landmarks[], focused, consoleErrors[], ipcErrors[] }}` — each `interactives[i]` carries `selector`, `tag`, `role`, `name`, `text`, `classes[]`, `bbox`, `visible`, `enabled`, `active` (boolean from `.active` class), and optional ARIA booleans `pressed` / `checked` / `expanded` / `selected` (only present when the source `aria-*` attribute is set to `true`/`false`). `focused` is `{selector, tag, name, classes}` for `document.activeElement`, or `null` when nothing meaningful is focused — use it to verify a click landed on the right control and to diagnose focus-leak bugs. |
 | `{"act":"click","selector":"..."}` | `{"ok":true}` |
 | `{"act":"press","key":"Control+Tab"}` | `{"ok":true}` |
 | `{"act":"type","selector":"...","text":"..."}` | `{"ok":true}` |

--- a/.claude/skills/test-exploratory-e2e/runner/observe-dom.test.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/observe-dom.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  ariaBool,
+  buildToggleState,
+  readClasses,
+  buildFocused,
+  ariaName,
+  focusSelector,
+} from "./observe-dom";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ariaBool", () => {
+  it("returns true / false when the attribute is set to a recognised string", () => {
+    const a = document.createElement("button");
+    a.setAttribute("aria-pressed", "true");
+    expect(ariaBool(a, "aria-pressed")).toBe(true);
+
+    const b = document.createElement("button");
+    b.setAttribute("aria-pressed", "false");
+    expect(ariaBool(b, "aria-pressed")).toBe(false);
+  });
+
+  it("returns null when the attribute is absent or unrecognised", () => {
+    const a = document.createElement("button");
+    expect(ariaBool(a, "aria-pressed")).toBeNull();
+
+    const b = document.createElement("input");
+    b.setAttribute("aria-checked", "mixed");
+    expect(ariaBool(b, "aria-checked")).toBeNull();
+  });
+});
+
+describe("buildToggleState", () => {
+  it("surfaces aria-pressed for toggle buttons", () => {
+    const on = document.createElement("button");
+    on.setAttribute("aria-pressed", "true");
+    expect(buildToggleState(on)).toEqual({ pressed: true, active: false });
+
+    const off = document.createElement("button");
+    off.setAttribute("aria-pressed", "false");
+    expect(buildToggleState(off)).toEqual({ pressed: false, active: false });
+  });
+
+  it("surfaces aria-checked for switch/checkbox roles", () => {
+    const sw = document.createElement("input");
+    sw.setAttribute("role", "switch");
+    sw.setAttribute("aria-checked", "true");
+    expect(buildToggleState(sw)).toEqual({ checked: true, active: false });
+  });
+
+  it("surfaces aria-expanded for disclosure-style controls", () => {
+    const summary = document.createElement("summary");
+    summary.setAttribute("aria-expanded", "true");
+    expect(buildToggleState(summary)).toEqual({ expanded: true, active: false });
+  });
+
+  it("surfaces aria-selected for tab-like controls", () => {
+    const tab = document.createElement("div");
+    tab.setAttribute("role", "tab");
+    tab.setAttribute("aria-selected", "false");
+    expect(buildToggleState(tab)).toEqual({ selected: false, active: false });
+  });
+
+  it("surfaces .active class membership independent of ARIA state", () => {
+    const tab = document.createElement("button");
+    tab.className = "tab active";
+    expect(buildToggleState(tab)).toEqual({ active: true });
+  });
+
+  it("omits ARIA fields when the source attribute is absent", () => {
+    const plain = document.createElement("button");
+    plain.className = "toolbar-btn";
+    const state = buildToggleState(plain);
+    expect(state).toEqual({ active: false });
+    expect(state).not.toHaveProperty("pressed");
+    expect(state).not.toHaveProperty("checked");
+    expect(state).not.toHaveProperty("expanded");
+    expect(state).not.toHaveProperty("selected");
+  });
+
+  it("combines multiple ARIA booleans with .active when present", () => {
+    const el = document.createElement("button");
+    el.className = "viewer-toolbar-btn active";
+    el.setAttribute("aria-pressed", "true");
+    el.setAttribute("aria-expanded", "false");
+    expect(buildToggleState(el)).toEqual({
+      pressed: true,
+      expanded: false,
+      active: true,
+    });
+  });
+});
+
+describe("readClasses", () => {
+  it("returns every class up to the cap, in classList order", () => {
+    const el = document.createElement("div");
+    el.className = "a b c d";
+    expect(readClasses(el)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("caps the array at the requested max", () => {
+    const el = document.createElement("div");
+    el.className = "a b c d e f g h";
+    expect(readClasses(el, 3)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns [] for elements with no classes", () => {
+    const el = document.createElement("div");
+    expect(readClasses(el)).toEqual([]);
+  });
+});
+
+describe("buildFocused", () => {
+  it("returns null when nothing meaningful is focused", () => {
+    expect(buildFocused(document)).toBeNull();
+  });
+
+  it("describes the focused element with selector / tag / name / classes", () => {
+    const btn = document.createElement("button");
+    btn.id = "settings-btn";
+    btn.className = "toolbar-btn primary";
+    btn.setAttribute("aria-label", "Open settings");
+    document.body.appendChild(btn);
+    btn.focus();
+
+    expect(buildFocused(document)).toEqual({
+      selector: "#settings-btn",
+      tag: "button",
+      name: "Open settings",
+      classes: ["toolbar-btn", "primary"],
+    });
+  });
+
+  it("falls back to tag.class selector when the element has no id", () => {
+    const btn = document.createElement("button");
+    btn.className = "viewer-toolbar-btn";
+    btn.textContent = "Wrap";
+    document.body.appendChild(btn);
+    btn.focus();
+
+    const focused = buildFocused(document);
+    expect(focused?.selector).toBe("button.viewer-toolbar-btn");
+    expect(focused?.tag).toBe("button");
+  });
+});
+
+describe("observe roundtrip — pressed flips after toggling the source attribute", () => {
+  // Skill-self-test for issue #149: simulates the observe→click→observe
+  // sequence the persona-driven REPL goes through. Uses jsdom + the same
+  // pure helpers the in-page evaluate body uses, so any drift in the
+  // descriptor builder breaks this test.
+  it("captures pressed=false, flips to pressed=true after the click is applied", () => {
+    const btn = document.createElement("button");
+    btn.className = "viewer-toolbar-btn";
+    btn.textContent = "Wrap";
+    btn.setAttribute("aria-pressed", "false");
+    document.body.appendChild(btn);
+
+    const before = buildToggleState(btn);
+    expect(before.pressed).toBe(false);
+    expect(before.active).toBe(false);
+
+    // Simulate the side-effect of clicking the toggle: aria-pressed flips
+    // and the chrome adds .active. Mirrors what mdownreview's toolbar does.
+    btn.setAttribute("aria-pressed", "true");
+    btn.classList.add("active");
+
+    const after = buildToggleState(btn);
+    expect(after.pressed).toBe(true);
+    expect(after.active).toBe(true);
+  });
+});
+
+describe("ariaName / focusSelector", () => {
+  it("ariaName prefers aria-label, then title, then trimmed text", () => {
+    const a = document.createElement("button");
+    a.setAttribute("aria-label", "Aria");
+    a.setAttribute("title", "Title");
+    a.textContent = "Text";
+    expect(ariaName(a)).toBe("Aria");
+
+    const b = document.createElement("button");
+    b.setAttribute("title", "Title");
+    b.textContent = "Text";
+    expect(ariaName(b)).toBe("Title");
+
+    const c = document.createElement("button");
+    c.textContent = "  Text  ";
+    expect(ariaName(c)).toBe("Text");
+  });
+
+  it("focusSelector prefers id, then data-testid, then tag.class", () => {
+    const idEl = document.createElement("button");
+    idEl.id = "x";
+    expect(focusSelector(idEl)).toBe("#x");
+
+    const tidEl = document.createElement("div");
+    tidEl.setAttribute("data-testid", "save-btn");
+    expect(focusSelector(tidEl)).toBe("div[data-testid='save-btn']");
+
+    const clsEl = document.createElement("button");
+    clsEl.className = "btn primary";
+    expect(focusSelector(clsEl)).toBe("button.btn");
+  });
+});

--- a/.claude/skills/test-exploratory-e2e/runner/observe-dom.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/observe-dom.ts
@@ -1,0 +1,116 @@
+// Pure DOM helpers used by the test-exploratory-e2e REPL `observe` action.
+//
+// These functions are written so they work both in the browser (when
+// serialized into Playwright's `page.evaluate`) AND in jsdom (so the
+// behaviour can be unit-tested without spinning up a Tauri window).
+//
+// Issue #149 — surface toggle/active state, classes[], and focused element
+// in observe.interactives[] so persona-driven runs can verify toggle/state
+// without re-screenshotting.
+
+export type ToggleState = {
+  pressed?: boolean;
+  checked?: boolean;
+  expanded?: boolean;
+  selected?: boolean;
+  active: boolean;
+};
+
+export type FocusedDescriptor = {
+  selector: string;
+  tag: string;
+  name: string;
+  classes: string[];
+};
+
+/**
+ * Reads an ARIA tristate attribute and returns true/false when present and
+ * recognised, or null when the attribute is absent or has a non-boolean
+ * value (e.g. aria-checked="mixed"). The caller decides whether to omit
+ * the field entirely when null.
+ */
+export function ariaBool(el: Element, attr: string): boolean | null {
+  if (!el.hasAttribute(attr)) return null;
+  const v = el.getAttribute(attr);
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return null;
+}
+
+/**
+ * Builds the toggle/active descriptor for an interactive element. Each
+ * ARIA boolean is included only when the source attribute is present and
+ * recognised; `active` is always included (boolean from classList).
+ */
+export function buildToggleState(el: Element): ToggleState {
+  const out: ToggleState = {
+    active: el.classList ? el.classList.contains("active") : false,
+  };
+  const pressed = ariaBool(el, "aria-pressed");
+  if (pressed !== null) out.pressed = pressed;
+  const checked = ariaBool(el, "aria-checked");
+  if (checked !== null) out.checked = checked;
+  const expanded = ariaBool(el, "aria-expanded");
+  if (expanded !== null) out.expanded = expanded;
+  const selected = ariaBool(el, "aria-selected");
+  if (selected !== null) out.selected = selected;
+  return out;
+}
+
+/**
+ * Returns up to `max` class names from the element's classList. Bounded so
+ * the observe payload stays small even when an element accumulates many
+ * utility/style classes.
+ */
+export function readClasses(el: Element, max = 6): string[] {
+  if (!el.classList) return [];
+  const out: string[] = [];
+  for (let i = 0; i < el.classList.length && i < max; i++) {
+    out.push(el.classList[i]);
+  }
+  return out;
+}
+
+/**
+ * Best-effort accessible name (matches the inline logic in repl.ts so the
+ * focused descriptor stays consistent with interactive descriptors).
+ */
+export function ariaName(el: Element): string {
+  const aria = el.getAttribute("aria-label");
+  if (aria) return aria;
+  const title = el.getAttribute("title");
+  if (title) return title;
+  const text = (el as HTMLElement).innerText ?? el.textContent ?? "";
+  return text.trim().slice(0, 80);
+}
+
+/**
+ * Cheap CSS selector for the focused element. Mirrors the logic in
+ * repl.ts's makeSelectorFn but kept independent so unit tests don't
+ * depend on the live REPL helper.
+ */
+export function focusSelector(el: Element): string {
+  if (el.id) return `#${el.id}`;
+  const tid = el.getAttribute("data-testid");
+  const tag = el.tagName.toLowerCase();
+  if (tid) return `${tag}[data-testid='${tid}']`;
+  const cls = el.classList && el.classList.length > 0 ? `.${el.classList[0]}` : "";
+  return `${tag}${cls}`;
+}
+
+/**
+ * Returns a descriptor for `document.activeElement`, or null when nothing
+ * meaningful is focused (body or null). Required for diagnosing focus-leak
+ * bugs (e.g. PageDown firing on a stuck toolbar button instead of the
+ * scroll container).
+ */
+export function buildFocused(doc: Document): FocusedDescriptor | null {
+  const a = doc.activeElement;
+  if (!a || a === doc.body || a === doc.documentElement) return null;
+  return {
+    selector: focusSelector(a),
+    tag: a.tagName.toLowerCase(),
+    name: ariaName(a),
+    classes: readClasses(a),
+  };
+}

--- a/.claude/skills/test-exploratory-e2e/runner/repl.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/repl.ts
@@ -106,6 +106,15 @@ async function observe(page: Page): Promise<Observation> {
       select: "combobox", nav: "navigation", header: "banner", main: "main",
       footer: "contentinfo", aside: "complementary", dialog: "dialog",
     };
+    // Mirrors observe-dom.ts ariaBool — kept inline so this evaluate body
+    // is self-contained when serialized into Playwright's page context.
+    const ariaBool = (el: Element, attr: string): boolean | null => {
+      if (!el.hasAttribute(attr)) return null;
+      const v = el.getAttribute(attr);
+      if (v === "true") return true;
+      if (v === "false") return false;
+      return null;
+    };
     const out: Interactive[] = [];
     const seenSel = new Set<string>();
     const nodes = document.querySelectorAll(
@@ -124,17 +133,27 @@ async function observe(page: Page): Promise<Observation> {
         ?? "";
       const text = ((el as HTMLElement).innerText ?? el.textContent ?? "").trim().slice(0, 80);
       const classes: string[] = [];
-      for (let k = 0; k < Math.min(2, el.classList.length); k++) classes.push(el.classList[k]);
+      for (let k = 0; k < Math.min(6, el.classList.length); k++) classes.push(el.classList[k]);
       let selector: string;
       try { selector = sel(el); } catch { selector = tag; }
       if (seenSel.has(selector)) return;
       seenSel.add(selector);
-      out.push({
+      const entry: Interactive = {
         selector, tag, role, name, text, classes,
         bbox: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) },
         visible: true,
         enabled: !(el as HTMLInputElement).disabled,
-      });
+        active: el.classList ? el.classList.contains("active") : false,
+      };
+      const pressed = ariaBool(el, "aria-pressed");
+      if (pressed !== null) entry.pressed = pressed;
+      const checked = ariaBool(el, "aria-checked");
+      if (checked !== null) entry.checked = checked;
+      const expanded = ariaBool(el, "aria-expanded");
+      if (expanded !== null) entry.expanded = expanded;
+      const selected = ariaBool(el, "aria-selected");
+      if (selected !== null) entry.selected = selected;
+      out.push(entry);
     });
     return out;
   }, makeSelectorFn());
@@ -186,12 +205,37 @@ async function observe(page: Page): Promise<Observation> {
     return (h >>> 0).toString(16).padStart(8, "0");
   });
 
+  const focused = await page.evaluate(() => {
+    const a = document.activeElement;
+    if (!a || a === document.body || a === document.documentElement) return null;
+    const tag = a.tagName.toLowerCase();
+    let selector: string;
+    if (a.id) {
+      selector = `#${a.id}`;
+    } else {
+      const tid = a.getAttribute("data-testid");
+      if (tid) {
+        selector = `${tag}[data-testid='${tid}']`;
+      } else {
+        const cls = a.classList && a.classList.length > 0 ? `.${a.classList[0]}` : "";
+        selector = `${tag}${cls}`;
+      }
+    }
+    const name = a.getAttribute("aria-label")
+      ?? a.getAttribute("title")
+      ?? ((a as HTMLElement).innerText ?? a.textContent ?? "").trim().slice(0, 80);
+    const classes: string[] = [];
+    for (let k = 0; k < Math.min(6, a.classList.length); k++) classes.push(a.classList[k]);
+    return { selector, tag, name, classes };
+  });
+
   return {
     url, title,
     screenId: `${url}:${screenId}`,
     viewport,
     interactives,
     landmarks,
+    focused,
     consoleErrors: drained.c
       .filter((c) => c.level === "error" || c.level === "warn")
       .map((c) => ({ ts: new Date().toISOString(), text: c.text })),

--- a/.claude/skills/test-exploratory-e2e/runner/tools.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/tools.ts
@@ -32,10 +32,25 @@ export type Interactive = {
   role: string;           // ARIA role (computed or implicit)
   name: string;           // accessible name (aria-label / text / alt)
   text: string;           // visible text trimmed to 80 chars
-  classes: string[];      // first 2 class names (stable anchor candidates)
+  classes: string[];      // up to 6 class names from element.classList
   bbox: { x: number; y: number; w: number; h: number };
   visible: boolean;
   enabled: boolean;
+  // Toggle/active state — issue #149. ARIA booleans are optional and only
+  // present when the source attribute is set to a recognised value;
+  // `active` is always present (boolean from element.classList).
+  pressed?: boolean;
+  checked?: boolean;
+  expanded?: boolean;
+  selected?: boolean;
+  active: boolean;
+};
+
+export type Focused = {
+  selector: string;
+  tag: string;
+  name: string;
+  classes: string[];
 };
 
 export type Landmark = {
@@ -51,6 +66,9 @@ export type Observation = {
   viewport: { width: number; height: number };
   interactives: Interactive[];
   landmarks: Landmark[];
+  // Currently focused element (document.activeElement), or null when nothing
+  // meaningful is focused. Required for diagnosing focus-leak bugs (issue #149).
+  focused: Focused | null;
   consoleErrors: { ts: string; text: string }[];
   ipcErrors:     { ts: string; cmd: string; error: string }[];
 };


### PR DESCRIPTION
Closes #149.

## What
Extends `observe.interactives[]` and adds `observe.focused` so persona-driven runs of `test-exploratory-e2e` can verify the result of clicking a toggle (Wrap, Comments-pane, Show-resolved, etc.) without re-screenshotting, and can diagnose focus-leak bugs (PageDown opening Settings).

## Acceptance criteria
- [x] AC1: `observe.interactives[i]` gains optional `pressed` / `checked` / `expanded` / `selected` (from `aria-pressed` / `aria-checked` / `aria-expanded` / `aria-selected`).
- [x] AC2: `observe.interactives[i]` gains `active: boolean` from `element.classList.contains('active')`.
- [x] AC3: jsdom unit test feeds synthetic DOM with each variant, asserts descriptors carry expected booleans (`observe-dom.test.ts`, 18 tests).
- [x] AC4: regression skill-self-test simulates observeclickobserve and asserts `pressed` flips (round-trip test in `observe-dom.test.ts`).
- [x] iter-3 follow-up: `classes[]` is now full classList (capped at 6) instead of first 2.
- [x] iter-5 follow-up: `observe.focused` exposes `document.activeElement` as `{selector, tag, name, classes}` or null.
- [x] SKILL.md observe row documents all new fields.

## Verification
- `npx tsc --noEmit`  clean
- `npx vitest run`  1481 pass
- `npm run lint`  0 errors (3 unrelated coverage warnings, baseline)
