### PR TITLE
feat: implement #174  R2e label guard

### DIFF
--- a/.claude/shared/retrospective.md
+++ b/.claude/shared/retrospective.md
@@ -190,6 +190,14 @@ Then exit Step R — do **not** create a duplicate.
 
 ### R2e. Create the issue
 
+**Label rules (enforced by post-create assertion below):**
+
+| Rule | Labels |
+|------|--------|
+| **ALWAYS required** | `groomed`, `iterate-improvement`, `self-improve:<SKILL_TAG>` |
+| **Exactly one category** | one of: `process`, `tooling`, `test-strategy`, `architecture`, `docs`, `skill`, `agent`, `bug` |
+| **FORBIDDEN** | `needs-grooming` — the filer authored the spec body, so the issue is groomed by definition. `needs-grooming` is reserved for issues where `iterate-one-issue` 0d cannot proceed due to ambiguous specs from external authors. Violating this silently removes the issue from `iterate-loop`'s eligible pool (Step 1 skip filter). See #174. |
+
 ```bash
 NEW_ISSUE_URL=$(gh issue create \
   --title "$ISSUE_TITLE" \
@@ -198,7 +206,26 @@ NEW_ISSUE_URL=$(gh issue create \
               "$ISSUE_BODY" "$SKILL_TAG" "$RUN_TAG" "$OUTCOME" \
               "<links to each retro file>")")
 NEW_ISSUE_NUMBER=$(echo "$NEW_ISSUE_URL" | grep -oE '[0-9]+$')
+```
 
+**Post-create label assertion (#174 AC2):**
+
+```bash
+ACTUAL_LABELS=$(gh issue view "$NEW_ISSUE_NUMBER" --json labels --jq '[.labels[].name]')
+HAS_GROOMED=$(echo "$ACTUAL_LABELS" | jq 'index("groomed") != null')
+HAS_FORBIDDEN=$(echo "$ACTUAL_LABELS" | jq 'index("needs-grooming") != null')
+
+if [ "$HAS_GROOMED" != "true" ] || [ "$HAS_FORBIDDEN" = "true" ]; then
+  echo "[R2e] LABEL VIOLATION on #$NEW_ISSUE_NUMBER (see #174):"
+  echo "  groomed present: $HAS_GROOMED (must be true)"
+  echo "  needs-grooming present: $HAS_FORBIDDEN (must be false)"
+  # AC3 backfill — auto-correct and continue
+  gh issue edit "$NEW_ISSUE_NUMBER" --add-label "groomed" --remove-label "needs-grooming" 2>/dev/null || true
+  echo "[R2e] Auto-corrected: added groomed, removed needs-grooming."
+fi
+```
+
+```bash
 gh issue comment "$NEW_ISSUE_NUMBER" --body "$(cat <<EOF
 <!-- mdownreview-spec -->
 $SPEC_BODY

--- a/src/__tests__/retrospective-labeling-contract.test.ts
+++ b/src/__tests__/retrospective-labeling-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const RETRO_PATH = resolve(".", ".claude/shared/retrospective.md");
+
+describe("retrospective labeling contract (#174)", () => {
+  const content = readFileSync(RETRO_PATH, "utf8");
+
+  it("contains the 'ALWAYS includes groomed' rule", () => {
+    expect(content).toContain("ALWAYS includes `groomed`");
+  });
+
+  it("contains a Forbidden labels block with needs-grooming", () => {
+    expect(content).toContain("FORBIDDEN");
+    expect(content).toContain("`needs-grooming`");
+    // Verify the forbidden rule explains WHY
+    expect(content).toMatch(/FORBIDDEN.*needs-grooming/s);
+  });
+
+  it("contains the post-create label assertion snippet", () => {
+    // Must have the gh issue view --json labels verification
+    expect(content).toMatch(/gh issue view.*--json labels/);
+    // Must check for groomed presence
+    expect(content).toMatch(/HAS_GROOMED/);
+    // Must check for needs-grooming absence
+    expect(content).toMatch(/HAS_FORBIDDEN/);
+  });
+
+  it("contains the auto-correct backfill step", () => {
+    // Must auto-add groomed and remove needs-grooming
+    expect(content).toMatch(/--add-label.*groomed.*--remove-label.*needs-grooming/);
+  });
+
+  it("references issue #174 for traceability", () => {
+    expect(content).toContain("#174");
+  });
+});


### PR DESCRIPTION
## feat: implement #174  Self-improve filer must never apply needs-grooming

Hardens R2e in .claude/shared/retrospective.md to prevent the self-improve filer from applying needs-grooming, which caused issues to be silently skipped by iterate-loop.

## Requirements

- [ ] AC1: Prompt hardening with Allowed/Forbidden labels table
- [ ] AC2: Post-create assertion verifying labels
- [ ] AC3: Backfill rule (auto-correct if wrong labels)
- [ ] AC4: Contract test parsing retrospective.md

Closes #174