### PR TITLE
chore(skills): harden iterate-one-issue  scope deferral, phased planning, bug verification

### DIFF
--- a/.claude/skills/iterate-one-issue/SKILL.md
+++ b/.claude/skills/iterate-one-issue/SKILL.md
@@ -70,17 +70,31 @@ Set `ACCEPTANCE_CRITERIA` from the resolved spec (parsed `- [ ]` / `- [x]` lines
 
 ### 0d. Clarification questions (no user prompt — defer to grooming)
 
-This skill **never calls `ask_user`**. If after reading the issue body, comments, deep-dive docs, and the assessor's view of `REQUIREMENTS` the goal is still genuinely ambiguous (scope boundaries, observable success signal, internal contradictions), do **not** guess and do **not** stop the autonomous run silently. Instead:
+This skill **never calls `ask_user`**. Defer only when the spec has a **genuine ambiguity** that falls into one of these three closed categories:
 
-1. **Goal mode** — there is no issue to update. Proceed with the most defensible interpretation of `GOAL_TEXT`, capture the ambiguity as a `### Operator clarifications (deferred)` block in the PR description, and continue.
+| # | Deferral category | Example |
+|---|---|---|
+| 1 | **Internal contradictions** | AC-3 requires X, AC-7 forbids X |
+| 2 | **Undefined success signal** | No AC has an observable verification method; "make it better" with no metric |
+| 3 | **Unresolvable external dependency** | Spec references an external API, third-party service, or user workflow the assessor cannot inspect from the codebase |
 
-2. **Issue mode** — defer to grooming:
+**Anti-pattern: scope-size deferral.** Scope size (many ACs, many files, large architectural change) is **never** a deferral reason. The 30-iteration loop with phased planning (Step 4) exists to break large goals into incremental progress. If the spec is clear, proceed — even for multi-hundred-file changes. (Incident: issue #147 was incorrectly deferred as "scope too large" despite having 9 clear ACs and a full architecture spec.)
+
+**Bias is to skip this branch entirely.** Never defer over: implementation detail, anything answered by deep-dive docs, anything the assessor can discover from the codebase, style/naming/framework choices, or scope size.
+
+When deferral is warranted:
+
+1. **Goal mode** — proceed with the most defensible interpretation of `GOAL_TEXT`, capture the ambiguity as a `### Operator clarifications (deferred)` block in the PR description, and continue.
+
+2. **Issue mode** — defer to grooming. The comment **must cite one of the three categories above**:
    ```bash
    gh issue comment $ISSUE_NUMBER --body "$(cat <<'EOF'
    <!-- iterate-needs-grooming -->
    ## /iterate-one-issue halted — clarification needed before autonomous work can proceed
 
-   The autonomous iteration loop attempted to pick up this issue but found the goal under-specified for the assessor (scope, success signal, or internal contradictions). The following blocking questions need answers before /iterate-one-issue can implement safely:
+   **Deferral category:** <internal-contradiction | undefined-success-signal | unresolvable-external-dependency>
+
+   The following blocking questions need answers before /iterate-one-issue can implement safely:
 
    <numbered list of ≤5 questions, each one sentence, each citing the ambiguity in the spec>
 
@@ -90,8 +104,6 @@ This skill **never calls `ask_user`**. If after reading the issue body, comments
    gh issue edit $ISSUE_NUMBER --add-label "needs-grooming"
    ```
    Then STOP `[iterate-one-issue] Issue #$ISSUE_NUMBER deferred to grooming. See comment.` Exit cleanly so the calling `iterate-loop` (if any) can move on to the next eligible issue.
-
-**Bias is to skip this branch entirely.** Never defer over: implementation detail, anything answered by deep-dive docs, anything the assessor can discover from the codebase, style/naming/framework choices. Only defer for genuine spec ambiguity.
 
 After 0e, no GitHub-side spec changes; the loop runs purely against the captured `REQUIREMENTS`.
 
@@ -317,7 +329,7 @@ If RCA inconclusive: do NOT halt — log `DEGRADED — bug-mode RCA inconclusive
 
 Spawn `general-purpose`:
 ```
-Comprehensive sprint plan for this iteration. Identify ALL changes — do not artificially narrow scope.
+Sprint plan for this iteration. Identify all required work, then scope this iteration to a convergent phase.
 
 Goal: <GOAL_FOR_ASSESSOR>   Iteration: <N>/30   Mode: <MODE>
 <issue mode:>
@@ -330,6 +342,12 @@ ADVISORY_SUMMARY: <…>
 BUG_RCA (load-bearing): <verbatim>
 The first plan group MUST add the regression test from BUG_RCA §5. Fix MUST follow §6 canonical shape. No fix without a corresponding test = Zero Bug Policy violation.
 <end>
+
+Phased planning (apply when NEXT_REQUIREMENTS contains >5 items OR overall risk is high):
+- Map all remaining work, then choose ONE iteration-sized phase for this iteration.
+- Phase boundaries follow dependency order (e.g. data model before UI, core logic before integration).
+- Carry remaining phases forward explicitly as "deferred to iteration N+1" — the assessor tracks partial met/unmet progress.
+- Example: a 9-AC architectural feature might target ACs 1-3 (Rust data model + types) in iteration 1, ACs 4-6 (IPC + store) in iteration 2, ACs 7-9 (UI + E2E) in iteration 3.
 
 Use NEXT_REQUIREMENTS grouping: independent groups parallel; dependents wait.
 Per group: files · exact changes · tests · group dependencies · expected local validation · AC items satisfied (issue mode, cite spec).

--- a/.claude/skills/iterate-one-issue/references/done-handlers.md
+++ b/.claude/skills/iterate-one-issue/references/done-handlers.md
@@ -4,25 +4,54 @@ Reached when Step 2's `exe-goal-assessor` returns `achieved` (every `REQUIREMENT
 
 Handler steps (in order):
 
-1. Refresh PR body — tick every requirement checkbox the assessor marked `met`, replace the summary line with `Ready for review — goal achieved.`. Issue mode keeps the `Closes #<ISSUE_NUMBER>` trailer:
+1. **Bug-mode behavioural verification (`IS_BUG` only).** Before marking the PR ready-for-review, verify the original bug is resolved at the **observation level** of the bug report — not the implementation level.
+
+   Spawn `general-purpose`:
+   ```
+   Behavioural verification for bug fix.
+   Issue: #<ISSUE_NUMBER> — <ISSUE_TITLE>
+   Bug report (body): <ISSUE_BODY>
+   BUG_RCA (from Step 3a): <BUG_RCA or "n/a">
+
+   Reproduce the original failure mode against the current codebase. Return this exact template:
+
+   LAYER: <unit | browser-e2e | native-e2e | manual-not-runnable-locally>
+   REPRO_COMMAND: <exact command or steps executed>
+   OBSERVATION: <what you inspected — DOM property, HTTP response, test assertion, file content>
+   EXPECTED: <what the bug report says should happen>
+   ACTUAL: <what you observed>
+   VERDICT: <CONFIRMED_FIXED | STILL_BROKEN | UNABLE_TO_VERIFY>
+   EVIDENCE: <command output, assertion result, or screenshot path>
+   ```
+
+   Routing:
+   - `CONFIRMED_FIXED` → continue to step 2.
+   - `STILL_BROKEN` → revert to `in_progress`. Inject the verification failure as a new `NEXT_REQUIREMENT`: `- [ ] Bug verification: <OBSERVATION> still shows <ACTUAL>; expected <EXPECTED>`. Loop back to Step 3 of the current iteration (do not increment iteration counter).
+   - `UNABLE_TO_VERIFY` (layer is `native-e2e` or `manual-not-runnable-locally` and no local reproduction is possible) → log `[done-achieved] behavioural verification: UNABLE_TO_VERIFY — <reason>`. Continue to step 2 but add a PR comment noting the limitation:
+     ```bash
+     gh pr comment <PR_NUMBER> --body "<!-- iterate-verify-limitation -->
+     ⚠️ Bug-mode behavioural verification could not confirm fix at the reporter's observation level (requires <LAYER>). Unit/browser tests pass. Manual verification recommended before merge."
+     ```
+
+2. Refresh PR body — tick every requirement checkbox the assessor marked `met`, replace the summary line with `Ready for review — goal achieved.`. Issue mode keeps the `Closes #<ISSUE_NUMBER>` trailer:
    ```bash
    gh pr edit <PR_NUMBER> --body "<final body>"
    ```
-2. Mark the PR ready-for-review (only place this skill flips the draft state):
+3. Mark the PR ready-for-review (only place this skill flips the draft state):
    ```bash
    gh pr ready <PR_NUMBER>
    ```
-3. Add the `iterate-pr` label so `merge-pr-loop` will pick it up. Idempotent label create on first run:
+4. Add the `iterate-pr` label so `merge-pr-loop` will pick it up. Idempotent label create on first run:
    ```bash
    gh label create iterate-pr --description "PR opened by iterate-one-issue, awaiting release-gate validation by merge-pr-loop" --color BFD4F2 2>/dev/null || true
    gh pr edit <PR_NUMBER> --add-label iterate-pr
    ```
-4. Comment on the PR:
+5. Comment on the PR:
    ```bash
    gh pr comment <PR_NUMBER> --body "<!-- iterate-done-achieved -->
    ✅ Goal achieved on commit \`$(git rev-parse --short HEAD)\`. PR ready for review; \`merge-pr-loop\` will run the release gate and merge."
    ```
-5. Run **Phase 2** (only path where 2e may auto-recurse).
+6. Run **Phase 2** (only path where 2e may auto-recurse).
 
 Source-issue closure is automatic on PR merge via the `Closes #<N>` trailer. The `iterate-in-progress` claim label is owned by `iterate-loop` (when this skill was invoked from it) and cleared by the loop after parsing `ITERATE_OUTCOME` — this skill does not touch it.
 

--- a/.claude/skills/iterate-one-issue/references/halt-semantics.md
+++ b/.claude/skills/iterate-one-issue/references/halt-semantics.md
@@ -22,7 +22,7 @@
 - No arg passed (use `iterate-loop` for backlog drain)
 - Dirty tree at setup
 - Pre-existing target branch (issue/goal mode only — `--resume-pr` deliberately reuses an existing branch)
-- Genuine spec ambiguity in issue mode (posts comment + `needs-grooming` label, exits cleanly so `iterate-loop` can move on)
+- Genuine spec ambiguity in issue mode — restricted to three closed categories: internal contradictions, undefined success signal, unresolvable external dependency (posts comment citing category + `needs-grooming` label, exits cleanly so `iterate-loop` can move on)
 - `--resume-pr` referenced PR is not OPEN, or lacks the `iterate-pr` label
 
 **No chaining inside this skill.** Done-Achieved / Done-Blocked / Done-TimedOut / Done-ForwardFixed all print `ITERATE_OUTCOME: …` then exit. The caller (`iterate-loop` for the backlog drain, `merge-pr-loop` for forward-fix passes) decides what runs next.
@@ -30,5 +30,6 @@
 **No longer halts:**
 - Issue has no `<!-- mdownreview-spec -->` comment (0c derives)
 - Genuine spec ambiguity in goal mode (captured in PR description, run continues)
+- Large scope / many ACs / many files (30-iteration loop + phased planning handles this; see 0d anti-pattern)
 
 ---

--- a/src/__tests__/iterate-skill-contract.test.ts
+++ b/src/__tests__/iterate-skill-contract.test.ts
@@ -17,6 +17,18 @@ const SKILL_PATH = resolve(
 );
 const SKILL = readFileSync(SKILL_PATH, "utf8");
 
+const HALT_PATH = resolve(
+  __dirname,
+  "../../.claude/skills/iterate-one-issue/references/halt-semantics.md",
+);
+const HALT = readFileSync(HALT_PATH, "utf8");
+
+const DONE_HANDLERS_PATH = resolve(
+  __dirname,
+  "../../.claude/skills/iterate-one-issue/references/done-handlers.md",
+);
+const DONE_HANDLERS = readFileSync(DONE_HANDLERS_PATH, "utf8");
+
 describe("iterate-one-issue skill — DIFF_CLASS scoping (issue #122)", () => {
   it("Step 6b classifies the diff into code | prompt-only | docs-only | none", () => {
     expect(SKILL).toMatch(/####\s+6b\.?\s+Classify diff/i);
@@ -52,5 +64,79 @@ describe("iterate-one-issue skill — DIFF_CLASS scoping (issue #122)", () => {
   it("CI poller comment notes path-filtered checks skip fast on docs/prompt diffs", () => {
     expect(SKILL.toLowerCase()).toContain("path-filtered");
     expect(SKILL).toMatch(/prompt-only[`'/\\\s]+docs-only[\s\S]{0,80}skip[s]?\s+green/);
+  });
+});
+
+describe("iterate-one-issue skill — 0d closed deferral categories (issue #147)", () => {
+  it("Step 0d defines exactly three closed deferral categories", () => {
+    expect(SKILL).toMatch(/Internal contradictions/);
+    expect(SKILL).toMatch(/Undefined success signal/);
+    expect(SKILL).toMatch(/Unresolvable external dependency/);
+  });
+
+  it("Step 0d explicitly forbids scope-size deferral as an anti-pattern", () => {
+    expect(SKILL).toMatch(
+      /[Ss]cope.size[\s\S]*?never[\s\S]*?deferral reason/,
+    );
+  });
+
+  it("Step 0d deferral comment template requires citing a category", () => {
+    expect(SKILL).toMatch(
+      /Deferral category.*internal-contradiction.*undefined-success-signal.*unresolvable-external-dependency/s,
+    );
+  });
+
+  it("halt-semantics.md lists scope size in 'No longer halts'", () => {
+    expect(HALT).toMatch(/No longer halts/);
+    expect(HALT).toMatch(/[Ll]arge scope|many ACs|many files/);
+  });
+
+  it("halt-semantics.md pre-loop halt cites the three closed categories", () => {
+    expect(HALT).toMatch(
+      /internal contradictions.*undefined success signal.*unresolvable external dependency/is,
+    );
+  });
+});
+
+describe("iterate-one-issue skill — phased planning in Step 4", () => {
+  it("Step 4 planner prompt includes phased planning guidance", () => {
+    expect(SKILL).toMatch(/Phased planning/);
+    expect(SKILL).toMatch(/iteration-sized phase/);
+  });
+
+  it("Step 4 planner prompt does not say 'do not artificially narrow scope'", () => {
+    // Old wording conflicted with phased planning; replaced with convergent-phase language
+    expect(SKILL).not.toMatch(/do not artificially narrow scope/i);
+  });
+});
+
+describe("iterate-one-issue skill — bug-mode behavioural verification (issue #192)", () => {
+  it("Done-Achieved handler includes bug-mode behavioural verification step", () => {
+    expect(DONE_HANDLERS).toMatch(/[Bb]ug.mode behavioural verification/);
+  });
+
+  it("verification requires observation-level evidence, not implementation-level", () => {
+    expect(DONE_HANDLERS).toMatch(/observation level/);
+    expect(DONE_HANDLERS).toMatch(/not the implementation level/);
+  });
+
+  it("verification template includes structured fields", () => {
+    expect(DONE_HANDLERS).toMatch(/LAYER:/);
+    expect(DONE_HANDLERS).toMatch(/REPRO_COMMAND:/);
+    expect(DONE_HANDLERS).toMatch(/OBSERVATION:/);
+    expect(DONE_HANDLERS).toMatch(/VERDICT:.*CONFIRMED_FIXED.*STILL_BROKEN.*UNABLE_TO_VERIFY/s);
+  });
+
+  it("STILL_BROKEN verdict reverts to in_progress, not ready-for-review", () => {
+    expect(DONE_HANDLERS).toMatch(/STILL_BROKEN.*revert to.*in_progress/is);
+  });
+
+  it("verification runs before PR is marked ready-for-review", () => {
+    // Bug verification (step 1) must appear before gh pr ready (step 3)
+    const verifyIdx = DONE_HANDLERS.indexOf("Bug-mode behavioural verification");
+    const readyIdx = DONE_HANDLERS.indexOf("gh pr ready");
+    expect(verifyIdx).toBeGreaterThan(-1);
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(verifyIdx).toBeLessThan(readyIdx);
   });
 });


### PR DESCRIPTION
## Summary

Four improvements to iterate-one-issue driven by real incidents and self-improvement issues.

### P1+P5: Closed deferral categories in Step 0d (fixes #147 regression)
- Rewrote Step 0d with three explicit, closed deferral categories: internal contradictions, undefined success signal, unresolvable external dependency
- Explicitly forbid scope-size deferral as an anti-pattern with citation of the #147 incident
- Updated halt-semantics.md to reflect the closed categories and add scope-size to 'No longer halts'

### P2: Bug-mode behavioural verification in Done-Achieved (#192)
- Before marking a bug-fix PR ready-for-review, a new verification step reproduces the original bug at the **observation level** of the bug report
- Structured verification recipe: LAYER, REPRO_COMMAND, OBSERVATION, EXPECTED, ACTUAL, VERDICT, EVIDENCE
- Three verdict paths: CONFIRMED_FIXED (continue), STILL_BROKEN (revert to in_progress), UNABLE_TO_VERIFY (continue with caveat)
- Prevents false-positive closes like #94, #181, #177

### P3: Phased planning in Step 4
- Replaced conflicting 'do not artificially narrow scope' with convergent-phase language
- When >5 unchecked ACs or high risk, planner partitions into iteration-sized phases
- Assessor already tracks partial met/unmet progress; planner now matches

### Contract tests
- Extended \iterate-skill-contract.test.ts\ with 11 new tests covering all changes
- 0d closed categories + anti-pattern, phased planning, behavioural verification ordering

### Also
- Closed #179 (prioritize test-exploratory-e2e in auto-pick)  decided not to implement

## Test results
All 149 test files, 1592 tests pass.