### PR TITLE
fix: folder pane no longer jumps to active file on folder expand

### DIFF
--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -55,6 +55,8 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   const [otherFilesOpen, setOtherFilesOpen] = useState(true);
   const [, startTransition] = useTransition();
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollTargetRef = useRef<string | null>(null);
+  const prevActiveRef = useRef<string | null>(null);
 
   // Listen for the clear-filter custom event dispatched by the Ctrl/Cmd+P
   // toggle-off path in useGlobalShortcuts.
@@ -153,12 +155,22 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   }, [activeTabPath, root]);
 
   // ── Effect B: scroll the active row into view once it has rendered ───────
+  // Only scrolls when activeTabPath actually changes (not on every navRows
+  // update, which would hijack viewport on manual folder toggles).
   useLayoutEffect(() => {
-    if (!activeTabPath) return;
+    if (activeTabPath !== prevActiveRef.current) {
+      prevActiveRef.current = activeTabPath;
+      scrollTargetRef.current = activeTabPath;
+    }
+    const target = scrollTargetRef.current;
+    if (!target) return;
     const el = containerRef.current?.querySelector<HTMLDivElement>(
-      `[data-path="${CSS.escape(activeTabPath)}"]`
+      `[data-path="${CSS.escape(target)}"]`
     );
-    el?.scrollIntoView?.({ block: "nearest" });
+    if (el) {
+      el.scrollIntoView?.({ block: "nearest" });
+      scrollTargetRef.current = null;
+    }
   }, [activeTabPath, navRows]);
 
   const handleKeyDown = (e: React.KeyboardEvent, path: string, isDir: boolean) => {

--- a/src/components/FolderTree/__tests__/FolderTree.test.tsx
+++ b/src/components/FolderTree/__tests__/FolderTree.test.tsx
@@ -548,6 +548,38 @@ describe("filter input shortcut hint placeholder (#209)", () => {
   });
 });
 
+// ─── Regression: expanding a folder must NOT scroll to the active file ───────
+
+describe("expanding a folder does not scroll to the active file", () => {
+  it("scrollIntoView is not called on the active row when only a folder is toggled", async () => {
+    renderTree();
+    await waitFor(() => screen.getByText("README.md"));
+
+    // Simulate opening README.md so it becomes the active tab
+    act(() => {
+      useStore.setState({ activeTabPath: "/test/README.md" });
+    });
+
+    // Wait for the initial scroll-into-view to fire
+    await waitFor(() => {
+      const el = screen.getByText("README.md").closest(".tree-entry")!;
+      expect(el).toHaveAttribute("data-path", "/test/README.md");
+    });
+
+    // Spy on scrollIntoView after the initial active-tab scroll has settled
+    const readmeEntry = screen.getByText("README.md").closest(".tree-entry")!;
+    const spy = vi.fn();
+    readmeEntry.scrollIntoView = spy;
+
+    // Now expand the subfolder — this changes navRows but NOT activeTabPath
+    fireEvent.click(screen.getByText("subdir").closest(".tree-entry")!);
+    await waitFor(() => screen.getByText("child.md"));
+
+    // scrollIntoView on the active entry must NOT have been called
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Ghost badge on collapsed folders (#216) ─────────────────────────────────
 
 describe("#216 – ghost badge on collapsed folders", () => {


### PR DESCRIPTION
## Problem
Expanding a folder in the folder pane caused the viewport to scroll to the currently active file, even when that file was off-screen. Users expected the pane to stay focused on the folder they just expanded.

## Root Cause
Effect B in \FolderTree.tsx\ called \scrollIntoView\ on the active file row whenever \
avRows\ changed. Since expanding a folder adds children to \
avRows\, every toggle triggered a scroll to the active file.

## Fix
Replaced the unconditional scroll with a ref-based pending scroll target (\scrollTargetRef\ + \prevActiveRef\). The scroll target is only set when \ctiveTabPath\ actually changes and is consumed after a successful scroll. Manual folder toggles no longer trigger a scroll.

## Testing
- Regression test added: verifies \scrollIntoView\ is not called on the active row when only a folder is toggled
- All 24 FolderTree tests pass