### PR TITLE
feat: implement #94 - syntax highlighting for source view across common file types

### DIFF
--- a/src/components/viewers/__tests__/SourceView.test.tsx
+++ b/src/components/viewers/__tests__/SourceView.test.tsx
@@ -4,12 +4,21 @@ import { SourceView } from "../SourceView";
 
 vi.mock("@/lib/shiki", () => ({
   getSharedHighlighter: vi.fn().mockResolvedValue({
-    codeToHtml: vi.fn().mockImplementation((code: string) => {
+    codeToTokens: vi.fn().mockImplementation((code: string) => {
       const lines = code.split("\n");
-      const lineSpans = lines.map(() => '<span class="line">highlighted</span>').join("\n");
-      return `<pre class="shiki"><code>${lineSpans}</code></pre>`;
+      // No color/fontStyle → tokenToSpan emits the raw content (no <span>),
+      // so existing assertions on `.source-line-content` innerHTML still
+      // see the literal token text.
+      return {
+        tokens: lines.map(() => [{ content: "highlighted", color: "", fontStyle: 0 }]),
+        fg: "#000",
+        bg: "#fff",
+        themeName: "github-light",
+        rootStyle: undefined,
+        grammarState: undefined,
+      };
     }),
-    getLoadedLanguages: vi.fn().mockReturnValue([]),
+    getLoadedLanguages: vi.fn().mockReturnValue(["typescript", "python", "text"]),
     loadLanguage: vi.fn().mockResolvedValue(undefined),
   }),
 }));

--- a/src/hooks/__tests__/useSourceHighlighting.test.ts
+++ b/src/hooks/__tests__/useSourceHighlighting.test.ts
@@ -2,14 +2,29 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { useSourceHighlighting, escapeHtml } from "../useSourceHighlighting";
 
+// Helper: build a fake `codeToTokens` return shape from raw lines, optionally
+// emitting multi-token lines. Each token is `{ content, color, fontStyle }`.
+function makeTokens(lines: string[][], color = "#abc123") {
+  return {
+    tokens: lines.map((tokensInLine) =>
+      tokensInLine.map((content) => ({ content, color, fontStyle: 0 })),
+    ),
+    fg: "#000",
+    bg: "#fff",
+    themeName: "github-light",
+    rootStyle: undefined,
+    grammarState: undefined,
+  };
+}
+
 vi.mock("@/lib/shiki", () => ({
   getSharedHighlighter: vi.fn().mockResolvedValue({
-    codeToHtml: vi.fn().mockImplementation((code: string) => {
+    codeToTokens: vi.fn().mockImplementation((code: string) => {
       const lines = code.split("\n");
-      const lineSpans = lines.map(() => '<span class="line">highlighted</span>').join("\n");
-      return `<pre class="shiki"><code>${lineSpans}</code></pre>`;
+      // Single token per line by default — the simple shape for shape tests.
+      return makeTokens(lines.map((l) => [l || ""]));
     }),
-    getLoadedLanguages: vi.fn().mockReturnValue([]),
+    getLoadedLanguages: vi.fn().mockReturnValue(["typescript", "python"]),
     loadLanguage: vi.fn().mockResolvedValue(undefined),
   }),
 }));
@@ -23,7 +38,8 @@ describe("useSourceHighlighting", () => {
     await waitFor(() => {
       expect(result.current.highlightedLines).toHaveLength(3);
     });
-    expect(result.current.highlightedLines[0]).toContain("highlighted");
+    expect(result.current.highlightedLines[0]).toContain("line1");
+    expect(result.current.highlightedLines[0]).toContain("color:");
   });
 
   it("produces one highlighted line per source line", async () => {
@@ -34,8 +50,8 @@ describe("useSourceHighlighting", () => {
     await waitFor(() => {
       expect(result.current.highlightedLines).toHaveLength(2);
     });
-    expect(result.current.highlightedLines[0]).toContain("highlighted");
-    expect(result.current.highlightedLines[1]).toContain("highlighted");
+    expect(result.current.highlightedLines[0]).toContain("a");
+    expect(result.current.highlightedLines[1]).toContain("b");
   });
 
   it("updates highlighted lines when content changes", async () => {
@@ -72,6 +88,59 @@ describe("useSourceHighlighting", () => {
     });
   });
 
+  // Issue #94 regression — Bug RCA §5: a multi-token line MUST preserve
+  // every token in the rendered HTML. The previous regex-based extractor
+  // (`/<span class="line">(.*?)<\/span>/gs`) terminated at the first inner
+  // `</span>` and dropped trailing tokens silently. The replacement uses
+  // Shiki's structured `codeToTokens` output, so all tokens survive.
+  it("preserves every token on a multi-token line (regression for #94)", async () => {
+    const { getSharedHighlighter } = await import("@/lib/shiki");
+    const mockedGet = vi.mocked(getSharedHighlighter);
+    mockedGet.mockResolvedValueOnce({
+      codeToTokens: vi
+        .fn()
+        .mockReturnValue(
+          makeTokens([
+            // const x = 1; broken into five tokens
+            ["const", " ", "x", " = ", "1;"],
+          ]),
+        ),
+      getLoadedLanguages: vi.fn().mockReturnValue(["typescript"]),
+      loadLanguage: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Awaited<ReturnType<typeof import("@/lib/shiki").getSharedHighlighter>>);
+
+    const { result } = renderHook(() =>
+      useSourceHighlighting("const x = 1;", "/test.ts")
+    );
+
+    await waitFor(() => {
+      expect(result.current.highlightedLines).toHaveLength(1);
+    });
+
+    const line = result.current.highlightedLines[0];
+    // Each token becomes one `<span style="color:…">…</span>` — count
+    // the styled spans. Old regex would have dropped tokens 2–5.
+    const spanCount = (line.match(/<span style="color:/g) || []).length;
+    expect(spanCount).toBe(5);
+    expect(line).toContain("const");
+    expect(line).toContain("x");
+    expect(line).toContain("1;");
+  });
+
+  // Issue #94 — `text` lang (unknown extension) must still render content.
+  it("falls back to escaped plain text for unmapped file types", async () => {
+    const { result } = renderHook(() =>
+      useSourceHighlighting("plain <text> & more\nline2", "/foo.unknownext")
+    );
+
+    await waitFor(() => {
+      expect(result.current.highlightedLines).toHaveLength(2);
+    });
+    // HTML-escaped content, no Shiki spans (lang === "text" short-circuits).
+    expect(result.current.highlightedLines[0]).toBe("plain &lt;text&gt; &amp; more");
+    expect(result.current.highlightedLines[1]).toBe("line2");
+  });
+
   it("does not apply stale highlight results after rapid path changes", async () => {
     const { getSharedHighlighter } = await import("@/lib/shiki");
     const mockedGet = vi.mocked(getSharedHighlighter);
@@ -87,7 +156,9 @@ describe("useSourceHighlighting", () => {
           setTimeout(
             () =>
               resolve({
-                codeToHtml: vi.fn().mockReturnValue('<pre class="shiki"><code><span class="line">STALE_A_TS</span></code></pre>'),
+                codeToTokens: vi
+                  .fn()
+                  .mockReturnValue(makeTokens([["STALE_A_TS"]])),
                 getLoadedLanguages: vi.fn().mockReturnValue(["typescript"]),
                 loadLanguage: vi.fn().mockResolvedValue(undefined),
               } as unknown as Awaited<ReturnType<typeof import("@/lib/shiki").getSharedHighlighter>>),
@@ -97,7 +168,9 @@ describe("useSourceHighlighting", () => {
       }
       // Second call: fast highlighter — resolves immediately
       return Promise.resolve({
-        codeToHtml: vi.fn().mockReturnValue('<pre class="shiki"><code><span class="line">FRESH_B_PY</span></code></pre>'),
+        codeToTokens: vi
+          .fn()
+          .mockReturnValue(makeTokens([["FRESH_B_PY"]])),
         getLoadedLanguages: vi.fn().mockReturnValue(["python"]),
         loadLanguage: vi.fn().mockResolvedValue(undefined),
       } as unknown as Awaited<ReturnType<typeof import("@/lib/shiki").getSharedHighlighter>>);

--- a/src/hooks/useSourceHighlighting.ts
+++ b/src/hooks/useSourceHighlighting.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useDeferredValue } from "react";
-import { type BundledLanguage } from "shiki";
+import { type BundledLanguage, type ThemedToken } from "shiki";
 import { getSharedHighlighter } from "@/lib/shiki";
 import { getShikiLanguage } from "@/lib/file-types";
 import { useTheme } from "@/hooks/useTheme";
@@ -9,23 +9,68 @@ export function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+// Shiki's `fontStyle` is a bitmask: 1=italic, 2=bold, 4=underline, 8=strikethrough.
+// (See shiki/packages/core/src/types/tokens.ts — FontStyle enum.)
+const FS_ITALIC = 1;
+const FS_BOLD = 2;
+const FS_UNDERLINE = 4;
+const FS_STRIKETHROUGH = 8;
+
+// Render a single Shiki token as a coloured `<span>`. Mirrors what
+// `codeToHtml` produces per token (one span per token), but without the
+// surrounding `<pre>`/`<code>`/`<span class="line">` wrappers — those are
+// owned by the SourceView so each line becomes one row in the gutter table.
+function tokenToSpan(token: ThemedToken): string {
+  const styles: string[] = [];
+  if (token.color) styles.push(`color:${token.color}`);
+  if (token.bgColor) styles.push(`background-color:${token.bgColor}`);
+  if (token.fontStyle && token.fontStyle > 0) {
+    if (token.fontStyle & FS_ITALIC) styles.push("font-style:italic");
+    if (token.fontStyle & FS_BOLD) styles.push("font-weight:bold");
+    if (token.fontStyle & FS_UNDERLINE) styles.push("text-decoration:underline");
+    if (token.fontStyle & FS_STRIKETHROUGH) styles.push("text-decoration:line-through");
+  }
+  const style = styles.join(";");
+  return style
+    ? `<span style="${style}">${escapeHtml(token.content)}</span>`
+    : escapeHtml(token.content);
+}
+
 export function useSourceHighlighting(content: string, path: string) {
-  const [highlightedLines, setHighlightedLines] = useState<string[]>([]);
+  const [shikiLines, setShikiLines] = useState<string[]>([]);
   const deferredContent = useDeferredValue(content);
   const deferredLines = useMemo(() => deferredContent.split("\n"), [deferredContent]);
 
   const currentTheme = useTheme();
+  const lang = useMemo(() => getShikiLanguage(path), [path]);
 
-  // Syntax highlighting: single call for the whole document, then split by line
+  // `text` is a no-op for Shiki — skip the round-trip entirely and just
+  // escape per line. Computed via `useMemo` (not `setState` in an effect)
+  // to satisfy `react-hooks/set-state-in-effect`. This is also the fallback
+  // when an unmapped file type reaches us (`getShikiLanguage` returns
+  // `text`).
+  const textLines = useMemo<string[] | null>(
+    () => (lang === "text" ? deferredLines.map(escapeHtml) : null),
+    [lang, deferredLines],
+  );
+
+  // Syntax highlighting: single tokenisation for the whole document, then
+  // serialise per-line. `codeToTokens` returns `ThemedToken[][]` (outer index
+  // = line, inner = tokens within that line) so there is no fragile HTML
+  // post-processing — every token becomes one span, every line is one entry
+  // in the array, which the SourceView renders as one row in its gutter
+  // table. Replaces an earlier regex-based extractor that truncated
+  // multi-token lines at the first inner `</span>`.
   useEffect(() => {
+    if (lang === "text") return;   // text path handled by `textLines` memo
     let cancelled = false;
     const theme = currentTheme === "dark" ? "github-dark" : "github-light";
-    const lang = getShikiLanguage(path);
+
     getSharedHighlighter()
       .then(async (hl) => {
         if (cancelled) return;
         const loaded = hl.getLoadedLanguages();
-        if (!loaded.includes(lang) && lang !== "text") {
+        if (!loaded.includes(lang)) {
           if (lang === "kql") {
             await hl.loadLanguage({
               name: "kql",
@@ -37,29 +82,27 @@ export function useSourceHighlighting(content: string, path: string) {
         }
         if (cancelled) return;
         try {
-          const fullHtml = hl.codeToHtml(deferredContent || " ", { lang, theme });
-          // Shiki wraps each line in <span class="line">...</span>
-          // Extract the inner HTML of each line span
-          const lineRegex = /<span class="line">(.*?)<\/span>/gs;
-          const htmlLines: string[] = [];
-          let match;
-          while ((match = lineRegex.exec(fullHtml)) !== null) {
-            htmlLines.push(match[1]);
+          const result = hl.codeToTokens(deferredContent || " ", {
+            lang: lang as BundledLanguage,
+            theme,
+          });
+          const htmlLines = result.tokens.map((lineTokens) =>
+            lineTokens.map(tokenToSpan).join(""),
+          );
+          // Empty content produced one synthetic blank line — keep alignment
+          // with `deferredLines` so the gutter row count matches.
+          if (deferredContent === "" && htmlLines.length === 1) {
+            setShikiLines([""]);
+          } else {
+            setShikiLines(htmlLines);
           }
-          // Fallback: if regex didn't match (unexpected format), use plain escape
-          if (htmlLines.length === 0) {
-            for (const line of deferredLines) {
-              htmlLines.push(escapeHtml(line));
-            }
-          }
-          setHighlightedLines(htmlLines);
         } catch {
-          setHighlightedLines(deferredLines.map(l => escapeHtml(l)));
+          setShikiLines(deferredLines.map(escapeHtml));
         }
       })
-      .catch(() => { if (!cancelled) setHighlightedLines([]); });
+      .catch(() => { if (!cancelled) setShikiLines([]); });
     return () => { cancelled = true; };
-  }, [deferredContent, deferredLines, path, currentTheme]);
+  }, [deferredContent, deferredLines, path, currentTheme, lang]);
 
-  return { highlightedLines };
+  return { highlightedLines: textLines ?? shikiLines };
 }

--- a/src/lib/__tests__/file-types.test.ts
+++ b/src/lib/__tests__/file-types.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { getFileCategory, hasVisualization, getDefaultView, getShikiLanguage, getFoldLanguage, getFiletypeKey } from "@/lib/file-types";
+import { bundledLanguages } from "shiki";
+import {
+  getFileCategory,
+  hasVisualization,
+  getDefaultView,
+  getShikiLanguage,
+  getFoldLanguage,
+  getFiletypeKey,
+  SHIKI_LANGUAGE_MAP_FOR_TEST,
+  BASENAME_MAP_FOR_TEST,
+} from "@/lib/file-types";
 
 describe("getFileCategory", () => {
   it("classifies markdown files", () => {
@@ -164,9 +174,10 @@ describe("getShikiLanguage", () => {
   });
 
   it("returns 'text' for unknown / missing extensions", () => {
-    expect(getShikiLanguage("Makefile")).toBe("text");
     expect(getShikiLanguage("data.unknownext")).toBe("text");
     expect(getShikiLanguage("noext")).toBe("text");
+    // `.m` is intentionally deferred (ambiguous: Objective-C / MATLAB / Mathematica)
+    expect(getShikiLanguage("foo.m")).toBe("text");
   });
 
   it("returns 'text' for .mdx (not in Shiki map even though it is a markdown category)", () => {
@@ -179,6 +190,61 @@ describe("getShikiLanguage", () => {
   it("is case-insensitive (extname lowercases)", () => {
     expect(getShikiLanguage("App.TS")).toBe("typescript");
     expect(getShikiLanguage("Q.KQL")).toBe("kql");
+  });
+
+  // Issue #94 — table-driven coverage for the expanded extension set. Spec
+  // acceptance criterion: every listed ext yields a non-`text` Shiki id and
+  // produces highlighted output.
+  it.each([
+    ["main.lua", "lua"], ["main.dart", "dart"],
+    ["main.scala", "scala"], ["main.zig", "zig"],
+    ["pkg.svelte", "svelte"], ["app.vue", "vue"], ["x.astro", "astro"],
+    ["main.tf", "terraform"], ["vars.tfvars", "terraform"],
+    ["main.hcl", "hcl"], ["schema.proto", "proto"],
+    ["build.gradle", "groovy"],   // .gradle = Groovy DSL
+    ["app.bicep", "bicep"], ["build.cmake", "cmake"],
+    ["query.graphql", "graphql"], ["q.gql", "graphql"],
+    ["schema.prisma", "prisma"], ["data.jsonc", "jsonc"],
+    ["patch.diff", "diff"], ["patch.patch", "diff"],
+    ["config.ini", "ini"], ["nginx.conf", "ini"], [".env.local.env", "ini"],
+    ["script.ps1", "powershell"],
+    ["analysis.r", "r"], ["build.groovy", "groovy"],
+    ["x.mm", "objective-cpp"],
+  ])("extension: %s -> %s", (path, expected) => {
+    expect(getShikiLanguage(path)).toBe(expected);
+  });
+
+  // Filename-only patterns (no recognisable extension) — issue #94.
+  it.each([
+    ["Dockerfile", "docker"],
+    ["a/b/Dockerfile", "docker"],
+    ["dockerfile", "docker"],
+    ["Containerfile", "docker"],
+    ["Makefile", "make"],
+    ["GNUmakefile", "make"],
+    ["CMakeLists.txt", "cmake"],
+    // Extension wins when present — no map entry for `.dockerfile`, so text.
+    ["foo.Dockerfile", "text"],
+    ["unknownfile", "text"],
+  ])("basename: %s -> %s", (path, expected) => {
+    expect(getShikiLanguage(path)).toBe(expected);
+  });
+
+  // Runtime guard — every value of either map MUST be a Shiki bundled
+  // language id (or the special `kql` id which we register from a custom
+  // TextMate grammar). This catches typos and Shiki-version drift; without
+  // it, bad ids silently degrade to `text` because `loadLanguage(...).catch`
+  // swallows errors in `useSourceHighlighting`.
+  it("only maps to Shiki bundled language ids (or custom kql)", () => {
+    const bundled = new Set(Object.keys(bundledLanguages));
+    for (const value of Object.values(SHIKI_LANGUAGE_MAP_FOR_TEST)) {
+      if (value === "kql") continue;
+      expect(bundled, `SHIKI_LANGUAGE_MAP value "${value}"`).toContain(value);
+    }
+    for (const value of Object.values(BASENAME_MAP_FOR_TEST)) {
+      if (value === "kql") continue;
+      expect(bundled, `BASENAME_MAP value "${value}"`).toContain(value);
+    }
   });
 });
 

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -1,4 +1,4 @@
-import { extname } from "@/lib/path-utils";
+import { basename, extname } from "@/lib/path-utils";
 
 export type FileCategory =
   | "markdown"
@@ -121,19 +121,82 @@ export function getDefaultView(category: FileCategory): "source" | "visual" {
 // the Rust fold-region detector (`src-tauri/src/core/fold_regions.rs`), which
 // recognises both `python`/`py` and `yaml`/`yml` for its indent-language hint,
 // so this single table serves both syntax highlighting and folding.
+//
+// Every value here MUST be either a key of Shiki's `bundledLanguages` (so
+// `loadLanguage(id)` succeeds at runtime) or the special `kql` id which is
+// registered separately from `kql.tmLanguage.json`. The runtime guard test
+// in `src/lib/__tests__/file-types.test.ts` enforces this — a typo or
+// Shiki-version drift fails fast there instead of silently degrading to
+// `text` (Shiki swallows `loadLanguage` errors).
+//
+// `.m` is intentionally NOT mapped: ambiguous between Objective-C, MATLAB,
+// and Mathematica. Falls back to `text` until product picks a default.
+// Niche languages (clj, hs, elm, ml, fs, nim, cr, jl, tex, vim, pl) are
+// deferred to keep the table tight; re-add only on user request.
+//
+// Aliases that Shiki does not bundle directly:
+// - `.gradle` → `groovy`     (Gradle DSL is Groovy)
+// - `.conf`/`.env` → `ini`   (close-enough syntax for highlighting)
 const SHIKI_LANGUAGE_MAP: Record<string, string> = {
+  // TS / JS family
   ts: "typescript", tsx: "tsx", js: "javascript", jsx: "jsx",
+  // Mainstream languages
   py: "python", rs: "rust", go: "go", java: "java",
-  c: "c", cpp: "cpp", h: "c", css: "css", html: "html",
-  json: "json", yaml: "yaml", yml: "yaml", toml: "toml",
-  sh: "bash", bash: "bash", md: "markdown", sql: "sql",
-  rb: "ruby", php: "php", swift: "swift", kt: "kotlin", cs: "csharp",
-  xml: "xml", kql: "kql", csl: "kql",
+  c: "c", cpp: "cpp", h: "c", cs: "csharp", swift: "swift", kt: "kotlin",
+  rb: "ruby", php: "php", lua: "lua", dart: "dart", scala: "scala", zig: "zig",
+  r: "r", groovy: "groovy",
+  // Web / app frameworks
+  css: "css", html: "html", svelte: "svelte", vue: "vue", astro: "astro",
+  graphql: "graphql", gql: "graphql", prisma: "prisma",
+  // Data / config
+  json: "json", jsonc: "jsonc", yaml: "yaml", yml: "yaml", toml: "toml",
+  xml: "xml", ini: "ini", conf: "ini", env: "ini",
+  // Shells / scripts
+  sh: "bash", bash: "bash", ps1: "powershell",
+  // Docs / misc
+  md: "markdown", sql: "sql",
+  // Infra / config
+  tf: "terraform", tfvars: "terraform", hcl: "hcl",
+  proto: "proto", gradle: "groovy", cmake: "cmake", bicep: "bicep",
+  diff: "diff", patch: "diff",
+  // Apple
+  mm: "objective-cpp",
+  // KQL — registered separately via custom TextMate grammar
+  kql: "kql", csl: "kql",
 };
 
+// Filename-only patterns matched when there is no recognisable extension.
+// Lookups are case-insensitive (`Dockerfile`/`dockerfile`). Extensions WIN
+// when present — `foo.Dockerfile` falls through to extension lookup (which
+// has no `.dockerfile` entry) and ends up as `text`.
+const BASENAME_MAP: Record<string, string> = {
+  dockerfile: "docker",
+  containerfile: "docker",
+  makefile: "make",
+  gnumakefile: "make",
+  "cmakelists.txt": "cmake",
+};
+
+// Exported for the runtime guard test (file-types.test.ts) which verifies
+// every value is a key of Shiki's `bundledLanguages` (or `kql`).
+export const SHIKI_LANGUAGE_MAP_FOR_TEST: Readonly<Record<string, string>> = SHIKI_LANGUAGE_MAP;
+export const BASENAME_MAP_FOR_TEST: Readonly<Record<string, string>> = BASENAME_MAP;
+
 export function getShikiLanguage(path: string): string {
+  // Filename-only patterns take precedence — `CMakeLists.txt` is in the
+  // basename map even though `.txt` has no extension entry, and bare
+  // `Dockerfile`/`Makefile` have no extension at all. Lookups are
+  // case-insensitive. Files like `foo.Dockerfile` (basename
+  // `foo.dockerfile`, lowercase) are NOT in the map and fall through to
+  // the extension lookup — which has no `.dockerfile` entry, yielding
+  // `text`. This preserves the spec rule that genuine extensions win when
+  // present.
+  const base = basename(path).toLowerCase();
+  const fromBase = BASENAME_MAP[base];
+  if (fromBase) return fromBase;
+
   const ext = extname(path).slice(1);
-  return SHIKI_LANGUAGE_MAP[ext] ?? "text";
+  return ext ? (SHIKI_LANGUAGE_MAP[ext] ?? "text") : "text";
 }
 
 // Fold-region language hint. Currently identical to the Shiki id space — the


### PR DESCRIPTION
Implements [#94](https://github.com/dryotta/reviewreview/issues/94) — syntax highlighting for source view across the common file types developers receive from AI tools.

Two defects, fixed together (per the groomed spec):

1. **Broken Shiki line extraction** in `useSourceHighlighting.ts` — the regex `/<span class="line">(.*?)<\/span>/gs` is non-balanced and truncates multi-token lines at the first inner `</span>`. Replaced with a token-based renderer that uses Shiki's structured `codeToTokens()` output and serialises one `<span style="color:…">` per token.
2. **Sparse extension coverage** — `SHIKI_LANGUAGE_MAP` covered ~20 extensions; AI agents commonly emit Lua, Dart, Terraform, GraphQL, Prisma, JSONC, Bicep, Vue/Svelte/Astro, etc. Expanded the map and added a small `BASENAME_MAP` so `Dockerfile`/`Makefile`/`CMakeLists.txt` highlight without an extension.

## Acceptance criteria

- [x] `useSourceHighlighting.ts` no longer uses the broken regex; multi-token lines preserve every token (regression test added).
- [x] At minimum the following extensions yield non-`text` Shiki ids and produce highlighted output (subject to Shiki's bundled list — drop any Shiki does not ship): `lua, dart, scala, zig, svelte, vue, astro, tf, tfvars, hcl, proto, gradle, cmake, bicep, graphql, gql, prisma, jsonc, diff, patch, ini, conf, env, ps1, r, groovy, mm`.
- [x] Basename matches: `Dockerfile`, `dockerfile`, `Containerfile`, `Makefile`, `GNUmakefile`, `CMakeLists.txt` highlight correctly. `.m` remains `text` (deferred — comment in source).
- [x] Runtime guard test verifies every map value is in Shiki's `bundledLanguages` (except `kql`).
- [x] Unknown extensions still fall back to `text` and render escaped plain text (no crash).
- [x] Bundle audit: **entry chunk** (`dist/assets/index-*.js`) size delta ≤ small tolerance vs. baseline; no eager `langs: [...]` preload added in `src/lib/shiki.ts`.
- [x] Existing source-highlighting tests pass; new table-driven tests added.

Closes #94
