### PR TITLE
feat: implement #129  modal UX fix

### DIFF
--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -74,7 +74,11 @@ export function AboutDialog({ onClose }: Props) {
     >
       <div className="dialog-header">
         <h2 id="about-title">mdownreview</h2>
-        <button className="dialog-close" onClick={onClose} aria-label="Close">×</button>
+        <button className="dialog-close" onClick={onClose} aria-label="Close">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z" />
+          </svg>
+        </button>
       </div>
       <div className="dialog-body">
           <p className="dialog-version">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -104,7 +104,9 @@ export function SettingsDialog({ onClose }: Props) {
       <div className="dialog-header">
         <h2 id="settings-title">Settings</h2>
         <button className="dialog-close" onClick={onClose} aria-label="Close">
-          ×
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z" />
+          </svg>
         </button>
       </div>
       <div className="dialog-body">

--- a/src/styles/about-dialog.css
+++ b/src/styles/about-dialog.css
@@ -8,6 +8,11 @@
   z-index: 1000;
 }
 
+/* Native <dialog> backdrop when opened with showModal() */
+.dialog-box::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
 .dialog-box {
   background: var(--color-bg);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
Fixes About/Settings dialog modal UX: adds backdrop scrim, replaces  with SVG close icon.

Closes #129