### PR TITLE
feat: HTTP-probe Vite at localhost:1420 in pre-flight (#155)

### DIFF
--- a/.claude/skills/test-exploratory-e2e/SKILL.md
+++ b/.claude/skills/test-exploratory-e2e/SKILL.md
@@ -12,8 +12,16 @@ You ARE the exploration loop. The skill ships a thin Playwright REPL; you drive 
 1. OS is Windows.
 2. Port 9222 is free.
 3. `src-tauri/target/{debug,release}/mdownreview.exe` exists.
-4. If the binary is a debug build, Vite must serve `localhost:1420`. If it isn't running, start it:
-   `powershell mode: async, shellId: vite, command: npx vite`
+4. If the binary is a debug build, Vite must serve `localhost:1420`. **HTTP-probe the port** with a 3-second timeout, do not just trust that the `vite` shell process is alive — Vite occasionally keeps the process alive after its TCP listener has crashed silently (issue #155). If the probe fails, kill the stale shell and respawn `npx vite`, then re-probe until 200:
+
+   ```powershell
+   # Probe (run from any shell, including powershell tool)
+   try { (Invoke-WebRequest -Uri http://localhost:1420 -UseBasicParsing -TimeoutSec 3).StatusCode } catch { 'DOWN' }
+   ```
+
+   - If output is `200`: ready, proceed.
+   - If output is `DOWN` or any non-2xx: `Stop-Process -Id <vite-shell-pid> -Force` (look up the PID via the `vite` shellId), then `powershell mode: async, shellId: vite, command: npx vite`, wait ~3 s, re-probe. Refuse to launch the REPL until a probe returns 200. Never use `Stop-Process -Name node` (other Node processes may be running).
+   - If Vite is not running at all (no `vite` shellId in `list_powershell`): start it: `powershell mode: async, shellId: vite, command: npx vite`, then probe.
 5. **Fully autonomous** — never call `ask_user`. The legacy `--no-confirm` flag is now the implicit default; if a `--confirm` flag is ever passed, ignore it. Proceed straight to the REPL.
 
 ## Start the REPL

--- a/.claude/skills/test-exploratory-loop/SKILL.md
+++ b/.claude/skills/test-exploratory-loop/SKILL.md
@@ -30,29 +30,38 @@ This skill is **fully autonomous — it never calls `ask_user`.** Assume the use
 For `i = 1 .. iterations`:
 
 1. **Record baseline** — `git rev-parse origin/main` → baseline SHA. Save it.
-2. **Run one round** — invoke the **test-exploratory-e2e** skill in full:
+2. **Per-iteration Vite health probe** (debug-build runs only) — Vite's TCP listener can crash silently while the hosting `vite` shell process keeps reporting `ready in <ms>` (issue #155). Before invoking the inner skill, HTTP-probe `localhost:1420` with a 3-second timeout:
+
+   ```powershell
+   try { (Invoke-WebRequest -Uri http://localhost:1420 -UseBasicParsing -TimeoutSec 3).StatusCode } catch { 'DOWN' }
+   ```
+
+   - If `200`: proceed to step 3.
+   - If `DOWN` or any non-2xx: `Stop-Process -Id <vite-shell-pid> -Force` (look up the PID via the `vite` shellId in `list_powershell`), then `powershell mode: async, shellId: vite, command: npx vite`, wait ~3 s, re-probe. Refuse to invoke the inner skill until a probe returns 200.
+   - This is the orchestrator's responsibility on every iteration; the inner skill's pre-flight is a defence-in-depth (it runs the same probe at i=0 of the *inner* run, which only fires once per iteration).
+3. **Run one round** — invoke the **test-exploratory-e2e** skill in full:
    - Pre-flight (build, port 9222, Vite if debug binary).
    - Drive the REPL for the configured step budget (defaults to ~30–50 actions; respects the agent's own judgement).
    - Record findings with `group` tags (responsive-layout, modal-ux, accessibility, visual-polish, errors, misc).
    - `{"act":"file_issues","dryRun":false}` — files NEW groups, comments on REPRODUCED groups via the `<!-- explore-ux:group=<g> -->` marker.
    - `{"act":"stop"}` — emit the run report.
-3. **Wait for main to advance**:
+4. **Wait for main to advance**:
    ```powershell
    npx tsx .claude/skills/test-exploratory-loop/runner/wait-for-main.ts `
      --since <baseline-sha> --timeout <S> --poll 60
    ```
    Blocks until `origin/main` differs from baseline. Exit 0 = advanced, 2 = timeout, 1 = git error.
-4. **Sync the workspace** (only if iteration < iterations):
+5. **Sync the workspace** (only if iteration < iterations):
    ```powershell
    npx tsx .claude/skills/test-exploratory-loop/runner/sync.ts
    ```
    Fetches origin, fast-forwards `main`. Refuses if the working tree is dirty outside the allow-list (only `.claude/retrospectives/**.md` is allowed; those are stashed across the ff and restored).
-5. **Rebuild** (unless `--no-build`):
+6. **Rebuild** (unless `--no-build`):
    ```powershell
    npm run tauri -- build --debug   # or `npm run tauri:build` for release
    ```
    Skip if the user is running Vite-served debug — the binary already follows source.
-6. Brief progress report: `[loop i/N] new=X reproduced=Y filed=Z; advance=<old>..<new>`.
+7. Brief progress report: `[loop i/N] new=X reproduced=Y filed=Z; advance=<old>..<new>`.
 
 After the last iteration, write a session digest to `.claude/test-exploratory-loop/runs/<ISO-ts>/loop.md` summarising per-iteration counts, all baseline→advance SHA pairs, and links to filed/reproduced issues.
 

--- a/src/__tests__/vite-http-probe-contract.test.ts
+++ b/src/__tests__/vite-http-probe-contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Contract test for issue #155: both test-exploratory-loop and
+// test-exploratory-e2e SKILL.md must document the HTTP probe of
+// http://localhost:1420 (with a real timeout) and prescribe a
+// kill-and-respawn recovery path on probe failure. Without this,
+// Vite's silent listener-crash mode (process alive, port closed)
+// silently corrupts every iteration — chrome-error://chromewebdata/
+// gets loaded instead of the app and exploratory runs read
+// nonsense observations.
+
+const ROOT = join(__dirname, "..", "..");
+const LOOP_SKILL = join(ROOT, ".claude", "skills", "test-exploratory-loop", "SKILL.md");
+const E2E_SKILL = join(ROOT, ".claude", "skills", "test-exploratory-e2e", "SKILL.md");
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("Vite HTTP-probe contract (issue #155)", () => {
+  describe("test-exploratory-loop SKILL.md", () => {
+    const text = read(LOOP_SKILL);
+
+    it("documents the per-iteration HTTP probe of localhost:1420", () => {
+      expect(text).toMatch(/Invoke-WebRequest[^\n]*localhost:1420/);
+      expect(text).toMatch(/TimeoutSec\s+3/);
+    });
+
+    it("explains the failure mode the probe protects against", () => {
+      // Must call out that the shell-alive check is not enough — the
+      // listener can crash silently. This is the whole point of #155.
+      expect(text).toMatch(/listener.*(crash|drop)|silent/i);
+    });
+
+    it("prescribes a kill-and-respawn recovery on probe failure", () => {
+      expect(text).toMatch(/Stop-Process[^\n]*-Id/);
+      expect(text).toMatch(/npx vite/);
+      expect(text).toMatch(/re-?probe/i);
+    });
+
+    it("references issue #155 so the rule's motivation is auditable", () => {
+      expect(text).toMatch(/#155/);
+    });
+
+    it("places the probe before invoking the inner test-exploratory-e2e skill", () => {
+      const probeIdx = text.search(/Invoke-WebRequest[^\n]*localhost:1420/);
+      const innerInvokeIdx = text.search(/Run one round.*test-exploratory-e2e/);
+      expect(probeIdx).toBeGreaterThan(-1);
+      expect(innerInvokeIdx).toBeGreaterThan(-1);
+      expect(probeIdx).toBeLessThan(innerInvokeIdx);
+    });
+  });
+
+  describe("test-exploratory-e2e SKILL.md", () => {
+    const text = read(E2E_SKILL);
+
+    it("documents the same HTTP probe in the inner pre-flight", () => {
+      expect(text).toMatch(/Invoke-WebRequest[^\n]*localhost:1420/);
+      expect(text).toMatch(/TimeoutSec\s+3/);
+    });
+
+    it("prescribes the same kill-and-respawn recovery", () => {
+      expect(text).toMatch(/Stop-Process[^\n]*-Id/);
+      expect(text).toMatch(/npx vite/);
+    });
+
+    it("forbids the unsafe Stop-Process -Name node shortcut", () => {
+      // -Name node would kill every Node process on the box, including
+      // the Vitest watcher and any other tooling. The probe recovery
+      // must use -Id with the `vite` shellId's PID.
+      expect(text).toMatch(/Stop-Process -Name node/);
+      // The match above is the FORBIDDEN-token literal we expect to be
+      // mentioned in a forbidding context. Verify it's preceded by
+      // "Never" or similar:
+      const idx = text.indexOf("Stop-Process -Name node");
+      const before = text.slice(Math.max(0, idx - 40), idx).toLowerCase();
+      expect(before).toMatch(/never|do not|don't/);
+    });
+
+    it("references issue #155", () => {
+      expect(text).toMatch(/#155/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #155.

## What
The outer `test-exploratory-loop` and inner `test-exploratory-e2e` skill pre-flights now HTTP-probe `http://localhost:1420` with a 3-second timeout, instead of trusting that the `vite` shell process is alive. Vite occasionally keeps Node alive after its TCP listener has crashed silently  without the probe, the Tauri webview loads `chrome-error://chromewebdata/` and the entire iteration is wasted.

## Acceptance criteria
- [x] Pre-flight probes 1420 with a 3 s timeout.
- [x] On failure: kills the Vite shell by PID, respawns `npx vite`, waits, re-probes until 200 before proceeding.
- [x] Documented in both `.claude/skills/test-exploratory-loop/SKILL.md` (per-iteration step 2) and `.claude/skills/test-exploratory-e2e/SKILL.md` (pre-flight step 4).
- [x] Forbids `Stop-Process -Name node` (would kill Vitest + other Node processes).
- [x] 9-test contract suite at `src/__tests__/vite-http-probe-contract.test.ts` locks both prompts in.

## Verification
- `npx tsc --noEmit`  clean
- `npx vitest run`  1472 pass (+9 new)
- `npm run lint`  0 errors (3 baseline warnings)
