### PR TITLE
fix: hide 'Empty folder' label when Other Files section is visible (#197)

### DIFF
--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -233,7 +233,7 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   const inFilterMode = !!deferredFilter;
   const noResults = inFilterMode
     ? filterGroups.length === 0
-    : treeList.length === 0;
+    : treeList.length === 0 && !showOtherFiles;
 
   return (
     <div className="folder-tree" style={{ width: folderPaneWidth }}>


### PR DESCRIPTION
## Root Cause

`noResults` in non-filter mode checked `treeList.length === 0` but didn't account for the 'Other files' section (tabs from outside the workspace root). When files existed only there, both the populated 'Other files' list and the 'Empty folder' placeholder rendered simultaneously.

## Fix

One-line change: `noResults` now also requires `!showOtherFiles` in non-filter mode:

`treeList.length === 0 && !showOtherFiles`

## Requirements

- [x] 'Empty folder' hidden when Other Files section is populated
- [x] 'Empty folder' still shows when both treeList and otherFiles are empty
- [x] All 23 FolderTree tests pass

Closes #197