### PR TITLE
fix: constrain icon size in viewer toolbar buttons (#196)

### DIFF
--- a/src/styles/viewer-toolbar.css
+++ b/src/styles/viewer-toolbar.css
@@ -18,6 +18,9 @@
 }
 
 .viewer-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   padding: 3px 12px;
   font-size: 12px;
   border: none;
@@ -25,6 +28,21 @@
   color: var(--color-text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
+}
+
+.viewer-toolbar-btn .toolbar-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.viewer-toolbar-btn .toolbar-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
 }
 
 .viewer-toolbar-btn:hover {


### PR DESCRIPTION
## Root Cause

Same class as #190: `IconComment` wraps SVG in `<span class='toolbar-icon'>` but `.viewer-toolbar-btn` has no `.toolbar-icon` sizing rules (only `.toolbar-btn .toolbar-icon` in `app.css` does). The SVG renders at intrinsic size (~8080px).

## Fix

Added `.viewer-toolbar-btn .toolbar-icon` CSS rules (1616px container, 1414px SVG with `fill: currentColor`). Also added `display: inline-flex`, `gap: 5px`, and `align-items: center` to `.viewer-toolbar-btn` for proper icon-text alignment.

## Requirements

- [x] Comment-on-file icon renders at 1616px
- [x] Button label sits inline next to the icon
- [x] All existing ViewerToolbar tests pass (18/18)

Closes #196