### PR TITLE
fix: constrain HTML preview comment toggle button size

### DIFF
--- a/src/styles/html-preview.css
+++ b/src/styles/html-preview.css
@@ -1,10 +1,27 @@
 .html-preview-comment-toggle {
-  padding: 2px 8px;
+  padding: 3px 10px;
   border: 1px solid var(--color-border, #d0d7de);
-  background: var(--color-surface, #f6f8fa);
+  background: transparent;
   border-radius: 4px;
   cursor: pointer;
   font-size: 12px; /* zoom-cascade: chrome */
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  vertical-align: middle;
+}
+.html-preview-comment-toggle .toolbar-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+.html-preview-comment-toggle .toolbar-icon svg {
+  width: 12px;
+  height: 12px;
+  fill: currentColor;
 }
 .html-preview-comment-toggle.is-active {
   background: var(--color-accent-bg, #ddf4ff);


### PR DESCRIPTION
## Problem

The Comment toggle button in HtmlPreviewView was rendering at ~7378px  oversized relative to sibling toolbar buttons (~22px height). At narrow viewports (600px), the banner controls consumed ~50% of viewport height, pushing content below the fold.

**Root cause:** \IconComment\ wraps its SVG in \<span class='toolbar-icon'>\, but \.toolbar-icon\ sizing rules only applied inside \.toolbar-btn\, \.folder-tree-title\, or \.viewer-toolbar-btn\  not \.html-preview-comment-toggle\. The SVG rendered at its natural (unconstrained) size.

## Fix

Added explicit \.toolbar-icon\ sizing rules scoped to \.html-preview-comment-toggle\ in \html-preview.css\:
- Constrain icon to 1412px (matching toolbar conventions)
- Use \inline-flex\ + \gap\ for icon/label alignment
- Match padding to sibling \.comment-btn\ buttons

CSS-only change  no component logic altered.

## Testing

All 16 HtmlPreviewView tests pass.

Closes #205