### PR TITLE
feat: implement #128  responsive layout fixes

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -208,7 +208,7 @@ body,
   flex-direction: column;
   flex: 1;
   overflow: hidden;
-  min-width: 0;
+  min-width: 200px;
 }
 
 /* ── Empty state ───────────────────────────────────────────────────── */

--- a/src/styles/comments.css
+++ b/src/styles/comments.css
@@ -18,6 +18,8 @@
   border-bottom: 1px solid var(--color-border);
   background: var(--color-surface);
   flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .comments-panel-title {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -8,6 +8,7 @@
      capped at one viewport, so the toolbar follows it off-screen
      once the user scrolls past the first viewport (#90). */
   min-height: 100%;
+  overflow-x: hidden;
 }
 
 .size-warning {

--- a/src/styles/tab-bar.css
+++ b/src/styles/tab-bar.css
@@ -5,10 +5,10 @@
   border-bottom: 1px solid var(--color-border);
   /* Must shrink so the inner .tab-bar (overflow-x: auto) overflows naturally
      and the chevrons appear at realistic viewport widths. The toolbar pairs
-     this with min-width: 0 so flex layout actually compresses the wrapper. */
+     this with min-width: 100px so at least one tab stays visible. */
   flex-shrink: 1;
   height: 34px;
-  min-width: 0;
+  min-width: 100px;
 }
 
 .tab-bar {
@@ -18,11 +18,11 @@
   flex: 1 1 auto;
   min-width: 0;
   height: 100%;
-  scrollbar-width: thin;
+  scrollbar-width: none;
 }
 
 .tab-bar::-webkit-scrollbar {
-  height: 3px;
+  display: none;
 }
 
 .tab-chevron {

--- a/src/styles/viewer-toolbar.css
+++ b/src/styles/viewer-toolbar.css
@@ -200,3 +200,19 @@
   padding: 20px;
   color: var(--color-badge);
 }
+
+/* ── Responsive toolbar labels ─────────────────────────────────────── */
+
+.viewer-toolbar-comment-on-file-label,
+.viewer-toolbar-next-unresolved-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .viewer-toolbar-comment-on-file-label,
+  .viewer-toolbar-next-unresolved-label {
+    display: none;
+  }
+}


### PR DESCRIPTION
## feat: implement #128  responsive layout fixes

Addresses 6 of 7 responsive layout findings from explore-ux (P1/P2).

## Requirements

- [x] Viewer pane has min-width: 200px (MDR-VIEWER-SQUEEZED-OUT P1)
- [x] Tab strip wrapper min-width: 100px (MDR-TABSTRIP-COLLAPSED P1)
- [x] Toolbar labels hidden at narrow widths (MDR-TOOLBAR-TEXT-CLIP P2)
- [x] Tab strip native scrollbar hidden (MDR-TABSTRIP-SCROLLBAR P2)
- [x] Comments panel header wraps gracefully (MDR-COMMENTS-HEADER-CLIPPED P2)
- [x] Markdown viewer overflow-x hidden (MDR-VIEWER-HSCROLL P2)
- [ ] Tab scroll state reset on resize (MDR-TAB-SCROLL-STATE-STICKY P3)  deferred, needs JS

Ready for review — 6/7 findings addressed (P3 deferred).

Closes #128