### PR TITLE
fix: implement #214  Fix links in md and html views

### DIFF
--- a/src/__mocks__/@tauri-apps/plugin-opener.ts
+++ b/src/__mocks__/@tauri-apps/plugin-opener.ts
@@ -1,0 +1,3 @@
+import { vi } from "vitest";
+
+export const openUrl = vi.fn().mockResolvedValue(undefined);

--- a/src/components/viewers/HtmlPreviewView.tsx
+++ b/src/components/viewers/HtmlPreviewView.tsx
@@ -167,7 +167,7 @@ export function HtmlPreviewView({ content, filePath }: Props) {
             warn(`HtmlPreviewView: blocked iframe link (${route.reason}): ${route.href}`);
             break;
           case "external":
-            openExternalUrl(route.href).catch(() => {});
+            openExternalUrl(route.href).catch((e) => warn(`[HtmlPreviewView] link open failed: ${e}`));
             break;
           case "fragment":
             // Best-effort placeholder — full in-iframe scroll requires
@@ -238,30 +238,46 @@ export function HtmlPreviewView({ content, filePath }: Props) {
               // and link routing is delivered via the bridge postMessage path
               // (see the message-handler effect above).
               if (allowScripts) return;
+              const installClickHandler = (doc: Document) => {
+                doc.addEventListener("click", (event) => {
+                  const target = event.target as Element | null;
+                  const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
+                  if (!anchor) return;
+                  const href = anchor.getAttribute("href");
+                  if (href === null) return;
+                  const route = routeLinkClick(href, { baseDir, workspaceRoot });
+                  switch (route.kind) {
+                    case "fragment":
+                      return; // let the browser scroll natively
+                    case "blocked":
+                      event.preventDefault();
+                      warn(`HtmlPreviewView: blocked iframe link (${route.reason}): ${route.href}`);
+                      return;
+                    case "external":
+                      event.preventDefault();
+                      openExternalUrl(route.href).catch((e) => warn(`[HtmlPreviewView] link open failed: ${e}`));
+                      return;
+                    case "workspace":
+                      event.preventDefault();
+                      useStore.getState().openFile(route.path);
+                      return;
+                  }
+                });
+              };
               const doc = iframeRef.current?.contentDocument;
-              if (!doc) return;
-              doc.addEventListener("click", (event) => {
-                const target = event.target as Element | null;
-                const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
-                if (!anchor) return;
-                const href = anchor.getAttribute("href");
-                if (href === null) return;
-                const route = routeLinkClick(href, { baseDir, workspaceRoot });
-                switch (route.kind) {
-                  case "fragment":
-                    return; // let the browser scroll natively
-                  case "blocked":
-                    event.preventDefault();
-                    warn(`HtmlPreviewView: blocked iframe link (${route.reason}): ${route.href}`);
-                    return;
-                  case "external":
-                    event.preventDefault();
-                    openExternalUrl(route.href).catch(() => {});
-                    return;
-                  case "workspace":
-                    event.preventDefault();
-                    useStore.getState().openFile(route.path);
-                    return;
+              if (doc) {
+                installClickHandler(doc);
+                return;
+              }
+              // Bounded retry — contentDocument can be null when the load
+              // event fires before the document is fully committed (observed
+              // in some Chromium builds with srcdoc). One rAF is enough.
+              requestAnimationFrame(() => {
+                const retryDoc = iframeRef.current?.contentDocument;
+                if (retryDoc) {
+                  installClickHandler(retryDoc);
+                } else {
+                  warn("[HtmlPreviewView] contentDocument unavailable after rAF retry");
                 }
               });
             }}

--- a/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
+++ b/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/lib/tauri-commands", () => ({
 
 import { HtmlPreviewView } from "../HtmlPreviewView";
 import { openExternalUrl, fetchRemoteAsset, getFileViewerPref, setFileViewerPref } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
 import { useStore } from "@/store";
 
 beforeEach(() => {
@@ -23,6 +24,7 @@ beforeEach(() => {
   (fetchRemoteAsset as unknown as { mockClear: () => void }).mockClear();
   (getFileViewerPref as unknown as { mockClear: () => void }).mockClear();
   (setFileViewerPref as unknown as { mockClear: () => void }).mockClear();
+  vi.mocked(warn).mockClear();
 });
 
 describe("HtmlPreviewView — sandbox toggles (H1)", () => {
@@ -238,6 +240,52 @@ describe("HtmlPreviewView — link bridge in scripts mode (H2)", () => {
       source: "mdr-html-bridge", nonce: "WRONG", type: "link", href: "https://evil.example",
     });
     expect(openExternalUrl).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("openExternalUrl failure logs via warn()", async () => {
+    vi.mocked(openExternalUrl).mockRejectedValueOnce(new Error("plugin unavailable"));
+    const { container } = render(<HtmlPreviewView content="<p>x</p>" filePath="/wk/page.html" />);
+    enableScripts();
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const nonce = nonceOf(iframe);
+    dispatchBridgeMsg(iframe, {
+      source: "mdr-html-bridge", nonce, type: "link", href: "https://example.com",
+    });
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[HtmlPreviewView] link open failed:"),
+      );
+    });
+    cleanup();
+  });
+});
+
+describe("HtmlPreviewView — safe-mode link interception (H3)", () => {
+  it("safe-mode iframe click on anchor calls openExternalUrl", () => {
+    const { container } = render(
+      <HtmlPreviewView content='<a href="https://example.com">link</a>' filePath="/wk/page.html" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    // In safe mode (allow-same-origin), the onLoad handler installs a
+    // click listener on contentDocument. jsdom exposes contentDocument
+    // directly, so we simulate a click there.
+    const doc = iframe.contentDocument;
+    if (!doc) {
+      // jsdom should provide contentDocument for srcdoc iframes
+      throw new Error("contentDocument is null — jsdom limitation");
+    }
+    // Fire the iframe load event to trigger handler installation.
+    fireEvent.load(iframe);
+    // Now simulate a click on the anchor within the contentDocument.
+    // jsdom doesn't parse srcdoc into the contentDocument, so we need to
+    // create a synthetic anchor inside it.
+    const anchor = doc.createElement("a");
+    anchor.setAttribute("href", "https://example.com");
+    anchor.textContent = "link";
+    doc.body.appendChild(anchor);
+    fireEvent.click(anchor);
+    expect(openExternalUrl).toHaveBeenCalledWith("https://example.com");
     cleanup();
   });
 });

--- a/src/components/viewers/markdown/MarkdownComponentsMap.tsx
+++ b/src/components/viewers/markdown/MarkdownComponentsMap.tsx
@@ -104,7 +104,7 @@ function makeAnchorComponent(filePath: string, workspaceRoot: string) {
           return;
         case "external":
           e.preventDefault();
-          openExternalUrl(route.href).catch(() => {});
+          openExternalUrl(route.href).catch((e) => warn(`[MarkdownViewer] link open failed: ${e}`));
           return;
         case "workspace":
           e.preventDefault();

--- a/src/components/viewers/markdown/__tests__/MarkdownComponentsMap.test.tsx
+++ b/src/components/viewers/markdown/__tests__/MarkdownComponentsMap.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { buildMarkdownComponents } from "../MarkdownComponentsMap";
@@ -13,6 +13,14 @@ vi.mock("@/lib/tauri-commands", async () => ({
 }));
 
 vi.mock("@/logger");
+
+import { openExternalUrl } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
+
+beforeEach(() => {
+  vi.mocked(openExternalUrl).mockClear();
+  vi.mocked(warn).mockClear();
+});
 
 vi.mock("@/lib/shiki", () => ({
   getSharedHighlighter: vi.fn().mockResolvedValue({
@@ -139,6 +147,33 @@ describe("buildMarkdownComponents — block wrappings carry data-source-line", (
     await waitFor(() => {
       expect(mockHl.loadLanguage).toHaveBeenCalled();
       expect(mockHl.codeToHtml).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("buildMarkdownComponents — anchor link handling", () => {
+  it("external link click calls openExternalUrl", async () => {
+    const { container } = renderMd("[link](https://example.com)\n");
+    await waitFor(() => {
+      const a = container.querySelector("a");
+      expect(a).not.toBeNull();
+    });
+    const a = container.querySelector("a")!;
+    fireEvent.click(a);
+    expect(openExternalUrl).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("openExternalUrl failure produces a warn() call", async () => {
+    vi.mocked(openExternalUrl).mockRejectedValueOnce(new Error("plugin unavailable"));
+    const { container } = renderMd("[link](https://example.com)\n");
+    await waitFor(() => {
+      expect(container.querySelector("a")).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector("a")!);
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[MarkdownViewer] link open failed:"),
+      );
     });
   });
 });

--- a/src/lib/__tests__/tauri-commands.test.ts
+++ b/src/lib/__tests__/tauri-commands.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
-// Mock the underlying Tauri plugins. The wrappers in tauri-commands.ts use
-// dynamic imports, so vi.mock intercepts them when the wrapper is invoked.
-const writeText = vi.fn().mockResolvedValue(undefined);
-const openUrl = vi.fn().mockResolvedValue(undefined);
-const relaunch = vi.fn().mockResolvedValue(undefined);
-const open = vi.fn().mockResolvedValue("/some/path");
+// vi.hoisted ensures these variables are available when the hoisted vi.mock
+// factories run. Required because @tauri-apps/plugin-opener is now a static
+// import in tauri-commands.ts.
+const { writeText, openUrl, relaunch, open } = vi.hoisted(() => ({
+  writeText: vi.fn().mockResolvedValue(undefined),
+  openUrl: vi.fn().mockResolvedValue(undefined),
+  relaunch: vi.fn().mockResolvedValue(undefined),
+  open: vi.fn().mockResolvedValue("/some/path"),
+}));
 
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -1,5 +1,6 @@
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { warn } from "@/logger";
 import { EXTERNAL_LINK_SCHEME, BLOCKED_LINK_SCHEME } from "@/lib/url-policy";
 
@@ -368,7 +369,7 @@ export const openExternalUrl = (url: string): Promise<void> => {
     warn(`openExternalUrl: blocked URL scheme: ${url}`);
     return Promise.reject(new Error(`Blocked URL scheme: ${url}`));
   }
-  return import("@tauri-apps/plugin-opener").then((m) => m.openUrl(url));
+  return openUrl(url);
 };
 
 export const restartApp = (): Promise<void> => {


### PR DESCRIPTION
## Issue

Closes #214  Links in md and html doesn't work

## Requirements

- [x] External links (https://) in markdown visual view open in default browser
- [x] Local/workspace links (./other.md) in markdown visual view open in the app
- [x] External links in HTML visual view (safe mode) open in default browser
- [x] Local/workspace links in HTML visual view (safe mode) open in the app
- [x] External links in HTML visual view (scripts mode) open in default browser
- [x] Local/workspace links in HTML visual view (scripts mode) open in the app
- [x] Blocked schemes (javascript:, file:, data:) still blocked with logged warning
- [x] All `.catch(() => {})` on `openExternalUrl` replaced with `.catch((e) => warn(...))`
- [x] No silent failures  every link click either succeeds or produces a log message
- [x] Safe mode HTML preview remains `allow-same-origin` without `allow-scripts`
- [x] No duplicate click listeners on iframe re-render/remount
- [x] Unit test: `openExternalUrl` succeeds for http/https URLs
- [x] Unit test: `openExternalUrl` failure produces a `warn()` call
- [x] Unit test: HTML safe-mode iframe click handler installs and routes links
- [x] Unit test: HTML scripts-mode bridge routes link clicks correctly