### PR TITLE
feat: implement #94  syntax highlighting for source view

### DIFF
--- a/src/hooks/__tests__/useSourceHighlighting.test.ts
+++ b/src/hooks/__tests__/useSourceHighlighting.test.ts
@@ -129,6 +129,48 @@ describe("useSourceHighlighting", () => {
     expect(result.current.highlightedLines[0]).toContain("FRESH_B_PY");
     expect(result.current.highlightedLines[0]).not.toContain("STALE_A_TS");
   });
+  it("preserves all tokens in multi-token lines (regression: broken regex truncation)", async () => {
+    const { getSharedHighlighter } = await import("@/lib/shiki");
+
+    // Realistic Shiki output with nested token spans per line
+    const multiTokenHtml =
+      '<pre class="shiki github-light" style="background-color:#fff"><code>' +
+      '<span class="line"><span style="color:#CF222E">const</span><span style="color:#953800"> x</span><span style="color:#CF222E"> =</span><span style="color:#0550AE"> 1</span><span style="color:#24292F">;</span></span>\n' +
+      '<span class="line"><span style="color:#CF222E">let</span><span style="color:#953800"> y</span><span style="color:#CF222E"> =</span><span style="color:#0550AE"> 2</span><span style="color:#24292F">;</span></span>' +
+      '</code></pre>';
+
+    const mockHl = {
+      getLoadedLanguages: () => ["typescript"],
+      loadLanguage: vi.fn(),
+      codeToHtml: () => multiTokenHtml,
+    };
+    vi.mocked(getSharedHighlighter).mockResolvedValue(mockHl as any);
+
+    const { result } = renderHook(() =>
+      useSourceHighlighting("const x = 1;\nlet y = 2;", "test.ts")
+    );
+    await waitFor(() => {
+      expect(result.current.highlightedLines.length).toBeGreaterThan(0);
+    });
+
+    // Line 1 must contain ALL token spans, not just the first one
+    const line1 = result.current.highlightedLines[0];
+    expect(line1).toContain("const");
+    expect(line1).toContain(" x");
+    expect(line1).toContain(" =");
+    expect(line1).toContain(" 1");
+    expect(line1).toContain(";");
+    // With the old broken regex, only the first token span would be captured.
+    // Verify at least 4 <span tokens survive (there are 5 in the mock).
+    expect((line1.match(/<span /g) ?? []).length).toBeGreaterThanOrEqual(4);
+
+    // Line 2 must also contain all tokens
+    const line2 = result.current.highlightedLines[1];
+    expect(line2).toContain("let");
+    expect(line2).toContain(" y");
+    expect(line2).toContain(" =");
+    expect(line2).toContain(" 2");
+  });
 });
 
 describe("escapeHtml", () => {

--- a/src/hooks/__tests__/useSourceHighlighting.test.ts
+++ b/src/hooks/__tests__/useSourceHighlighting.test.ts
@@ -144,7 +144,9 @@ describe("useSourceHighlighting", () => {
       loadLanguage: vi.fn(),
       codeToHtml: () => multiTokenHtml,
     };
-    vi.mocked(getSharedHighlighter).mockResolvedValue(mockHl as any);
+    vi.mocked(getSharedHighlighter).mockResolvedValue(
+      mockHl as unknown as Awaited<ReturnType<typeof getSharedHighlighter>>
+    );
 
     const { result } = renderHook(() =>
       useSourceHighlighting("const x = 1;\nlet y = 2;", "test.ts")

--- a/src/hooks/useSourceHighlighting.ts
+++ b/src/hooks/useSourceHighlighting.ts
@@ -38,15 +38,19 @@ export function useSourceHighlighting(content: string, path: string) {
         if (cancelled) return;
         try {
           const fullHtml = hl.codeToHtml(deferredContent || " ", { lang, theme });
-          // Shiki wraps each line in <span class="line">...</span>
-          // Extract the inner HTML of each line span
-          const lineRegex = /<span class="line">(.*?)<\/span>/gs;
+          // Shiki wraps each line in <span class="line">…</span> with nested
+          // token <span>s inside. A regex with lazy .*? truncates at the first
+          // inner </span>, so we split on the line-span boundary instead.
+          const parts = fullHtml.split('<span class="line">');
           const htmlLines: string[] = [];
-          let match;
-          while ((match = lineRegex.exec(fullHtml)) !== null) {
-            htmlLines.push(match[1]);
+          for (let i = 1; i < parts.length; i++) {
+            // Strip the closing </span> that belongs to the line wrapper.
+            // Each part ends with </span> (line close) possibly followed by
+            // </code></pre> or more line spans.
+            const endIdx = parts[i].lastIndexOf('</span>');
+            htmlLines.push(endIdx >= 0 ? parts[i].substring(0, endIdx) : parts[i]);
           }
-          // Fallback: if regex didn't match (unexpected format), use plain escape
+          // Fallback: if split found no line spans (unexpected format), use plain escape
           if (htmlLines.length === 0) {
             for (const line of deferredLines) {
               htmlLines.push(escapeHtml(line));

--- a/src/lib/__tests__/file-types.test.ts
+++ b/src/lib/__tests__/file-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { getFileCategory, hasVisualization, getDefaultView, getShikiLanguage, getFoldLanguage, getFiletypeKey } from "@/lib/file-types";
+import { bundledLanguages } from "shiki";
+import { getFileCategory, hasVisualization, getDefaultView, getShikiLanguage, getFoldLanguage, getFiletypeKey, SHIKI_LANGUAGE_MAP, BASENAME_MAP } from "@/lib/file-types";
 
 describe("getFileCategory", () => {
   it("classifies markdown files", () => {
@@ -163,10 +164,61 @@ describe("getShikiLanguage", () => {
     expect(getShikiLanguage("readme.md")).toBe("markdown");
   });
 
+  it("maps new language extensions (#94 Group B)", () => {
+    expect(getShikiLanguage("a.lua")).toBe("lua");
+    expect(getShikiLanguage("a.dart")).toBe("dart");
+    expect(getShikiLanguage("a.scala")).toBe("scala");
+    expect(getShikiLanguage("a.zig")).toBe("zig");
+    expect(getShikiLanguage("a.groovy")).toBe("groovy");
+    expect(getShikiLanguage("a.r")).toBe("r");
+    expect(getShikiLanguage("a.ps1")).toBe("powershell");
+  });
+
+  it("maps web/app framework extensions (#94 Group B)", () => {
+    expect(getShikiLanguage("a.svelte")).toBe("svelte");
+    expect(getShikiLanguage("a.vue")).toBe("vue");
+    expect(getShikiLanguage("a.astro")).toBe("astro");
+    expect(getShikiLanguage("a.graphql")).toBe("graphql");
+    expect(getShikiLanguage("a.gql")).toBe("graphql");
+    expect(getShikiLanguage("a.prisma")).toBe("prisma");
+    expect(getShikiLanguage("a.jsonc")).toBe("jsonc");
+  });
+
+  it("maps infra/config extensions (#94 Group B)", () => {
+    expect(getShikiLanguage("a.tf")).toBe("terraform");
+    expect(getShikiLanguage("a.tfvars")).toBe("terraform");
+    expect(getShikiLanguage("a.hcl")).toBe("hcl");
+    expect(getShikiLanguage("a.proto")).toBe("protobuf");
+    expect(getShikiLanguage("a.gradle")).toBe("groovy");
+    expect(getShikiLanguage("a.cmake")).toBe("cmake");
+    expect(getShikiLanguage("a.bicep")).toBe("bicep");
+    expect(getShikiLanguage("a.ini")).toBe("ini");
+    expect(getShikiLanguage("a.conf")).toBe("ini");
+    expect(getShikiLanguage("a.env")).toBe("ini");
+    expect(getShikiLanguage("a.diff")).toBe("diff");
+    expect(getShikiLanguage("a.patch")).toBe("diff");
+    expect(getShikiLanguage("a.mm")).toBe("objective-cpp");
+  });
+
+  it("falls back to basename matching for extensionless files (#94 Group B)", () => {
+    expect(getShikiLanguage("Dockerfile")).toBe("docker");
+    expect(getShikiLanguage("dockerfile")).toBe("docker");
+    expect(getShikiLanguage("Containerfile")).toBe("docker");
+    expect(getShikiLanguage("Makefile")).toBe("make");
+    expect(getShikiLanguage("GNUmakefile")).toBe("make");
+    expect(getShikiLanguage("CMakeLists.txt")).toBe("cmake");
+  });
+
+  it("basename matching works with directory prefixes (#94 Group B)", () => {
+    expect(getShikiLanguage("/app/Dockerfile")).toBe("docker");
+    expect(getShikiLanguage("C:\\project\\Makefile")).toBe("make");
+  });
+
   it("returns 'text' for unknown / missing extensions", () => {
-    expect(getShikiLanguage("Makefile")).toBe("text");
     expect(getShikiLanguage("data.unknownext")).toBe("text");
     expect(getShikiLanguage("noext")).toBe("text");
+    expect(getShikiLanguage("foo.m")).toBe("text"); // .m deliberately deferred — ambiguous
+    expect(getShikiLanguage("foo.Dockerfile")).toBe("text"); // extension wins, .dockerfile not mapped
   });
 
   it("returns 'text' for .mdx (not in Shiki map even though it is a markdown category)", () => {
@@ -188,6 +240,29 @@ describe("getFoldLanguage", () => {
     expect(getFoldLanguage("a.yml")).toBe("yaml");
     expect(getFoldLanguage("a.ts")).toBe("typescript");
     expect(getFoldLanguage("a.unknownext")).toBe("text");
+  });
+});
+
+describe("Shiki language map runtime guard (#94)", () => {
+  it("every SHIKI_LANGUAGE_MAP value is a valid bundled Shiki language (except kql)", () => {
+    const invalidEntries: string[] = [];
+    for (const [ext, lang] of Object.entries(SHIKI_LANGUAGE_MAP)) {
+      if (lang === "kql") continue;
+      if (!(lang in bundledLanguages)) {
+        invalidEntries.push(`.${ext} → "${lang}"`);
+      }
+    }
+    expect(invalidEntries, `Invalid Shiki language ids: ${invalidEntries.join(", ")}`).toEqual([]);
+  });
+
+  it("every BASENAME_MAP value is a valid bundled Shiki language", () => {
+    const invalidEntries: string[] = [];
+    for (const [name, lang] of Object.entries(BASENAME_MAP)) {
+      if (!(lang in bundledLanguages)) {
+        invalidEntries.push(`${name} → "${lang}"`);
+      }
+    }
+    expect(invalidEntries, `Invalid Shiki language ids: ${invalidEntries.join(", ")}`).toEqual([]);
   });
 });
 

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -1,4 +1,4 @@
-import { extname } from "@/lib/path-utils";
+import { extname, basename } from "@/lib/path-utils";
 
 export type FileCategory =
   | "markdown"
@@ -121,7 +121,8 @@ export function getDefaultView(category: FileCategory): "source" | "visual" {
 // the Rust fold-region detector (`src-tauri/src/core/fold_regions.rs`), which
 // recognises both `python`/`py` and `yaml`/`yml` for its indent-language hint,
 // so this single table serves both syntax highlighting and folding.
-const SHIKI_LANGUAGE_MAP: Record<string, string> = {
+export const SHIKI_LANGUAGE_MAP: Record<string, string> = {
+  // Existing entries
   ts: "typescript", tsx: "tsx", js: "javascript", jsx: "jsx",
   py: "python", rs: "rust", go: "go", java: "java",
   c: "c", cpp: "cpp", h: "c", css: "css", html: "html",
@@ -129,11 +130,37 @@ const SHIKI_LANGUAGE_MAP: Record<string, string> = {
   sh: "bash", bash: "bash", md: "markdown", sql: "sql",
   rb: "ruby", php: "php", swift: "swift", kt: "kotlin", cs: "csharp",
   xml: "xml", kql: "kql", csl: "kql",
+  // New — languages
+  lua: "lua", dart: "dart", scala: "scala", zig: "zig",
+  groovy: "groovy", r: "r", ps1: "powershell",
+  // New — web/app frameworks
+  svelte: "svelte", vue: "vue", astro: "astro",
+  graphql: "graphql", gql: "graphql", prisma: "prisma", jsonc: "jsonc",
+  // New — infra/config
+  tf: "terraform", tfvars: "terraform", hcl: "hcl",
+  proto: "protobuf", gradle: "groovy", cmake: "cmake", bicep: "bicep",
+  ini: "ini", conf: "ini", env: "ini",
+  diff: "diff", patch: "diff",
+  // New — Objective-C++; .m deliberately omitted — ambiguous (Objective-C vs MATLAB vs Mathematica)
+  mm: "objective-cpp",
+};
+
+/** Basename → Shiki language for files without a meaningful extension. */
+export const BASENAME_MAP: Record<string, string> = {
+  Dockerfile: "docker",
+  dockerfile: "docker",
+  Containerfile: "docker",
+  Makefile: "make",
+  GNUmakefile: "make",
+  "CMakeLists.txt": "cmake",
 };
 
 export function getShikiLanguage(path: string): string {
   const ext = extname(path).slice(1);
-  return SHIKI_LANGUAGE_MAP[ext] ?? "text";
+  if (ext && SHIKI_LANGUAGE_MAP[ext]) return SHIKI_LANGUAGE_MAP[ext];
+  // No extension match — try basename (Dockerfile, Makefile, etc.)
+  const base = basename(path);
+  return BASENAME_MAP[base] ?? "text";
 }
 
 // Fold-region language hint. Currently identical to the Shiki id space — the


### PR DESCRIPTION
## feat: implement #94  syntax highlighting for source view

Fixes syntax highlighting for most source file types by expanding the Shiki language map, adding basename matching, and fixing the broken line-extraction regex.

## Requirements

- [x] `useSourceHighlighting.ts` no longer uses the broken regex; multi-token lines preserve every token (regression test added).
- [x] At minimum the following extensions yield non-`text` Shiki ids and produce highlighted output: lua, dart, scala, zig, svelte, vue, astro, tf, tfvars, hcl, proto, gradle, cmake, bicep, graphql, gql, prisma, jsonc, diff, patch, ini, conf, env, ps1, r, groovy, mm.
- [x] Basename matches: Dockerfile, dockerfile, Containerfile, Makefile, GNUmakefile, CMakeLists.txt highlight correctly. .m remains text (deferred  comment in source).
- [x] Runtime guard test verifies every map value is in Shiki's `bundledLanguages` (except `kql`).
- [x] Unknown extensions still fall back to `text` and render escaped plain text (no crash).
- [x] Bundle audit: entry chunk size delta <= small tolerance vs. baseline; no eager `langs: [...]` preload added in `src/lib/shiki.ts`.
- [x] Existing source-highlighting tests pass; new table-driven tests added.

Ready for review  goal achieved.

Closes #94