### PR TITLE
feat: implement #157  zoom-cascade audit for all viewers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Lint skill docs (npm-script references)
         run: npm run lint:skills
 
+      - name: Audit zoom cascade
+        run: npm run audit:zoom-cascade
+
   # ── Playwright E2E (browser mode, Linux) ─────────────────────────────────
   e2e-browser:
     name: E2E browser (Linux)

--- a/e2e/browser/fixtures/sample.mmd
+++ b/e2e/browser/fixtures/sample.mmd
@@ -1,0 +1,4 @@
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Result 1]
+    B -->|No| D[Result 2]

--- a/e2e/browser/zoom-all-viewers.spec.ts
+++ b/e2e/browser/zoom-all-viewers.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+const FIXTURES_DIR = "/e2e/fixtures";
+
+// Each entry: [filename, extension, viewer selector for the zoom root]
+// HTML uses an iframe — zoom applies to the wrapper but content is isolated.
+// Mermaid uses transform:scale, not font-size zoom — excluded per issue #157.
+// KQL zoom was added in this PR (useZoom in KqlPlanView) and verified by unit
+// test; the e2e test is deferred because the mock IPC doesn't populate the
+// KQL operator-table path that renders .kql-plan-container with content.
+const VIEWERS = [
+  ["doc.md", ".md", ".markdown-viewer"],
+  ["data.json", ".json", ".json-tree"],
+  ["data.csv", ".csv", ".csv-table-container"],
+] as const;
+
+const FILE_CONTENTS: Record<string, string> = {
+  "doc.md": "# Heading\n\nSome **bold** text and `inline code`.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n",
+  "data.json": '{"name": "test", "items": [1, 2, 3]}',
+  "data.csv": "name,value\nalpha,1\nbeta,2\ngamma,3",
+  "page.html": "<html><body><h1>Hello</h1><p>World</p></body></html>",
+  "query.kql": "StormEvents\n| where State == 'TEXAS'\n| summarize count() by EventType\n| order by count_ desc\n| take 5",
+};
+
+async function setupMocks(page: Page, files: string[]) {
+  await page.addInitScript(({ dir, fileList, contents }: {
+    dir: string;
+    fileList: string[];
+    contents: Record<string, string>;
+  }) => {
+    window.__TAURI_IPC_MOCK__ = async (cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "get_launch_args") return { files: [], folders: [dir] };
+      if (cmd === "read_dir")
+        return fileList.map(name => ({
+          name,
+          path: `${dir}/${name}`,
+          is_dir: false,
+        }));
+      if (cmd === "read_text_file") {
+        const path = (args as { path: string }).path;
+        const name = path.split("/").pop() ?? "";
+        return contents[name] ?? "";
+      }
+      if (cmd === "load_review_comments") return null;
+      if (cmd === "save_review_comments") return null;
+      if (cmd === "check_path_exists") return "file";
+      if (cmd === "get_log_path") return "/mock/log.log";
+      if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
+      return null;
+    };
+  }, { dir: FIXTURES_DIR, fileList: files, contents: FILE_CONTENTS });
+}
+
+async function fontSize(page: Page, selector: string): Promise<number> {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) throw new Error(`element not found: ${sel}`);
+    return parseFloat(getComputedStyle(el).fontSize);
+  }, selector);
+}
+
+test.describe("Zoom all viewers (#157 AC1)", () => {
+  for (const [filename, _ext, selector] of VIEWERS) {
+    test(`${filename}: Ctrl+= grows font, Ctrl+- shrinks, Ctrl+0 resets`, async ({ page }) => {
+      const files = Object.keys(FILE_CONTENTS);
+      await setupMocks(page, files);
+      await page.goto("/");
+
+      // Open the file
+      await page.locator(".folder-tree").getByText(filename).click();
+      await expect(page.locator(selector)).toBeVisible({ timeout: 10000 });
+
+      const baseline = await fontSize(page, selector);
+      expect(baseline).toBeGreaterThan(0);
+
+      // Two zoom-in steps (×1.1 each → ~×1.21)
+      await page.keyboard.press("Control+=");
+      await page.keyboard.press("Control+=");
+      await expect
+        .poll(async () => await fontSize(page, selector))
+        .toBeGreaterThan(baseline * 1.15);
+      const grown = await fontSize(page, selector);
+
+      // One zoom-out step → smaller than the two-step zoomed value
+      await page.keyboard.press("Control+-");
+      await expect
+        .poll(async () => await fontSize(page, selector))
+        .toBeLessThan(grown);
+
+      // Reset → back to baseline
+      await page.keyboard.press("Control+0");
+      await expect
+        .poll(async () => await fontSize(page, selector))
+        .toBeCloseTo(baseline, 0);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test-exploratory-e2e:repl": "tsx .claude/skills/test-exploratory-e2e/runner/repl.ts",
     "test-exploratory-loop:wait": "tsx .claude/skills/test-exploratory-loop/runner/wait-for-main.ts",
     "test-exploratory-loop:sync": "tsx .claude/skills/test-exploratory-loop/runner/sync.ts",
+    "audit:zoom-cascade": "node scripts/audit-zoom-cascade.mjs",
     "bench:cli": "cd src-tauri && cargo bench",
     "bench:cli:script": "pwsh scripts/bench-cli.ps1"
   },

--- a/scripts/__tests__/audit-zoom-cascade.test.mjs
+++ b/scripts/__tests__/audit-zoom-cascade.test.mjs
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT = join(import.meta.dirname, "..", "audit-zoom-cascade.mjs");
+
+/**
+ * Helper: run the audit script against a temp --root directory.
+ * Returns { status, stderr }.
+ */
+function run(rootDir) {
+  const result = spawnSync("node", [SCRIPT, "--root", rootDir], {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return { status: result.status, stderr: result.stderr ?? "" };
+}
+
+/**
+ * Create a minimal temp root with src/styles/ containing the given files.
+ * Returns the root path.  Caller must clean up.
+ */
+function makeTempRoot(files) {
+  const root = mkdtempSync(join(tmpdir(), "zoom-audit-"));
+  const stylesDir = join(root, "src", "styles");
+  mkdirSync(stylesDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(stylesDir, name), content, "utf8");
+  }
+  return root;
+}
+
+describe("audit-zoom-cascade", () => {
+  it("exits 0 when no absolute font-size violations exist", () => {
+    const root = makeTempRoot({
+      "csv-table.css": `.csv-table-container { height: 100%; }
+.csv-table { font-size: 0.8125em; }
+`,
+      "markdown.css": `.markdown-viewer { padding: 20px; }
+.markdown-body p { line-height: 1.6; }
+`,
+    });
+    try {
+      const { status, stderr } = run(root);
+      expect(status).toBe(0);
+      expect(stderr).toContain("OK");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 when an absolute font-size violation is found", () => {
+    const root = makeTempRoot({
+      "csv-table.css": `.csv-table-container { height: 100%; }
+.csv-table { font-size: 0.8125em; }
+.csv-table-footer {
+  font-size: 14px;
+}
+`,
+    });
+    try {
+      const { status, stderr } = run(root);
+      expect(status).toBe(1);
+      expect(stderr).toContain("FAIL");
+      expect(stderr).toContain("csv-table-footer");
+      expect(stderr).toContain("font-size: 14px");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows zoom-cascade: chrome annotation on same line", () => {
+    const root = makeTempRoot({
+      "csv-table.css": `.csv-table-container { height: 100%; }
+.csv-sort-indicator {
+  font-size: 10px; /* zoom-cascade: chrome */
+}
+`,
+    });
+    try {
+      const { status } = run(root);
+      expect(status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows zoom-cascade: chrome annotation on preceding line", () => {
+    const root = makeTempRoot({
+      "json-tree.css": `.json-tree { font-size: 13px; }
+.json-toggle {
+  /* zoom-cascade: chrome */
+  font-size: 10px;
+}
+`,
+    });
+    try {
+      const { status } = run(root);
+      expect(status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows absolute font-size on the zoom root itself", () => {
+    const root = makeTempRoot({
+      "json-tree.css": `.json-tree {
+  font-size: 13px;
+}
+`,
+    });
+    try {
+      const { status } = run(root);
+      expect(status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows relative units (em, rem, %)", () => {
+    const root = makeTempRoot({
+      "markdown.css": `.markdown-viewer { padding: 20px; }
+.markdown-body code {
+  font-size: 0.875em;
+}
+.markdown-body h1 { font-size: 2em; }
+`,
+    });
+    try {
+      const { status } = run(root);
+      expect(status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not scan unrelated CSS files", () => {
+    const root = makeTempRoot({
+      // about-dialog.css is not in ZOOM_ROOTS — must be ignored.
+      "about-dialog.css": `.about-version { font-size: 14px; }`,
+      // Need at least one scanned file so the script doesn't exit 2.
+      "csv-table.css": `.csv-table-container { height: 100%; }`,
+    });
+    try {
+      const { status } = run(root);
+      expect(status).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not false-positive on root classes with similar prefixes", () => {
+    // .csv-table-footer starts with .csv-table but is NOT the root.
+    const root = makeTempRoot({
+      "csv-table.css": `.csv-table-container { height: 100%; }
+.csv-table { font-size: 0.8125em; }
+.csv-table-footer {
+  font-size: 12px;
+}
+`,
+    });
+    try {
+      const { status, stderr } = run(root);
+      expect(status).toBe(1);
+      expect(stderr).toContain("csv-table-footer");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 2 when no scanned CSS files exist", () => {
+    const root = makeTempRoot({
+      "about-dialog.css": `.about-version { font-size: 14px; }`,
+    });
+    try {
+      const { status, stderr } = run(root);
+      expect(status).toBe(2);
+      expect(stderr).toContain("no scanned CSS files");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/audit-zoom-cascade.mjs
+++ b/scripts/audit-zoom-cascade.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Audit zoom-aware viewer CSS files for absolute font-size declarations that
+// would break CSS-variable-driven zoom scaling.  A declaration is a violation
+// when it (a) lives in a scanned viewer CSS file, (b) uses absolute units
+// (px / pt), (c) does NOT target the zoom root element itself, and (d) is not
+// annotated with `/* zoom-cascade: chrome */`.
+//
+// Exit codes:
+//   0 — no violations
+//   1 — violations found (printed with file:line)
+//   2 — usage / IO error
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Configuration ─────────────────────────────────────────────────────
+
+/** CSS files to scan, keyed by basename → zoom-root selectors. */
+const ZOOM_ROOTS = {
+  "source-viewer.css": [".source-view"],
+  "markdown.css": [".markdown-viewer", ".markdown-body"],
+  "json-tree.css": [".json-tree"],
+  "csv-table.css": [".csv-table-container", ".csv-table"],
+  "html-preview.css": [".html-preview"],
+  "kql-plan.css": [".kql-plan-container"],
+  "mermaid-view.css": [".mermaid-view"],
+};
+
+/** Max CSS files to scan — hard cap per performance.md rule 1. */
+const MAX_FILES = 20;
+
+// ── Argument parsing ──────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let rootDir;
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--root" && i + 1 < args.length) {
+    rootDir = resolve(args[i + 1]);
+    i++;
+  }
+}
+
+if (!rootDir) {
+  rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+const stylesDir = join(rootDir, "src", "styles");
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Matches `font-size:` followed by an absolute value (digits then px/pt).
+ * The regex is intentionally generous — it catches `font-size: 13px`,
+ * `font-size:10pt`, `font-size: 13.5px`, etc.
+ */
+const ABS_FONT_SIZE_RE = /font-size:\s*[\d.]+\s*(px|pt)/i;
+
+/** Matches the `zoom-cascade: chrome` annotation comment. */
+const CHROME_ANNOTATION_RE = /\/\*\s*zoom-cascade:\s*chrome\s*\*\//;
+
+/**
+ * Very lightweight selector extractor.  Walks lines backwards from
+ * `lineIndex` to find the most recent non-empty, non-comment line that
+ * looks like a CSS selector (ends with `{` or contains a `{`).
+ *
+ * Returns the raw selector string (everything before `{`), or null.
+ */
+function extractSelector(lines, lineIndex) {
+  // If the font-size line itself contains a `{`, the rule is single-line.
+  const cur = lines[lineIndex];
+  const braceIdx = cur.indexOf("{");
+  if (braceIdx !== -1) {
+    return cur.slice(0, braceIdx).trim();
+  }
+
+  // Walk backwards to find the opening brace.
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === "" || line.startsWith("/*") || line.startsWith("*")) continue;
+    const bi = line.indexOf("{");
+    if (bi !== -1) return line.slice(0, bi).trim();
+    // If we hit a `}` we've left the rule — give up.
+    if (line.includes("}")) return null;
+    // Might be a multi-line selector — keep going.
+  }
+  return null;
+}
+
+/**
+ * Returns true when `selector` names exactly one of the zoom-root
+ * selectors (i.e. the declaration styles the root itself, not a
+ * descendant).
+ */
+function isZoomRootItself(selector, roots) {
+  if (!selector) return false;
+  // Normalise: strip combinators and pseudo-classes/elements, then check
+  // whether the selector is exactly one of the roots.  We split on commas
+  // for grouped selectors — every part must be a root for the whole rule
+  // to be exempt.
+  const parts = selector.split(",").map((s) => s.trim());
+  return parts.every((part) => {
+    // The selector is a root if it IS the root class (possibly with
+    // pseudo-classes/elements or attribute selectors appended, but no
+    // descendant combinator).
+    return roots.some((root) => {
+      // Exact match.
+      if (part === root) return true;
+      // Root + pseudo-class/element/attribute (no space = no descendant).
+      // The character after the root must NOT be a word/hyphen char,
+      // otherwise `.csv-table` would falsely match `.csv-table-footer`.
+      if (part.startsWith(root)) {
+        const rest = part.slice(root.length);
+        if (/^[a-zA-Z0-9_-]/.test(rest)) return false;
+        return !rest.includes(" ");
+      }
+      return false;
+    });
+  });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+function main() {
+  let entries;
+  try {
+    entries = readdirSync(stylesDir);
+  } catch (err) {
+    process.stderr.write(
+      `[audit-zoom-cascade] cannot read ${stylesDir}: ${err.message}\n`,
+    );
+    process.exit(2);
+  }
+
+  const filesToScan = entries
+    .filter((name) => ZOOM_ROOTS[name])
+    .slice(0, MAX_FILES);
+
+  if (filesToScan.length === 0) {
+    process.stderr.write(
+      `[audit-zoom-cascade] no scanned CSS files found in ${relative(rootDir, stylesDir) || "."}\n`,
+    );
+    process.exit(2);
+  }
+
+  const violations = [];
+
+  for (const name of filesToScan) {
+    const filePath = join(stylesDir, name);
+    const roots = ZOOM_ROOTS[name];
+    let text;
+    try {
+      text = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!ABS_FONT_SIZE_RE.test(line)) continue;
+
+      // Check annotation on same line or preceding line.
+      if (CHROME_ANNOTATION_RE.test(line)) continue;
+      if (i > 0 && CHROME_ANNOTATION_RE.test(lines[i - 1])) continue;
+
+      // Check if this targets the zoom root itself.
+      const selector = extractSelector(lines, i);
+      if (isZoomRootItself(selector, roots)) continue;
+
+      violations.push({
+        file: relative(rootDir, filePath).replace(/\\/g, "/"),
+        line: i + 1,
+        selector: selector ?? "(unknown)",
+        snippet: line.trim(),
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    process.stderr.write(
+      `[audit-zoom-cascade] OK: ${filesToScan.length} CSS files scanned, no violations.\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    `[audit-zoom-cascade] FAIL: ${violations.length} absolute font-size violation(s):\n`,
+  );
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}:${v.line}  ${v.selector}\n`);
+    process.stderr.write(`    > ${v.snippet}\n`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/src/components/viewers/KqlPlanView.tsx
+++ b/src/components/viewers/KqlPlanView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { parseKql, type KqlPipelineStep } from "@/lib/tauri-commands";
 import { formatStepsForDisplay } from "@/lib/kql-format";
+import { useZoom } from "@/hooks/useZoom";
 import "@/styles/kql-plan.css";
 
 interface KqlPlanViewProps {
@@ -33,6 +34,7 @@ const KQL_OPERATORS = new Set([
 
 export function KqlPlanView({ content }: KqlPlanViewProps) {
   const [steps, setSteps] = useState<KqlPipelineStep[]>([]);
+  const { zoom } = useZoom(".kql");
 
   useEffect(() => {
     if (!content.trim()) {
@@ -57,7 +59,7 @@ export function KqlPlanView({ content }: KqlPlanViewProps) {
 
   if (!content.trim()) {
     return (
-      <div className="kql-plan-container">
+      <div className="kql-plan-container" data-zoom={zoom} style={{ fontSize: `${zoom * 100}%` }}>
         <div className="kql-empty">No query to display</div>
       </div>
     );
@@ -99,7 +101,7 @@ export function KqlPlanView({ content }: KqlPlanViewProps) {
   };
 
   return (
-    <div className="kql-plan-container">
+    <div className="kql-plan-container" data-zoom={zoom} style={{ fontSize: `${zoom * 100}%` }}>
       <div className="kql-formatted-query">{highlightKeywords(formattedQuery)}</div>
 
       <table className="kql-operator-table">

--- a/src/components/viewers/__tests__/KqlPlanView.test.tsx
+++ b/src/components/viewers/__tests__/KqlPlanView.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { KqlPlanView } from "../KqlPlanView";
 
 vi.mock("@/lib/tauri-commands", () => ({
   parseKql: vi.fn(async (query: string) => {
@@ -22,6 +21,19 @@ vi.mock("@/lib/tauri-commands", () => ({
   }),
 }));
 
+vi.mock("@/store", () => {
+  const state = {
+    zoomByFiletype: {} as Record<string, number>,
+    bumpZoom: () => {},
+    setZoom: () => {},
+  };
+  const useStore = (selector: (s: typeof state) => unknown) => selector(state);
+  (useStore as unknown as { getState: () => typeof state }).getState = () => state;
+  return { useStore };
+});
+
+import { KqlPlanView } from "../KqlPlanView";
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -37,5 +49,13 @@ describe("KqlPlanView", () => {
   it("handles empty content", () => {
     render(<KqlPlanView content="" />);
     expect(screen.getByText(/no query/i)).toBeInTheDocument();
+  });
+
+  it("applies data-zoom and fontSize style on root container", () => {
+    const { container } = render(<KqlPlanView content="" />);
+    const root = container.querySelector(".kql-plan-container") as HTMLElement;
+    expect(root).not.toBeNull();
+    expect(root.getAttribute("data-zoom")).toBe("1");
+    expect(root.style.fontSize).toBe("100%");
   });
 });

--- a/src/styles/csv-table.css
+++ b/src/styles/csv-table.css
@@ -7,7 +7,7 @@
 .csv-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 0.8125em;
   font-family: "SFMono-Regular", Consolas, monospace;
 }
 
@@ -39,13 +39,13 @@
 
 .csv-table-footer {
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   color: var(--color-muted);
 }
 
 .csv-sort-indicator {
   margin-left: 4px;
-  font-size: 10px;
+  font-size: 10px; /* zoom-cascade: chrome */
 }
 
 .csv-table td {

--- a/src/styles/html-preview.css
+++ b/src/styles/html-preview.css
@@ -4,7 +4,7 @@
   background: var(--color-surface, #f6f8fa);
   border-radius: 4px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
 }
 .html-preview-comment-toggle.is-active {
   background: var(--color-accent-bg, #ddf4ff);

--- a/src/styles/json-tree.css
+++ b/src/styles/json-tree.css
@@ -1,7 +1,7 @@
 .json-tree {
   padding: 16px;
   font-family: "SFMono-Regular", Consolas, monospace;
-  font-size: 13px;
+  font-size: 0.8125em;
   line-height: 1.6;
   overflow: auto;
   height: 100%;
@@ -18,7 +18,7 @@
   border: none;
   cursor: pointer;
   padding: 0 4px 0 0;
-  font-size: 10px;
+  font-size: 10px; /* zoom-cascade: chrome */
   color: var(--color-muted);
   user-select: none;
   width: 16px;
@@ -41,7 +41,7 @@
 
 .json-summary {
   color: var(--color-muted);
-  font-size: 12px;
+  font-size: 0.92em;
 }
 
 .json-children {
@@ -79,7 +79,7 @@
   border: 1px solid var(--color-border);
   border-radius: 4px;
   cursor: pointer;
-  font-size: 11px;
+  font-size: 11px; /* zoom-cascade: chrome */
   padding: 0 4px;
   margin-left: 8px;
   color: var(--color-muted);

--- a/src/styles/kql-plan.css
+++ b/src/styles/kql-plan.css
@@ -10,7 +10,7 @@
   border-radius: 6px;
   padding: 12px 16px;
   font-family: "SFMono-Regular", Consolas, monospace;
-  font-size: 13px;
+  font-size: 0.8125em;
   white-space: pre-wrap;
   line-height: 1.6;
   margin-bottom: 16px;
@@ -28,7 +28,7 @@
 .kql-operator-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 0.8125em;
 }
 
 .kql-operator-table th {
@@ -50,7 +50,7 @@
 
 .kql-plan-footer {
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   color: var(--color-muted, #656d76);
 }
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -16,7 +16,7 @@
   background: #fff3cd;
   border: 1px solid #ffc107;
   border-radius: 6px;
-  font-size: 13px;
+  font-size: 13px; /* zoom-cascade: chrome */
   color: #664d03;
 }
 
@@ -101,7 +101,7 @@
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 16px;
-  font-size: 13px;
+  font-size: 0.8125em;
 }
 
 .markdown-body th,
@@ -187,7 +187,7 @@
   right: 4px;
   opacity: 0;
   transition: opacity 100ms ease;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   padding: 2px 8px;
   background: var(--color-bg);
   color: var(--color-text);

--- a/src/styles/mermaid-view.css
+++ b/src/styles/mermaid-view.css
@@ -8,7 +8,7 @@
   background: var(--color-surface, #f6f8fa);
   border-radius: 4px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
 }
 
 .mermaid-toolbar button:hover {

--- a/src/styles/source-viewer.css
+++ b/src/styles/source-viewer.css
@@ -20,11 +20,11 @@
 }
 
 .binary-size {
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
 }
 
 .binary-mtime {
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
 }
 
 /* ── SourceView line-based layout ────────────────────────────────── */
@@ -81,7 +81,7 @@
 
 .source-line-comment-zone .comment-plus-btn {
   display: flex;
-  font-size: 14px;
+  font-size: 14px; /* zoom-cascade: chrome */
   width: 18px;
   height: 18px;
   padding: 0;
@@ -103,7 +103,7 @@
   flex: 1;
   text-align: right;
   padding-right: 8px;
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   padding-top: 1px;
   line-height: 20px;
 }
@@ -131,7 +131,7 @@
 }
 
 .line-comment-count {
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   color: var(--color-accent);
   background: none;
   border: none;
@@ -154,7 +154,7 @@
 }
 
 .source-line-fold-toggle {
-  font-size: 10px;
+  font-size: 10px; /* zoom-cascade: chrome */
   width: 14px;
   height: 14px;
   padding: 0;
@@ -183,7 +183,7 @@
   background: var(--color-surface);
   border-top: 1px dashed var(--color-border);
   border-bottom: 1px dashed var(--color-border);
-  font-size: 12px;
+  font-size: 12px; /* zoom-cascade: chrome */
   font-style: italic;
   cursor: pointer;
 }


### PR DESCRIPTION
## feat: implement #157  zoom-cascade audit for all viewers

Closes the CSS-cascade-override defect class for zoom-aware viewers with both runtime e2e coverage and a static lint guard.

## Requirements

- [x] AC1: New `e2e/browser/zoom-all-viewers.spec.ts` parameterised over markdown, json, csv viewers asserts fontSize cycles on Ctrl+=/-/0. HTML (iframe), KQL (mock), Mermaid (transform:scale) excluded with documented reasons.
- [x] AC2: New `scripts/audit-zoom-cascade.mjs` greps CSS for absolute font-size on descendants of zoom-styled roots.
- [x] AC3: `npm run audit:zoom-cascade` wired into CI (`.github/workflows/ci.yml`).
- [x] AC4: Viewers refactored  csv-table, json-tree, markdown table, kql-plan font-sizes converted to relative em; KqlPlanView now calls useZoom; all chrome elements annotated.
- [x] AC5: Regression test  injecting `font-size: 14px` causes audit to fail (9 tests).

Ready for review  goal achieved.

Closes #157