### PR TITLE
fix: constrain folder icon size in workspace header (#190)

### DIFF
--- a/src/styles/folder-tree.css
+++ b/src/styles/folder-tree.css
@@ -233,6 +233,9 @@
 }
 
 .folder-tree-title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   font-size: 12px;
   font-weight: 600;
   overflow: hidden;
@@ -240,6 +243,21 @@
   white-space: nowrap;
   flex: 1;
   min-width: 0;
+}
+
+.folder-tree-title .toolbar-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.folder-tree-title .toolbar-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
 }
 
 .folder-tree-header-actions {


### PR DESCRIPTION
## Root Cause

`IconFolder` wraps its SVG in `<span class="toolbar-icon">`, but the CSS rules that constrain icon size (`.toolbar-btn .toolbar-icon`) require a `.toolbar-btn` ancestor. In the folder tree header, the icon sits inside `.folder-tree-title` with no `.toolbar-btn` parent, so the SVG renders at its intrinsic size (~140140px).

This pushes the workspace name label off-screen via `overflow: hidden` + `text-overflow: ellipsis`, making it invisible.

## Fix

Added explicit CSS rules for `.folder-tree-title .toolbar-icon` and `.folder-tree-title .toolbar-icon svg` that constrain the icon to 1616px (matching toolbar icons). Also added `display: flex` + `gap: 4px` to `.folder-tree-title` for proper icon-text alignment.

## Requirements

- [x] Folder icon renders at 1616px (not oversized)
- [x] Workspace name label visible alongside icon
- [x] Text ellipsis overflow still works for long paths

Closes #190