### PR TITLE
fix: implement #206  syntax highlighting regression (MDR-SYNTAX-FAIL)

### DIFF
--- a/e2e/browser/source-highlighting.spec.ts
+++ b/e2e/browser/source-highlighting.spec.ts
@@ -117,6 +117,65 @@ test.describe("Source view syntax highlighting (#181)", () => {
       `Expected multiple distinct token colors but found: ${[...colors].join(", ")}`,
     ).toBeGreaterThanOrEqual(2);
   });
+
+  test("TSX tokens render with non-default colors (#206)", async ({ page }) => {
+    const tsxContent = [
+      'import React from "react";',
+      "",
+      "interface Props { name: string; }",
+      "",
+      "export const App: React.FC<Props> = ({ name }) => {",
+      "  return <div className=\"app\">Hello {name}</div>;",
+      "};",
+    ].join("\n");
+
+    await page.addInitScript(
+      ({ dir, content }: { dir: string; content: string }) => {
+        window.__TAURI_IPC_MOCK__ = async (cmd: string) => {
+          if (cmd === "get_launch_args")
+            return { files: [], folders: [dir] };
+          if (cmd === "read_dir")
+            return [{ name: "App.tsx", path: `${dir}/App.tsx`, is_dir: false }];
+          if (cmd === "read_text_file") return content;
+          if (cmd === "load_review_comments") return null;
+          if (cmd === "save_review_comments") return null;
+          if (cmd === "get_log_path") return "/mock/log.log";
+          if (cmd === "get_file_comments")
+            return { threads: [], sidecar_mtime_ms: null };
+          return null;
+        };
+      },
+      { dir: FIXTURES_DIR, content: tsxContent },
+    );
+
+    await page.goto("/");
+    await page.locator(".folder-tree").getByText("App.tsx").click();
+
+    const sourceLines = page.locator(".source-line-content");
+    await expect(sourceLines.first()).toBeVisible();
+    await page.waitForTimeout(2000);
+
+    const coloredSpans = page.locator(
+      '.source-line-content span[style*="color:#"]',
+    );
+
+    const count = await coloredSpans.count();
+    expect(count).toBeGreaterThan(0);
+
+    const colors = new Set<string>();
+    for (let i = 0; i < Math.min(count, 20); i++) {
+      const style = await coloredSpans.nth(i).getAttribute("style");
+      if (style) {
+        const match = style.match(/color:\s*(#[0-9a-fA-F]{3,8})/);
+        if (match) colors.add(match[1].toLowerCase());
+      }
+    }
+
+    expect(
+      colors.size,
+      `Expected multiple distinct TSX token colors but found: ${[...colors].join(", ")}`,
+    ).toBeGreaterThanOrEqual(2);
+  });
 });
 
 test.describe("Markdown fenced code block highlighting (#181)", () => {

--- a/src/hooks/__tests__/shiki-integration.test.ts
+++ b/src/hooks/__tests__/shiki-integration.test.ts
@@ -82,4 +82,46 @@ describe("Shiki integration (real, not mocked)", () => {
     // Line 2: "function" should be colored
     expect(htmlLines[1]).toContain("function");
   });
+
+  it("tsx language loads and produces colored tokens (#206)", async () => {
+    const hl = await createHighlighter({
+      themes: ["github-light", "github-dark"],
+      langs: [],
+    });
+
+    await hl.loadLanguage("tsx");
+    expect(hl.getLoadedLanguages()).toContain("tsx");
+
+    const html = hl.codeToHtml(
+      'import React from "react";\nconst App = () => <div>Hello</div>;',
+      { lang: "tsx", theme: "github-light" },
+    );
+
+    // Must contain at least one span with a non-default color style
+    expect(html).toMatch(/style="color:#[0-9a-fA-F]{3,6}"/);
+
+    // Keywords should be colored distinctly from plain text
+    // "import" is a keyword
+    expect(html).toContain('style="color:#D73A49"');
+
+    // JSX tag names should be colored
+    expect(html).toContain("div");
+  });
+
+  it("jsx language loads and produces colored tokens (#206)", async () => {
+    const hl = await createHighlighter({
+      themes: ["github-light"],
+      langs: [],
+    });
+
+    await hl.loadLanguage("jsx");
+    expect(hl.getLoadedLanguages()).toContain("jsx");
+
+    const html = hl.codeToHtml(
+      'const el = <span className="test">hi</span>;',
+      { lang: "jsx", theme: "github-light" },
+    );
+
+    expect(html).toMatch(/style="color:#[0-9a-fA-F]{3,6}"/);
+  });
 });

--- a/src/hooks/__tests__/useSourceHighlighting.test.ts
+++ b/src/hooks/__tests__/useSourceHighlighting.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useSourceHighlighting, escapeHtml } from "../useSourceHighlighting";
+import { useSourceHighlighting, escapeHtml, loadLanguageWithRetry } from "../useSourceHighlighting";
 
 vi.mock("@/lib/shiki", () => ({
   getSharedHighlighter: vi.fn().mockResolvedValue({
@@ -190,5 +190,50 @@ describe("escapeHtml", () => {
 
   it("handles multiple special chars", () => {
     expect(escapeHtml("a < b & c > d")).toBe("a &lt; b &amp; c &gt; d");
+  });
+});
+
+describe("loadLanguageWithRetry", () => {
+  it("returns true on first-attempt success", async () => {
+    const loadedLangs: string[] = [];
+    const hl = {
+      loadLanguage: vi.fn().mockImplementation(async (lang: string) => {
+        loadedLangs.push(typeof lang === "string" ? lang : (lang as { name: string }).name);
+      }),
+      getLoadedLanguages: vi.fn().mockImplementation(() => loadedLangs),
+    } as unknown as import("shiki").Highlighter;
+
+    const result = await loadLanguageWithRetry(hl, "typescript");
+    expect(result).toBe(true);
+    expect(hl.loadLanguage).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries and succeeds on second attempt (#206)", async () => {
+    let attempt = 0;
+    const hl = {
+      loadLanguage: vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) throw new Error("transient failure");
+        // Second attempt succeeds — language appears in loaded list
+      }),
+      getLoadedLanguages: vi.fn().mockImplementation(() =>
+        attempt >= 2 ? ["tsx"] : [],
+      ),
+    } as unknown as import("shiki").Highlighter;
+
+    const result = await loadLanguageWithRetry(hl, "tsx");
+    expect(result).toBe(true);
+    expect(hl.loadLanguage).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false after all retries fail", async () => {
+    const hl = {
+      loadLanguage: vi.fn().mockRejectedValue(new Error("unavailable")),
+      getLoadedLanguages: vi.fn().mockReturnValue([]),
+    } as unknown as import("shiki").Highlighter;
+
+    const result = await loadLanguageWithRetry(hl, "tsx");
+    expect(result).toBe(false);
+    expect(hl.loadLanguage).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/hooks/useSourceHighlighting.ts
+++ b/src/hooks/useSourceHighlighting.ts
@@ -1,12 +1,44 @@
 import { useState, useEffect, useMemo, useDeferredValue } from "react";
-import { type BundledLanguage } from "shiki";
+import { type BundledLanguage, type Highlighter } from "shiki";
 import { getSharedHighlighter } from "@/lib/shiki";
 import { getShikiLanguage } from "@/lib/file-types";
 import { useTheme } from "@/hooks/useTheme";
+import { warn } from "@/logger";
 import kqlGrammar from "@/lib/kql.tmLanguage.json";
 
 export function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const MAX_LOAD_RETRIES = 2;
+const RETRY_DELAY_MS = 150;
+
+/**
+ * Load a Shiki language grammar with retry. Dynamic imports for grammar
+ * files can fail transiently in the Tauri webview (#206), so we retry
+ * once after a short delay before falling back to "text".
+ */
+export async function loadLanguageWithRetry(
+  hl: Highlighter,
+  lang: string,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < MAX_LOAD_RETRIES; attempt++) {
+    try {
+      if (lang === "kql") {
+        await hl.loadLanguage({ name: "kql", ...kqlGrammar });
+      } else {
+        await hl.loadLanguage(lang as BundledLanguage);
+      }
+    } catch {
+      // loadLanguage can throw on invalid/unavailable grammars
+    }
+    if (hl.getLoadedLanguages().includes(lang)) return true;
+    if (attempt < MAX_LOAD_RETRIES - 1) {
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+    }
+  }
+  warn(`[shiki] language "${lang}" failed to load after ${MAX_LOAD_RETRIES} attempts — falling back to plain text`);
+  return false;
 }
 
 export function useSourceHighlighting(content: string, path: string) {
@@ -27,18 +59,8 @@ export function useSourceHighlighting(content: string, path: string) {
         const loaded = hl.getLoadedLanguages();
         let effectiveLang = lang;
         if (!loaded.includes(lang) && lang !== "text") {
-          if (lang === "kql") {
-            await hl.loadLanguage({
-              name: "kql",
-              ...kqlGrammar,
-            }).catch(() => {});
-          } else {
-            await hl.loadLanguage(lang as BundledLanguage).catch(() => {});
-          }
-          // Verify loading succeeded; fall back to "text" if not (#181)
-          if (!hl.getLoadedLanguages().includes(lang)) {
-            effectiveLang = "text";
-          }
+          const ok = await loadLanguageWithRetry(hl, lang);
+          if (!ok) effectiveLang = "text";
         }
         if (cancelled) return;
         try {


### PR DESCRIPTION
## Issue

Fixes #206  Source view renders all tokens in uniform black/dark color for .tsx files. Shiki either fails to load the tsx grammar or codeToHtml returns unstyled output. Same regression class as #94 and #181.

## Requirements

- [x] Source view renders syntax-highlighted .tsx files with distinct token colors (keywords, strings, identifiers differ)  verifiable by Shiki codeToHtml producing styled span elements
- [x] Regression test covering the syntax highlighting path for .tsx files passes  verifiable by vitest

## Root cause

Shiki's \loadLanguage\ can fail transiently in the Tauri webview (dynamic import timing). The existing \.catch(() => {})\ on line 36 silently swallowed the error, causing fallback to \'text'\ language which produces uniform black output (no token coloring).

## Fix

- Extract \loadLanguageWithRetry()\  2 attempts with 150ms delay between retries
- Log failures via \warn()\ instead of swallowing silently
- Add tsx/jsx integration tests (real Shiki, not mocked)
- Add tsx browser e2e test for source view highlighting
- Add \loadLanguageWithRetry\ unit tests (first-attempt success, retry success, exhaustion)

Closes #206