### PR TITLE
fix: inject __name shim via addInitScript to fix page.evaluate ReferenceError (#177)

### DIFF
--- a/.claude/skills/test-exploratory-e2e/runner/repl.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/repl.ts
@@ -44,6 +44,16 @@ async function setup(): Promise<Session> {
   await spawnAppWithCdp();
   const browser = await chromium.connectOverCDP("http://localhost:9222");
   const context = browser.contexts()[0] ?? await browser.newContext();
+
+  // Shim esbuild's --keep-names __name helper so transformed function bodies
+  // don't ReferenceError when serialized into page.evaluate(). (#177)
+  await context.addInitScript(() => {
+    (globalThis as unknown as Record<string, unknown>).__name = (fn: unknown, _name: string) => {
+      try { Object.defineProperty(fn, "name", { value: _name, configurable: true }); } catch { /* noop */ }
+      return fn;
+    };
+  });
+
   const page = context.pages()[0] ?? await context.newPage();
   await attachDrains(page);
 
@@ -108,7 +118,6 @@ async function observe(page: Page): Promise<Observation> {
     };
     // Mirrors observe-dom.ts ariaBool — kept inline so this evaluate body
     // is self-contained when serialized into Playwright's page context.
-    // Uses plain function (no arrow + types) to avoid esbuild __name shim (#177).
     function ariaBool(el, attr) {
       if (!el.hasAttribute(attr)) return null;
       var v = el.getAttribute(attr);


### PR DESCRIPTION
## Fix

Injects a global `__name` shim via `context.addInitScript()` at REPL startup, covering **all** `page.evaluate` bodies  `observe`, `record`, `landmarks`, `screenId`, `focused`, `emit`, and any future ones.

### Root cause

`tsx` (esbuild) compiles with `--keep-names`, which wraps every named function/arrow with `__name(fn, "name")` calls. When those transformed bodies are serialized into `page.evaluate()`, the browser context has no `__name` helper  `ReferenceError`.

PR #189 tried switching arrowplain function, but esbuild wraps both forms identically.

### Fix approach (Option A from reopen comment)

`	s
await context.addInitScript(() => {
  globalThis.__name = (fn, name) => {
    try { Object.defineProperty(fn, "name", { value: name, configurable: true }); } catch {}
    return fn;
  };
});
`

One line at REPL startup. No per-evaluate changes. Covers current and future bodies.

## Requirements

- [x] `observe` action returns `{ok: true}` instead of `__name is not defined`
- [x] `record` action works (calls `observe` internally)
- [x] All other `page.evaluate` bodies with named functions are covered

Closes #177