### PR TITLE
fix: implement #216  Ghost entries under collapsed folders

### DIFF
--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -14,6 +14,7 @@ import { useFolderTree } from "@/hooks/useFolderTree";
 import { useTreeWatcher } from "@/hooks/useTreeWatcher";
 import { useFileBadges } from "@/hooks/useFileBadges";
 import { CommentBadge } from "@/components/comments/CommentBadge";
+import type { Severity } from "@/lib/tauri-commands";
 import {
   pathStartsWithRootCrossPlatform,
   getAncestors,
@@ -32,6 +33,8 @@ interface NavRow {
   isDir: boolean;
   name: string;
 }
+
+const SEVERITY_ORDER: Record<Severity, number> = { none: 0, low: 1, medium: 2, high: 3 };
 
 export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   const { root, expandedFolders, activeTabPath, ghostEntries, tabs, folderPaneWidth } = useStore(
@@ -64,7 +67,7 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   }, []);
 
   // ── Tree mode list (no filter — filter mode uses grouped view below) ──────
-  const treeList = useFolderTree(root, childrenCache, expandedFolders, "", ghostEntries);
+  const { nodes: treeList, hiddenGhostsByFolder } = useFolderTree(root, childrenCache, expandedFolders, "", ghostEntries);
 
   // ── "Other files" derived from open tabs that live outside `root` ─────────
   const otherFiles = useMemo(
@@ -100,8 +103,15 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
     return rows;
   }, [otherFiles, otherFilesOpen, deferredFilter, filterGroups, treeList]);
 
-  // Collect visible file paths for badge counts
-  const filePaths = useMemo(() => navRows.filter((r) => !r.isDir).map((r) => r.path), [navRows]);
+  // Collect visible file paths for badge counts, plus hidden ghost paths
+  // so collapsed folders can aggregate ghost badges. One deduped IPC call.
+  const filePaths = useMemo(() => {
+    const visible = navRows.filter((r) => !r.isDir).map((r) => r.path);
+    const hiddenGhosts = Object.values(hiddenGhostsByFolder).flat();
+    const deduped = [...new Set([...visible, ...hiddenGhosts])];
+    deduped.sort();
+    return deduped;
+  }, [navRows, hiddenGhostsByFolder]);
   const fileBadges = useFileBadges(filePaths);
 
   // ── Optimistic toggle ─────────────────────────────────────────────────────
@@ -235,6 +245,27 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
             className="tree-comment-badge"
           />
         )}
+        {opts.isDir && (() => {
+          const ghostPaths = hiddenGhostsByFolder[path];
+          if (!ghostPaths || ghostPaths.length === 0) return null;
+          let totalCount = 0;
+          let maxSev: Severity = "none";
+          for (const gp of ghostPaths) {
+            const badge = fileBadges[gp];
+            if (!badge) continue;
+            totalCount += badge.count;
+            if (SEVERITY_ORDER[badge.max_severity] > SEVERITY_ORDER[maxSev]) {
+              maxSev = badge.max_severity;
+            }
+          }
+          return (
+            <CommentBadge
+              count={totalCount}
+              severity={maxSev}
+              className="tree-comment-badge"
+            />
+          );
+        })()}
       </div>
     );
   };

--- a/src/components/FolderTree/__tests__/FolderTree.test.tsx
+++ b/src/components/FolderTree/__tests__/FolderTree.test.tsx
@@ -8,9 +8,12 @@ import type { DirEntry } from "@/lib/tauri-commands";
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
 
-// Mock the hook to avoid IPC / event listener setup in tests
+// Mock the hook to avoid IPC / event listener setup in tests.
+// Controlled via mockUseFileBadges for tests that need badge data.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUseFileBadges = vi.fn((_paths?: any) => ({}));
 vi.mock("@/hooks/useFileBadges", () => ({
-  useFileBadges: () => ({}),
+  useFileBadges: (paths: string[]) => mockUseFileBadges(paths),
 }));
 
 // Mock tauri-commands readDir so we can control what it returns
@@ -39,6 +42,8 @@ const initialState = useStore.getState();
 beforeEach(() => {
   useStore.setState(initialState, true);
   mockReadDir.mockReset();
+  mockUseFileBadges.mockReset();
+  mockUseFileBadges.mockReturnValue({});
   // Default: root returns ROOT_ENTRIES, subfolder returns SUB_ENTRIES
   mockReadDir.mockImplementation((path: string) => {
     if (path === FOLDER) return Promise.resolve(ROOT_ENTRIES);
@@ -540,5 +545,59 @@ describe("filter input shortcut hint placeholder (#209)", () => {
     await waitFor(() => screen.getByText("README.md"));
     const input = screen.getByRole("textbox", { name: "Filter files" }) as HTMLInputElement;
     expect(input.placeholder).toBe("Filter files (Ctrl+P)");
+  });
+});
+
+// ─── Ghost badge on collapsed folders (#216) ─────────────────────────────────
+
+describe("#216 – ghost badge on collapsed folders", () => {
+  it("collapsed folder shows aggregated badge for hidden ghosts", async () => {
+    // Ghost under collapsed "subdir" should produce a badge on the folder row
+    useStore.setState({
+      root: FOLDER,
+      expandedFolders: {},
+      tabs: [],
+      activeTabPath: null,
+      folderPaneWidth: 240,
+      ghostEntries: [
+        { sourcePath: "/test/subdir/deleted.md", sidecarPath: "/test/subdir/deleted.md.review.json" },
+      ],
+    });
+    mockUseFileBadges.mockReturnValue({
+      "/test/subdir/deleted.md": { count: 3, max_severity: "high" as const },
+    });
+
+    render(<FolderTree onFileOpen={vi.fn()} onCloseFolder={vi.fn()} />);
+    await waitFor(() => screen.getByText("subdir"));
+
+    const subdirEntry = screen.getByText("subdir").closest(".tree-entry")!;
+    const badge = subdirEntry.querySelector(".tree-comment-badge");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe("3");
+    expect(badge!.getAttribute("data-severity")).toBe("high");
+  });
+
+  it("expanded folder does NOT show ghost badge (ghosts are visible with own badges)", async () => {
+    useStore.setState({
+      root: FOLDER,
+      expandedFolders: { [SUBFOLDER]: true },
+      tabs: [],
+      activeTabPath: null,
+      folderPaneWidth: 240,
+      ghostEntries: [
+        { sourcePath: "/test/subdir/deleted.md", sidecarPath: "/test/subdir/deleted.md.review.json" },
+      ],
+    });
+    mockUseFileBadges.mockReturnValue({
+      "/test/subdir/deleted.md": { count: 2, max_severity: "medium" as const },
+    });
+
+    render(<FolderTree onFileOpen={vi.fn()} onCloseFolder={vi.fn()} />);
+    await waitFor(() => screen.getByText("subdir"));
+
+    const subdirEntry = screen.getByText("subdir").closest(".tree-entry")!;
+    const badge = subdirEntry.querySelector(".tree-comment-badge");
+    // Badge should not appear on the folder row (ghost is visible directly)
+    expect(badge).toBeNull();
   });
 });

--- a/src/hooks/__tests__/useFolderTree.test.ts
+++ b/src/hooks/__tests__/useFolderTree.test.ts
@@ -12,13 +12,13 @@ describe("buildFolderTree", () => {
   const noGhosts: GhostEntry[] = [];
 
   it("returns [] for null root", () => {
-    const result = buildFolderTree(null, {}, {}, "", noGhosts);
-    expect(result).toEqual([]);
+    const { nodes } = buildFolderTree(null, {}, {}, "", noGhosts);
+    expect(nodes).toEqual([]);
   });
 
   it("returns [] for empty childrenCache", () => {
-    const result = buildFolderTree(ROOT, {}, {}, "", noGhosts);
-    expect(result).toEqual([]);
+    const { nodes } = buildFolderTree(ROOT, {}, {}, "", noGhosts);
+    expect(nodes).toEqual([]);
   });
 
   it("builds flat list from root entries", () => {
@@ -28,8 +28,8 @@ describe("buildFolderTree", () => {
         makeEntry("src", "/project/src", true),
       ],
     };
-    const result = buildFolderTree(ROOT, cache, {}, "", noGhosts);
-    expect(result).toEqual([
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", noGhosts);
+    expect(nodes).toEqual([
       { path: "/project/readme.md", isDir: false, depth: 0, name: "readme.md" },
       { path: "/project/src", isDir: true, depth: 0, name: "src" },
     ]);
@@ -40,9 +40,9 @@ describe("buildFolderTree", () => {
       [ROOT]: [makeEntry("src", "/project/src", true)],
       "/project/src": [makeEntry("index.ts", "/project/src/index.ts", false)],
     };
-    const result = buildFolderTree(ROOT, cache, {}, "", noGhosts);
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("src");
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", noGhosts);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe("src");
   });
 
   it("expanded folders include children at increased depth", () => {
@@ -51,9 +51,9 @@ describe("buildFolderTree", () => {
       "/project/src": [makeEntry("index.ts", "/project/src/index.ts", false)],
     };
     const expanded = { "/project/src": true };
-    const result = buildFolderTree(ROOT, cache, expanded, "", noGhosts);
-    expect(result).toHaveLength(2);
-    expect(result[1]).toEqual({
+    const { nodes } = buildFolderTree(ROOT, cache, expanded, "", noGhosts);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[1]).toEqual({
       path: "/project/src/index.ts",
       isDir: false,
       depth: 1,
@@ -68,9 +68,9 @@ describe("buildFolderTree", () => {
         makeEntry("notes.txt", "/project/notes.txt", false),
       ],
     };
-    const result = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("readme.md");
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe("readme.md");
   });
 
   it("filter keeps directories that have matching descendants", () => {
@@ -82,18 +82,18 @@ describe("buildFolderTree", () => {
       ],
     };
     const expanded = { "/project/src": true };
-    const result = buildFolderTree(ROOT, cache, expanded, "match", noGhosts);
-    expect(result).toHaveLength(2);
-    expect(result[0].name).toBe("src");
-    expect(result[1].name).toBe("match.ts");
+    const { nodes } = buildFolderTree(ROOT, cache, expanded, "match", noGhosts);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].name).toBe("src");
+    expect(nodes[1].name).toBe("match.ts");
   });
 
   it("filter is case-insensitive", () => {
     const cache: Record<string, DirEntry[]> = {
       [ROOT]: [makeEntry("README.md", "/project/README.md", false)],
     };
-    const result = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
-    expect(result).toHaveLength(1);
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
+    expect(nodes).toHaveLength(1);
   });
 
   it("ghost entries are inserted at the correct depth", () => {
@@ -105,8 +105,8 @@ describe("buildFolderTree", () => {
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/src/deleted.ts", sidecarPath: "/project/src/deleted.ts.review.json" },
     ];
-    const result = buildFolderTree(ROOT, cache, expanded, "", ghosts);
-    const ghost = result.find((n) => n.isGhost);
+    const { nodes } = buildFolderTree(ROOT, cache, expanded, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
     expect(ghost).toBeDefined();
     expect(ghost!.depth).toBe(1);
     expect(ghost!.name).toBe("deleted.ts");
@@ -120,8 +120,8 @@ describe("buildFolderTree", () => {
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/file.md", sidecarPath: "/project/file.md.review.json" },
     ];
-    const result = buildFolderTree(ROOT, cache, {}, "", ghosts);
-    const matches = result.filter((n) => n.path === "/project/file.md");
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", ghosts);
+    const matches = nodes.filter((n) => n.path === "/project/file.md");
     expect(matches).toHaveLength(1);
     expect(matches[0].isGhost).toBeUndefined();
   });
@@ -133,8 +133,8 @@ describe("buildFolderTree", () => {
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/orphan.md", sidecarPath: "/project/orphan.md.review.json" },
     ];
-    const result = buildFolderTree(ROOT, cache, {}, "", ghosts);
-    const ghost = result.find((n) => n.isGhost);
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
     expect(ghost).toBeDefined();
     expect(ghost!.depth).toBe(0);
   });
@@ -149,10 +149,105 @@ describe("buildFolderTree", () => {
     const ghosts: GhostEntry[] = [
       { sourcePath: "C:\\project\\src\\ghost.md", sidecarPath: "C:\\project\\src\\ghost.md.review.json" },
     ];
-    const result = buildFolderTree(winRoot, cache, expanded, "", ghosts);
-    const ghost = result.find((n) => n.isGhost);
+    const { nodes } = buildFolderTree(winRoot, cache, expanded, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
     expect(ghost).toBeDefined();
     expect(ghost!.name).toBe("ghost.md");
     expect(ghost!.depth).toBe(1);
+  });
+
+  // ── Ghost visibility under collapsed folders (issue #216) ──────────────
+
+  it("omits ghost entries under collapsed parent folders", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [makeEntry("src", "/project/src", true)],
+      "/project/src": [makeEntry("app.ts", "/project/src/app.ts", false)],
+    };
+    // src is collapsed (not in expandedFolders)
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/src/deleted.ts", sidecarPath: "/project/src/deleted.ts.review.json" },
+    ];
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
+    expect(ghost).toBeUndefined();
+    expect(nodes).toHaveLength(1); // just "src" folder
+  });
+
+  it("includes ghost entries under expanded parent folders", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [makeEntry("src", "/project/src", true)],
+      "/project/src": [],
+    };
+    const expanded = { "/project/src": true };
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/src/deleted.ts", sidecarPath: "/project/src/deleted.ts.review.json" },
+    ];
+    const { nodes } = buildFolderTree(ROOT, cache, expanded, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
+    expect(ghost).toBeDefined();
+    expect(ghost!.depth).toBe(1);
+  });
+
+  it("root-level ghost entries are always visible regardless of expanded state", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [],
+    };
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/root-ghost.md", sidecarPath: "/project/root-ghost.md.review.json" },
+    ];
+    const { nodes } = buildFolderTree(ROOT, cache, {}, "", ghosts);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].isGhost).toBe(true);
+    expect(nodes[0].name).toBe("root-ghost.md");
+  });
+
+  it("deeply nested ghost with ancestor collapsed is hidden and mapped to nearest visible ancestor", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [makeEntry("src", "/project/src", true)],
+      "/project/src": [makeEntry("lib", "/project/src/lib", true)],
+      "/project/src/lib": [],
+    };
+    // src expanded, lib collapsed
+    const expanded = { "/project/src": true };
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/src/lib/deep.ts", sidecarPath: "/project/src/lib/deep.ts.review.json" },
+    ];
+    const { nodes, hiddenGhostsByFolder } = buildFolderTree(ROOT, cache, expanded, "", ghosts);
+    const ghost = nodes.find((n) => n.isGhost);
+    expect(ghost).toBeUndefined();
+    expect(hiddenGhostsByFolder).toEqual({
+      "/project/src/lib": ["/project/src/lib/deep.ts"],
+    });
+  });
+
+  it("hiddenGhostsByFolder correctly maps folder to ghost source paths", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [makeEntry("docs", "/project/docs", true)],
+      "/project/docs": [],
+    };
+    // docs is collapsed
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/docs/a.md", sidecarPath: "/project/docs/a.md.review.json" },
+      { sourcePath: "/project/docs/b.md", sidecarPath: "/project/docs/b.md.review.json" },
+    ];
+    const { nodes, hiddenGhostsByFolder } = buildFolderTree(ROOT, cache, {}, "", ghosts);
+    expect(nodes.filter((n) => n.isGhost)).toHaveLength(0);
+    expect(hiddenGhostsByFolder["/project/docs"]).toEqual([
+      "/project/docs/a.md",
+      "/project/docs/b.md",
+    ]);
+  });
+
+  it("hiddenGhostsByFolder is empty when all ghosts are visible", () => {
+    const cache: Record<string, DirEntry[]> = {
+      [ROOT]: [makeEntry("src", "/project/src", true)],
+      "/project/src": [],
+    };
+    const expanded = { "/project/src": true };
+    const ghosts: GhostEntry[] = [
+      { sourcePath: "/project/src/visible.ts", sidecarPath: "/project/src/visible.ts.review.json" },
+    ];
+    const { hiddenGhostsByFolder } = buildFolderTree(ROOT, cache, expanded, "", ghosts);
+    expect(Object.keys(hiddenGhostsByFolder)).toHaveLength(0);
   });
 });

--- a/src/hooks/useFolderTree.ts
+++ b/src/hooks/useFolderTree.ts
@@ -10,13 +10,19 @@ export type TreeNode = {
   isGhost?: boolean;
 };
 
+export interface FolderTreeResult {
+  nodes: TreeNode[];
+  /** Ghost source paths hidden under each collapsed ancestor folder. */
+  hiddenGhostsByFolder: Record<string, string[]>;
+}
+
 export function buildFolderTree(
   root: string | null,
   childrenCache: Record<string, DirEntry[]>,
   expandedFolders: Record<string, boolean>,
   filter: string,
   ghostEntries: GhostEntry[]
-): TreeNode[] {
+): FolderTreeResult {
   function hasMatch(folderPath: string): boolean {
     const entries = childrenCache[folderPath] ?? [];
     return entries.some(
@@ -46,12 +52,14 @@ export function buildFolderTree(
 
   const flatList = root ? buildFlatList(root, 0) : [];
   const merged: TreeNode[] = [...flatList];
+  const hiddenGhostsByFolder: Record<string, string[]> = {};
 
   if (root) {
     // Producer-side fix lives in `core::paths::canonicalize_no_verbatim` —
     // every Rust path crossing IPC is bare-form, so plain string equality
     // suffices here. See `docs/security.md` rules 11+ and issue #89.
     const flatPaths = new Set(flatList.map((n) => n.path));
+    const mergedDirSet = new Set(merged.filter((n) => n.isDir).map((n) => n.path));
     for (const ghost of ghostEntries) {
       if (flatPaths.has(ghost.sourcePath)) continue;
 
@@ -60,12 +68,49 @@ export function buildFolderTree(
       const parentPath = parts.slice(0, -1).join(sep);
       const fileName = parts[parts.length - 1];
 
+      // Root-level ghosts are always visible.
+      if (parentPath === root) {
+        const parentDepth = -1;
+        const ghostDepth = parentDepth + 1;
+        let insertIdx = 0;
+        while (insertIdx < merged.length && merged[insertIdx].depth >= ghostDepth) {
+          insertIdx++;
+        }
+        merged.splice(insertIdx, 0, {
+          path: ghost.sourcePath,
+          isDir: false,
+          depth: ghostDepth,
+          name: fileName,
+          isGhost: true,
+        });
+        continue;
+      }
+
+      // Parent must be in the merged list (ancestor chain expanded) AND expanded itself.
       const parentIdx = merged.findIndex(
         (n) => n.path === parentPath && n.isDir,
       );
-      if (parentIdx === -1 && parentPath !== root) continue;
 
-      const parentDepth = parentIdx >= 0 ? merged[parentIdx].depth : -1;
+      if (parentIdx === -1 || !expandedFolders[parentPath]) {
+        // Ghost is hidden — find nearest visible ancestor folder for badge aggregation.
+        const ancestorParts: string[] = parentPath.split(sep);
+        let nearestVisible: string | undefined;
+        // Walk from the parent upward (excluding root itself).
+        for (let i = ancestorParts.length; i > 0; i--) {
+          const candidate: string = ancestorParts.slice(0, i).join(sep);
+          if (candidate === root) break;
+          if (mergedDirSet.has(candidate)) {
+            nearestVisible = candidate;
+            break;
+          }
+        }
+        if (nearestVisible) {
+          (hiddenGhostsByFolder[nearestVisible] ??= []).push(ghost.sourcePath);
+        }
+        continue;
+      }
+
+      const parentDepth = merged[parentIdx].depth;
       const ghostDepth = parentDepth + 1;
 
       let insertIdx = parentIdx + 1;
@@ -83,7 +128,7 @@ export function buildFolderTree(
     }
   }
 
-  return merged;
+  return { nodes: merged, hiddenGhostsByFolder };
 }
 
 export function useFolderTree(
@@ -92,7 +137,7 @@ export function useFolderTree(
   expandedFolders: Record<string, boolean>,
   filter: string,
   ghostEntries: GhostEntry[]
-): TreeNode[] {
+): FolderTreeResult {
   return useMemo(
     () => buildFolderTree(root, childrenCache, expandedFolders, filter, ghostEntries),
     [root, childrenCache, expandedFolders, filter, ghostEntries]


### PR DESCRIPTION
## Issue

Closes #216  Files with reviews is wrongly shown as deleted file in folder pane when the folder tree for the file is collapsed

## Requirements

- [x] Ghost entries do not appear in the tree when their parent folder is collapsed
- [x] Ghost entries do not appear when any ancestor folder is collapsed (deeply nested)
- [x] Ghost entries appear normally when parent folder is expanded
- [x] Ghost entries at root level always appear
- [x] Collapsed folders with hidden ghosts show a comment-count badge
- [x] Badge count = total unresolved across hidden ghost files
- [x] Badge severity = max severity across hidden ghosts
- [x] Expand folder  badge disappears, ghost entries show with own badges
- [x] Collapse folder  ghost entries hide, folder badge restores
- [x] Deeply nested ghost maps to nearest visible ancestor
- [x] Multiple hidden ghosts aggregate correctly
- [x] No visual artifacts on expand/collapse
- [x] One top-level useFileBadges call with deduped path list
- [x] Unit tests for buildFolderTree collapse/expand scenarios (6 tests)
- [x] Unit tests for hiddenGhostsByFolder mapping
- [x] Unit tests for folder badge appearance/disappearance (2 component tests)