### PR TITLE
chore: improve test-exploratory-e2e skill  fix #177, #175, #191 + new actions, seeds, heuristics, flows

### DIFF
--- a/.claude/skills/test-exploratory-e2e/SKILL.md
+++ b/.claude/skills/test-exploratory-e2e/SKILL.md
@@ -45,7 +45,10 @@ You write one JSON line to stdin, the REPL writes one JSON line to stdout. Use `
 | `{"act":"press","key":"Control+Tab"}` | `{"ok":true}` |
 | `{"act":"type","selector":"...","text":"..."}` | `{"ok":true}` |
 | `{"act":"hover","selector":"..."}` | `{"ok":true}` |
+| `{"act":"select_text","selector":"...","startOffset":0,"endOffset":50}` | `{"ok":true}` — selects text range in the target element; triggers `selectionchange` so React listeners (SelectionToolbar) pick it up. Defaults: start=0, end=entire-text. |
 | `{"act":"resize","width":480,"height":800}` | `{"ok":true}` |
+| `{"act":"scroll","selector":".viewer-content","y":500}` | `{"ok":true}` — scrolls the element (or window if no selector) to the given x/y offset. |
+| `{"act":"wait_for_selector","selector":".selection-toolbar","state":"visible","timeout":3000}` | `{"ok":true}` — waits for a selector to reach the given state (visible/hidden/attached). Default timeout 5s. |
 | `{"act":"emit","event":"menu-about"}` | `{"ok":true}` |
 | `{"act":"cli","args":["D:/work/mdownreview2/docs/architecture.md", ...]}` | `{"ok":true}` |
 | `{"act":"record","heuristic":"<id>","severity":"P1\|P2\|P3","anchor":"...","detail":"...","screenshot":"...","group":"<tag>"}` | `{"ok":true,"result":{"status":"NEW\|REPRODUCED"}}` |

--- a/.claude/skills/test-exploratory-e2e/flows/catalogue.md
+++ b/.claude/skills/test-exploratory-e2e/flows/catalogue.md
@@ -225,3 +225,72 @@ steps:
   - { kind: press, key: "Control+W" }
   - { kind: wait, ms: 150 }
 ```
+
+## comment-on-file
+
+```yaml
+id: comment-on-file
+name: Open a file and attempt to add a file-level comment via toolbar
+priority: 1
+preconditions:
+  - "open-folder-and-files"
+steps:
+  - { kind: wait, ms: 500 }
+  - { kind: click, selector: "button[aria-label='Add comment on file'], button[aria-label='Comment on file'], .comment-file-btn" }
+  - { kind: wait, ms: 300 }
+  - { kind: press, key: "Escape" }
+  - { kind: wait, ms: 100 }
+```
+
+## open-source-files
+
+```yaml
+id: open-source-files
+name: Open TypeScript and Rust source files to exercise SourceView
+priority: 2
+steps:
+  - kind: cli
+    args:
+      - "D:/work/mdownreview2/src/App.tsx"
+      - "D:/work/mdownreview2/src/logger.ts"
+      - "D:/work/mdownreview2/src/store/index.ts"
+      - "D:/work/mdownreview2/src-tauri/src/lib.rs"
+      - "D:/work/mdownreview2/src-tauri/src/watcher.rs"
+  - { kind: wait, ms: 2000 }
+success_signal:
+  selector: ".tab-bar [role='tab'], .tab-bar button"
+```
+
+## search-in-viewer
+
+```yaml
+id: search-in-viewer
+name: Open in-viewer search and try basic queries
+priority: 2
+preconditions:
+  - "open-folder-and-files"
+steps:
+  - { kind: press, key: "Control+f" }
+  - { kind: wait, ms: 200 }
+  - { kind: press, key: "Escape" }
+  - { kind: wait, ms: 100 }
+```
+
+## source-file-resize
+
+```yaml
+id: source-file-resize
+name: Resize the window while a source file is active
+priority: 2
+preconditions:
+  - "open-source-files"
+steps:
+  - { kind: resize, width: 1280, height: 800 }
+  - { kind: wait, ms: 200 }
+  - { kind: resize, width: 800, height: 600 }
+  - { kind: wait, ms: 200 }
+  - { kind: resize, width: 480, height: 600 }
+  - { kind: wait, ms: 200 }
+  - { kind: resize, width: 1280, height: 800 }
+  - { kind: wait, ms: 100 }
+```

--- a/.claude/skills/test-exploratory-e2e/heuristics/mdownreview-specific.md
+++ b/.claude/skills/test-exploratory-e2e/heuristics/mdownreview-specific.md
@@ -13,6 +13,8 @@ target known soft spots in the codebase.
 | `MDR-THEME-FLASH` | FOUC on theme toggle (background transitions through wrong value) | Screenshot diff at 0/50/200 ms after toggle |
 | `MDR-SCROLL-JUMP` | Source view scroll position resets after add/edit comment | Capture scrollTop before/after IPC |
 | `MDR-CONSOLE-ERROR` | Any unhandled `console.error` during run | Console drain |
+| `MDR-SYNTAX-FAIL` | Source view tokens render uniform black (no syntax highlighting) | DOM scan for `<code>` / `<pre>` children: if all `<span>` children lack inline `style="color:..."`, flag. |
+| `MDR-BLANK-VIEWER` | Viewer pane is empty (no content rendered) after file load | DOM scan for empty `main` or `.viewer-content` with zero text nodes after a wait. |
 | `MDR-MENU-EVENT-MISMATCH` | Menu event fired but no handler | Listen for unhandled event payloads |
 
 ## MDR-IPC-RAW-JSON-ERROR
@@ -71,3 +73,20 @@ Menu events are flat kebab-case names that must be mirrored in
 `src/lib/tauri-events.ts` AND `src-tauri/src/lib.rs::on_menu_event`. Detector:
 capture every menu event payload during exploration; flag any payload name not
 present in the known event map.
+
+## MDR-SYNTAX-FAIL
+
+Source view code blocks render all tokens in the same colour (typically black
+or the base foreground). This indicates Shiki failed to load the language
+grammar or `codeToHtml` returned unstyled output. Prior regressions: #94,
+#181. Detector: after opening a `.ts` or `.rs` file, scan the rendered
+`<pre><code>` block for `<span>` children; flag if zero spans have an inline
+`style` attribute containing `color:`.
+
+## MDR-BLANK-VIEWER
+
+After opening a file, the viewer pane contains no visible text content. The
+file tree shows the file is selected and a tab exists, but the center pane is
+empty or shows only a loading indicator that never resolves. Detector: after
+`cli` action + 2s wait, check `document.querySelector('.viewer-content, main')`
+for `textContent.trim().length === 0`.

--- a/.claude/skills/test-exploratory-e2e/runner/analyze.test.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/analyze.test.ts
@@ -39,4 +39,24 @@ describe("rule engine — deterministic families", () => {
     const hits = runRules(load("ap-emoji-as-icon"));
     expect(hits.map((h) => h.id)).toContain("AP-EMOJI-AS-ICON");
   });
+
+  it("MDR-SYNTAX-FAIL fires when code block spans lack inline color styles", () => {
+    const hits = runRules(load("mdr-syntax-fail"));
+    expect(hits.some((h) => h.id === "MDR-SYNTAX-FAIL")).toBe(true);
+  });
+
+  it("MDR-SYNTAX-FAIL does not fire when spans have inline color styles", () => {
+    const hits = runRules(load("mdr-syntax-pass"));
+    expect(hits.some((h) => h.id === "MDR-SYNTAX-FAIL")).toBe(false);
+  });
+
+  it("MDR-BLANK-VIEWER fires when viewer pane has no text content", () => {
+    const hits = runRules(load("mdr-blank-viewer"));
+    expect(hits.some((h) => h.id === "MDR-BLANK-VIEWER")).toBe(true);
+  });
+
+  it("MDR-BLANK-VIEWER does not fire on normal content", () => {
+    const hits = runRules(load("mdr-syntax-pass"));
+    expect(hits.some((h) => h.id === "MDR-BLANK-VIEWER")).toBe(false);
+  });
 });

--- a/.claude/skills/test-exploratory-e2e/runner/analyze.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/analyze.ts
@@ -117,12 +117,53 @@ const ruleApEmojiAsIcon: Rule = (s) => {
   return hits;
 };
 
+const ruleMdrSyntaxFail: Rule = (s) => {
+  const codeBlockRe = /<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/gi;
+  const hits: RuleHit[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = codeBlockRe.exec(s.html)) !== null) {
+    const inner = m[1];
+    if (!inner.trim()) continue;
+    const spans = inner.match(/<span[^>]*>/g);
+    if (!spans || spans.length === 0) continue;
+    const styledSpans = spans.filter((sp) => /style="[^"]*color:/i.test(sp));
+    if (styledSpans.length === 0) {
+      hits.push({
+        id: "MDR-SYNTAX-FAIL",
+        detail: `code block has ${spans.length} spans but none with inline color — tokens may render uniform black`,
+        anchor: "pre > code",
+      });
+    }
+  }
+  return hits;
+};
+
+const ruleMdrBlankViewer: Rule = (s) => {
+  const viewerRe = /<(?:div|main|section)[^>]*class="[^"]*(?:viewer-content|markdown-body|source-view)[^"]*"[^>]*>([\s\S]*?)<\/(?:div|main|section)>/gi;
+  const hits: RuleHit[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = viewerRe.exec(s.html)) !== null) {
+    const inner = m[1].replace(/<[^>]+>/g, "").trim();
+    if (inner.length === 0) {
+      const cls = /class="([^"]*)"/.exec(m[0]);
+      hits.push({
+        id: "MDR-BLANK-VIEWER",
+        detail: "viewer pane is empty — no visible text content after file load",
+        anchor: cls ? `div.${cls[1].split(/\s+/)[0]}` : "div.viewer-content",
+      });
+    }
+  }
+  return hits;
+};
+
 const RULES: Rule[] = [
   ruleMdrIpcRawJson,
   ruleMdrConsoleError,
   ruleWcag143,
   ruleWcag412,
   ruleApEmojiAsIcon,
+  ruleMdrSyntaxFail,
+  ruleMdrBlankViewer,
 ];
 
 export function runRules(snapshot: Snapshot): RuleHit[] {

--- a/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-blank-viewer.json
+++ b/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-blank-viewer.json
@@ -1,0 +1,7 @@
+{
+  "html": "<div class=\"viewer-content markdown-body\"></div>",
+  "console": [],
+  "ipc_errors": [],
+  "a11y_nodes": [],
+  "computed_styles": []
+}

--- a/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-syntax-fail.json
+++ b/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-syntax-fail.json
@@ -1,0 +1,7 @@
+{
+  "html": "<pre class=\"shiki\"><code class=\"language-ts\"><span>const</span> <span>x</span> <span>=</span> <span>42</span></code></pre>",
+  "console": [],
+  "ipc_errors": [],
+  "a11y_nodes": [],
+  "computed_styles": []
+}

--- a/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-syntax-pass.json
+++ b/.claude/skills/test-exploratory-e2e/runner/fixtures/mdr-syntax-pass.json
@@ -1,0 +1,7 @@
+{
+  "html": "<pre class=\"shiki\"><code class=\"language-ts\"><span style=\"color:#C678DD\">const</span> <span style=\"color:#E06C75\">x</span> <span style=\"color:#56B6C2\">=</span> <span style=\"color:#D19A66\">42</span></code></pre>",
+  "console": [],
+  "ipc_errors": [],
+  "a11y_nodes": [],
+  "computed_styles": []
+}

--- a/.claude/skills/test-exploratory-e2e/runner/observe-dom.test.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/observe-dom.test.ts
@@ -206,3 +206,25 @@ describe("ariaName / focusSelector", () => {
     expect(focusSelector(clsEl)).toBe("button.btn");
   });
 });
+
+describe("__name injection guard (#177)", () => {
+  it("inline ariaBool in repl.ts observe body must be a plain function, not a typed arrow", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      ".claude/skills/test-exploratory-e2e/runner/repl.ts",
+      "utf8",
+    );
+    // Find the interactives evaluate body
+    const evalMatch = src.match(
+      /const interactives = await page\.evaluate\(([\s\S]*?)}, makeSelectorFn\(\)\);/,
+    );
+    expect(evalMatch).not.toBeNull();
+    const evalBody = evalMatch![1];
+    // ariaBool must NOT have TypeScript type annotations
+    expect(evalBody).not.toMatch(/function ariaBool\([^)]*:[^)]*\)/);
+    // Strip single-line comments before checking for __name() calls —
+    // the warning comment itself legitimately mentions __name().
+    const codeOnly = evalBody.replace(/\/\/.*$/gm, "");
+    expect(codeOnly).not.toContain("__name(");
+  });
+});

--- a/.claude/skills/test-exploratory-e2e/runner/repl.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/repl.ts
@@ -116,8 +116,12 @@ async function observe(page: Page): Promise<Observation> {
       select: "combobox", nav: "navigation", header: "banner", main: "main",
       footer: "contentinfo", aside: "complementary", dialog: "dialog",
     };
-    // Mirrors observe-dom.ts ariaBool — kept inline so this evaluate body
-    // is self-contained when serialized into Playwright's page context.
+    // ⚠️  CRITICAL: Every function inside this page.evaluate body MUST be a
+    // plain JS function with NO TypeScript type annotations. tsx/esbuild's
+    // --keepNames injects __name() wrappers around typed functions, and
+    // __name doesn't exist in the browser context → ReferenceError (#177).
+    // The addInitScript shim in setup() is defence-in-depth only.
+    // Regression test: observe-dom.test.ts "__name injection guard (#177)".
     function ariaBool(el, attr) {
       if (!el.hasAttribute(attr)) return null;
       var v = el.getAttribute(attr);
@@ -272,7 +276,62 @@ async function execute(cmd: Command, s: Session): Promise<Response> {
       case "press":      await s.page.keyboard.press(cmd.key); return ok({ ok: true });
       case "type":       await s.page.fill(cmd.selector, cmd.text, { timeout: 3000 }); return ok({ ok: true });
       case "hover":      await s.page.hover(cmd.selector, { timeout: 3000 }); return ok({ ok: true });
+      case "select_text": {
+        await s.page.evaluate(
+          function (sel, startOff, endOff) {
+            var target = document.querySelector(sel);
+            if (!target) throw new Error("select_text: selector not found: " + sel);
+            var textNode = target.firstChild;
+            if (textNode && textNode.nodeType !== Node.TEXT_NODE) {
+              var walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+              textNode = walker.nextNode();
+            }
+            if (!textNode) throw new Error("select_text: no text node in " + sel);
+            var len = textNode.textContent ? textNode.textContent.length : 0;
+            var range = document.createRange();
+            range.setStart(textNode, Math.min(startOff, len));
+            range.setEnd(textNode, Math.min(endOff, len));
+            var selection = window.getSelection();
+            if (selection) {
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+            document.dispatchEvent(new Event("selectionchange"));
+          },
+          cmd.selector,
+          cmd.startOffset ?? 0,
+          cmd.endOffset ?? 999999,
+        );
+        return ok({ ok: true });
+      }
       case "resize":     await s.page.setViewportSize({ width: cmd.width, height: cmd.height }); return ok({ ok: true });
+      case "scroll": {
+        if (cmd.selector) {
+          await s.page.evaluate(
+            function (sel, x, y) {
+              var el = document.querySelector(sel);
+              if (el) el.scrollTo(x, y);
+            },
+            cmd.selector,
+            cmd.x ?? 0,
+            cmd.y ?? 0,
+          );
+        } else {
+          await s.page.evaluate(
+            function (x, y) { window.scrollTo(x, y); },
+            cmd.x ?? 0,
+            cmd.y ?? 0,
+          );
+        }
+        return ok({ ok: true });
+      }
+      case "wait_for_selector": {
+        await s.page.waitForSelector(cmd.selector, {
+          state: cmd.state ?? "visible",
+          timeout: cmd.timeout ?? 5000,
+        });
+        return ok({ ok: true });
+      }
       case "emit": {
         const event = cmd.event;
         await s.page.evaluate(async (ev) => {

--- a/.claude/skills/test-exploratory-e2e/runner/tools.ts
+++ b/.claude/skills/test-exploratory-e2e/runner/tools.ts
@@ -12,6 +12,9 @@ export type Command =
   | { act: "press";  key: string }
   | { act: "type";   selector: string; text: string }
   | { act: "hover";  selector: string }
+  | { act: "select_text"; selector: string; startOffset?: number; endOffset?: number }
+  | { act: "scroll"; selector?: string; x?: number; y?: number }
+  | { act: "wait_for_selector"; selector: string; state?: "visible" | "hidden" | "attached"; timeout?: number }
   | { act: "resize"; width: number; height: number }
   | { act: "emit";   event: string }
   | { act: "cli";    args: string[] }

--- a/.claude/skills/test-exploratory-e2e/seeds/comment-reviewer.md
+++ b/.claude/skills/test-exploratory-e2e/seeds/comment-reviewer.md
@@ -1,0 +1,23 @@
+# comment-reviewer
+
+You are a reviewer who has been assigned a batch of markdown files to review.
+Your workflow: open files, read them, select text, add inline comments, edit
+comments, resolve comments. You exercise the full comment lifecycle.
+
+Behaviour to drive:
+- Open several files via `act:"cli"`.
+- Use `act:"select_text"` to select a passage, then look for the
+  SelectionToolbar to appear (use `act:"wait_for_selector"` + `act:"observe"`).
+- Click "Add comment on selection" if visible.
+- Type a review comment into the comment input field.
+- Try to edit an existing comment.
+- Try to resolve / delete a comment.
+- Toggle the comments pane (Ctrl+Shift+C) to see all comments.
+- Try adding a comment at the very top and very bottom of a file.
+
+You expose:
+- SelectionToolbar not appearing or appearing in the wrong position.
+- Comment input focus traps or keyboard-unreachable submit buttons.
+- Comments panel not updating after add/edit/delete.
+- Orphaned-comment indicators appearing incorrectly.
+- Scroll-jump after comment actions (MDR-SCROLL-JUMP).

--- a/.claude/skills/test-exploratory-e2e/seeds/multi-format.md
+++ b/.claude/skills/test-exploratory-e2e/seeds/multi-format.md
@@ -1,0 +1,25 @@
+# multi-format
+
+You open files of many different types to exercise every viewer in
+mdownreview: markdown, source code, Mermaid diagrams, JSON, CSV, HTML,
+images, and binary files.
+
+Behaviour to drive:
+- Use `act:"cli"` to open a mix of file types from the repo:
+  - `.md` files → MarkdownViewer
+  - `.ts` / `.tsx` / `.rs` files → SourceView
+  - `.json` files → JSON viewer
+  - `.css` files → SourceView
+  - Binary files (`.png`, `.exe`) → BinaryPlaceholder / image viewer
+- After opening each, screenshot + observe. Look for:
+  - Blank screens / loading spinners that never resolve.
+  - Syntax highlighting failures (uniform black text = MDR-SYNTAX-FAIL).
+  - Console errors from unsupported file types.
+- Switch between tabs of different viewer types rapidly (Ctrl+Tab).
+- Resize the window while a non-markdown file is active.
+
+You expose:
+- Viewer routing bugs (wrong viewer for a file type).
+- Syntax highlighting regressions (#94, #181).
+- Missing file-type support causing blank screens or crashes.
+- Console errors when switching between viewer types.

--- a/.claude/skills/test-exploratory-e2e/seeds/search-user.md
+++ b/.claude/skills/test-exploratory-e2e/seeds/search-user.md
@@ -1,0 +1,22 @@
+# search-user
+
+You use the search feature heavily. You search for terms within the current
+file and across the workspace. You test edge cases: empty queries, very long
+queries, special characters, regex patterns.
+
+Behaviour to drive:
+- Open several files via `act:"cli"`.
+- Press Ctrl+F to open in-viewer search (if available).
+- Type search queries and observe results highlighting.
+- Try workspace-level search if a search input exists in the sidebar.
+- Type edge-case queries: empty string, single character, `.*`, `[`, `(`,
+  Unicode characters, very long strings (200+ chars).
+- Press Enter / Shift+Enter to cycle through results.
+- Press Escape to dismiss search.
+
+You expose:
+- Search not finding visible text.
+- Regex special characters causing crashes or console errors.
+- Search highlight not clearing after dismiss.
+- Focus getting stuck in the search input.
+- Performance issues with large files or many results.

--- a/.claude/skills/test-exploratory-loop/SKILL.md
+++ b/.claude/skills/test-exploratory-loop/SKILL.md
@@ -58,9 +58,10 @@ For `i = 1 .. iterations`:
    Fetches origin, fast-forwards `main`. Refuses if the working tree is dirty outside the allow-list (only `.claude/retrospectives/**.md` is allowed; those are stashed across the ff and restored).
 6. **Rebuild** (unless `--no-build`):
    ```powershell
-   npm run tauri -- build --debug   # or `npm run tauri:build` for release
+   npm run build && npm run tauri -- build --debug
    ```
-   Skip if the user is running Vite-served debug — the binary already follows source.
+   **Always rebuild on every iteration.** Tauri `build --debug` bundles `dist/` at build time (`frontendDist=../dist` in `tauri.conf.json`), so frontend-only PRs are invisible to a previously-built `.exe` (#191). With Rust caching, rebuild is ~30s — well within the per-iteration budget. Running `npm run build` first ensures `dist/` is fresh before the Tauri bundler picks it up.
+   Skip only if the user explicitly passes `--no-build`.
 7. Brief progress report: `[loop i/N] new=X reproduced=Y filed=Z; advance=<old>..<new>`.
 
 After the last iteration, write a session digest to `.claude/test-exploratory-loop/runs/<ISO-ts>/loop.md` summarising per-iteration counts, all baseline→advance SHA pairs, and links to filed/reproduced issues.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     exclude: [
       "node_modules",
       "e2e",
-      ...(process.env.EXPLORE_UX_SMOKE === "1" ? [] : ["**/*.smoke.test.ts"]),
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary

Fixes all open \self-improve:test-exploratory-e2e\ issues and ships improvements identified from retrospectives.

### Bug fixes
- **#177**: Add regression test guarding against \__name\ injection in \page.evaluate\ bodies (esbuild \keepNames\ issue)
- **#175**: Add \select_text\ REPL action  unlocks SelectionToolbar/comment-on-selection testing via Range API
- **#191**: Always rebuild binary in test-exploratory-loop pre-flight to prevent stale \dist/\ false negatives

### New REPL actions
- \select_text\  programmatic text selection with \selectionchange\ dispatch
- \scroll\  scroll an element or window to x/y offset
- \wait_for_selector\  wait for a selector to reach visible/hidden/attached state

### New persona seeds
- \comment-reviewer\  exercises comment lifecycle (add, edit, resolve, delete)
- \multi-format\  opens diverse file types (md, ts, rs, json, binary)
- \search-user\  exercises search with edge cases

### New heuristics + automated rules
- \MDR-SYNTAX-FAIL\  detects unstyled code blocks (uniform black tokens regression)
- \MDR-BLANK-VIEWER\  detects empty viewer panes after file load

### New flow catalogue entries
- \comment-on-file\  file-level comment via toolbar
- \open-source-files\  SourceView exercise with .ts/.rs files
- \search-in-viewer\  Ctrl+F open/dismiss flow
- \source-file-resize\  resize with source file active

### Other
- Include smoke tests in vitest config (self-skip via \describe.skipIf\)

**Tests:** 1597 passed, 1 skipped, 0 failures