### PR TITLE
fix: per-window watcher state for tree dirs and watched files

### DIFF
--- a/src-tauri/src/commands/comments/badges.rs
+++ b/src-tauri/src/commands/comments/badges.rs
@@ -150,6 +150,7 @@ mod tests {
         let state = WatcherState::new(tx);
         state
             .set_tree_watched_dirs(
+                "test",
                 canonical.to_string_lossy().into_owned(),
                 vec![canonical.to_string_lossy().into_owned()],
             )

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -234,11 +234,12 @@ pub fn stat_file_inner(
 /// [`crate::watcher::MAX_TREE_WATCHED_DIRS`] entries per call.
 #[tauri::command]
 pub fn update_tree_watched_dirs(
+    window: tauri::Window,
     root: String,
     dirs: Vec<String>,
     state: tauri::State<'_, crate::watcher::WatcherState>,
 ) -> Result<(), String> {
-    state.set_tree_watched_dirs(root, dirs).map_err(|e| {
+    state.set_tree_watched_dirs(window.label(), root, dirs).map_err(|e| {
         tracing::warn!("[rust] update_tree_watched_dirs rejected: {}", e);
         e
     })

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -134,6 +134,7 @@ mod tests {
         let state = crate::watcher::WatcherState::new(tx);
         state
             .set_tree_watched_dirs(
+                "test",
                 workspace_canonical.to_string_lossy().into_owned(),
                 vec![workspace_canonical.to_string_lossy().into_owned()],
             )
@@ -159,6 +160,7 @@ mod tests {
         let state = crate::watcher::WatcherState::new(tx);
         state
             .set_tree_watched_dirs(
+                "test",
                 workspace_canonical.to_string_lossy().into_owned(),
                 vec![workspace_canonical.to_string_lossy().into_owned()],
             )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -383,6 +383,10 @@ pub fn run() {
                         "[window] Destroyed: {label} — unregistered from WindowRegistry"
                     );
                 }
+                if let Some(ws) = window.try_state::<watcher::WatcherState>() {
+                    ws.remove_window(&label);
+                    log::info!("[window] Destroyed: {label} — removed from WatcherState");
+                }
             }
         });
 

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,19 +1,19 @@
 use crate::core::paths::canonicalize_no_verbatim;
 use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
-/// Maximum number of tree-watched dirs accepted in a single `update_tree_watched_dirs` call.
+/// Maximum number of tree-watched dirs across ALL windows (merged union).
 pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
 
 pub struct WatcherState {
-    watched_paths: Arc<Mutex<HashSet<PathBuf>>>,
-    /// Canonical directories whose direct children should produce `folder-changed`
-    /// events (the open root + currently-expanded folders in the tree pane).
-    tree_watched_dirs: Arc<Mutex<HashSet<PathBuf>>>,
+    /// Per-window watched file paths (keyed by window label).
+    watched_paths: Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
+    /// Per-window tree-watched dirs (keyed by window label).
+    tree_watched_dirs: Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
     /// Sending on this channel wakes the watcher thread to sync dirs immediately.
     sync_tx: std::sync::mpsc::SyncSender<()>,
 }
@@ -21,10 +21,21 @@ pub struct WatcherState {
 impl WatcherState {
     pub fn new(sync_tx: std::sync::mpsc::SyncSender<()>) -> Self {
         Self {
-            watched_paths: Arc::new(Mutex::new(HashSet::new())),
-            tree_watched_dirs: Arc::new(Mutex::new(HashSet::new())),
+            watched_paths: Arc::new(Mutex::new(HashMap::new())),
+            tree_watched_dirs: Arc::new(Mutex::new(HashMap::new())),
             sync_tx,
         }
+    }
+
+    /// Remove all watcher entries for a destroyed window.
+    pub fn remove_window(&self, window_label: &str) {
+        if let Ok(mut guard) = self.tree_watched_dirs.lock() {
+            guard.remove(window_label);
+        }
+        if let Ok(mut guard) = self.watched_paths.lock() {
+            guard.remove(window_label);
+        }
+        let _ = self.sync_tx.try_send(());
     }
 
     /// Defense-in-depth allowlist for system-level commands (open / reveal):
@@ -41,14 +52,18 @@ impl WatcherState {
             Err(_) => return false,
         };
         if let Ok(watched) = self.watched_paths.lock() {
-            if watched.contains(&canonical) {
-                return true;
+            for set in watched.values() {
+                if set.contains(&canonical) {
+                    return true;
+                }
             }
         }
         if let Ok(dirs) = self.tree_watched_dirs.lock() {
-            for dir in dirs.iter() {
-                if canonical.starts_with(dir) {
-                    return true;
+            for set in dirs.values() {
+                for dir in set.iter() {
+                    if canonical.starts_with(dir) {
+                        return true;
+                    }
                 }
             }
         }
@@ -80,9 +95,11 @@ impl WatcherState {
             Err(_) => return false,
         };
         if let Ok(dirs) = self.tree_watched_dirs.lock() {
-            for dir in dirs.iter() {
-                if canonical_parent.starts_with(dir) {
-                    return true;
+            for set in dirs.values() {
+                for dir in set.iter() {
+                    if canonical_parent.starts_with(dir) {
+                        return true;
+                    }
                 }
             }
         }
@@ -93,7 +110,7 @@ impl WatcherState {
     /// Inputs are canonicalized internally — frontend may pass any absolute
     /// form (Windows `C:\...` or Unix `/...`); we normalize to the OS canonical
     /// form (e.g. `\\?\C:\...` on Windows) before storing.
-    pub fn set_tree_watched_dirs(&self, root: String, dirs: Vec<String>) -> Result<(), String> {
+    pub fn set_tree_watched_dirs(&self, window_label: &str, root: String, dirs: Vec<String>) -> Result<(), String> {
         if dirs.len() > MAX_TREE_WATCHED_DIRS {
             return Err(format!(
                 "too many dirs: {} (max {})",
@@ -124,7 +141,20 @@ impl WatcherState {
             .tree_watched_dirs
             .lock()
             .map_err(|e| format!("tree_watched_dirs lock poisoned: {}", e))?;
-        *guard = new_set;
+        let others_count: usize = guard
+            .iter()
+            .filter(|(k, _)| k.as_str() != window_label)
+            .map(|(_, v)| v.len())
+            .sum();
+        if others_count + new_set.len() > MAX_TREE_WATCHED_DIRS {
+            return Err(format!(
+                "too many dirs across all windows: {} + {} (max {})",
+                others_count,
+                new_set.len(),
+                MAX_TREE_WATCHED_DIRS
+            ));
+        }
+        guard.insert(window_label.to_string(), new_set);
         drop(guard);
 
         // Wake watcher thread to (un)register dirs immediately.
@@ -189,8 +219,8 @@ pub fn start_watcher(app: &AppHandle) {
             // Process debounced file-change events (200ms timeout for responsiveness).
             match rx.recv_timeout(Duration::from_millis(200)) {
                 Ok(Ok(events)) => {
-                    let current_watched = lock_watched(&watched);
-                    let current_tree = lock_watched(&tree_watched);
+                    let current_watched = lock_watched_union(&watched);
+                    let current_tree = lock_watched_union(&tree_watched);
                     // De-dup folder-changed emissions per debounced batch.
                     let mut folder_dirs: HashSet<PathBuf> = HashSet::new();
                     for event in events {
@@ -240,24 +270,27 @@ pub fn start_watcher(app: &AppHandle) {
     });
 }
 
-fn lock_watched(watched: &Arc<Mutex<HashSet<PathBuf>>>) -> HashSet<PathBuf> {
+fn lock_watched_union(watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>) -> HashSet<PathBuf> {
     match watched.lock() {
-        Ok(g) => g.clone(),
+        Ok(g) => g.values().flat_map(|s| s.iter().cloned()).collect(),
         Err(p) => {
             tracing::warn!("[watcher] mutex poisoned, recovering");
-            p.into_inner().clone()
+            p.into_inner()
+                .values()
+                .flat_map(|s| s.iter().cloned())
+                .collect()
         }
     }
 }
 
 fn sync_dirs(
-    watched: &Arc<Mutex<HashSet<PathBuf>>>,
-    tree_watched: &Arc<Mutex<HashSet<PathBuf>>>,
+    watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
+    tree_watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
     watched_dirs: &mut HashSet<PathBuf>,
     debouncer: &mut notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>,
 ) {
-    let current_watched = lock_watched(watched);
-    let current_tree = lock_watched(tree_watched);
+    let current_watched = lock_watched_union(watched);
+    let current_tree = lock_watched_union(tree_watched);
     let mut needed: HashSet<PathBuf> = current_watched
         .iter()
         .filter_map(|p| p.parent().map(|d| d.to_path_buf()))
@@ -292,31 +325,34 @@ fn sync_dirs(
 /// The frontend calls this whenever the set of open tabs changes.
 #[tauri::command]
 pub fn update_watched_files(
+    window: tauri::Window,
     paths: Vec<String>,
     state: tauri::State<'_, WatcherState>,
 ) -> Result<(), String> {
+    let window_label = window.label().to_string();
     let mut watched = state.watched_paths.lock().map_err(|e| e.to_string())?;
-    watched.clear();
+    let set = watched.entry(window_label).or_default();
+    set.clear();
 
     for path_str in &paths {
         let path = PathBuf::from(path_str);
         if let Ok(canonical) = canonicalize_no_verbatim(&path) {
-            watched.insert(canonical);
+            set.insert(canonical);
         }
         // Always store the raw path too — on deletion, canonicalize fails
         // and the notify crate may report the non-canonical form.
-        watched.insert(path.clone());
+        set.insert(path.clone());
         // Also watch sidecars
         for ext in &[".review.yaml", ".review.json"] {
             let sidecar = PathBuf::from(format!("{}{}", path_str, ext));
             if let Ok(canonical) = canonicalize_no_verbatim(&sidecar) {
-                watched.insert(canonical);
+                set.insert(canonical);
             }
-            watched.insert(sidecar);
+            set.insert(sidecar);
         }
     }
 
-    tracing::debug!("[watcher] updated watched files: {} paths", watched.len());
+    tracing::debug!("[watcher] updated watched files: {} paths", set.len());
     // Signal the watcher thread to sync dirs immediately (non-blocking: drop if full).
     let _ = state.sync_tx.try_send(());
     Ok(())

--- a/src-tauri/src/watcher_tests.rs
+++ b/src-tauri/src/watcher_tests.rs
@@ -16,6 +16,7 @@ fn update_tree_watched_dirs_canonicalizes_and_rejects_outside_root() {
 
     let err = state
         .set_tree_watched_dirs(
+            "test",
             root.to_string_lossy().into_owned(),
             vec![outside.to_string_lossy().into_owned()],
         )
@@ -28,6 +29,7 @@ fn update_tree_watched_dirs_canonicalizes_and_rejects_outside_root() {
     let inside_canonical = canonicalize_no_verbatim(&inside).unwrap();
     state
         .set_tree_watched_dirs(
+            "test",
             root.to_string_lossy().into_owned(),
             vec![inside_canonical.to_string_lossy().into_owned()],
         )
@@ -44,7 +46,7 @@ fn update_tree_watched_dirs_rejects_over_cap() {
     let state = make_state();
 
     let err = state
-        .set_tree_watched_dirs(root.to_string_lossy().into_owned(), dirs)
+        .set_tree_watched_dirs("test", root.to_string_lossy().into_owned(), dirs)
         .unwrap_err();
     assert!(err.contains("too many"), "unexpected error: {}", err);
 }
@@ -60,6 +62,7 @@ fn update_tree_watched_dirs_rejects_non_directory() {
 
     let err = state
         .set_tree_watched_dirs(
+            "test",
             root.to_string_lossy().into_owned(),
             vec![file_canonical.to_string_lossy().into_owned()],
         )
@@ -82,11 +85,11 @@ fn accepts_non_canonical_input_via_canonicalization() {
     let messy_root = dir.path().to_string_lossy().into_owned();
     let messy_dir = sub.to_string_lossy().into_owned();
     state
-        .set_tree_watched_dirs(messy_root, vec![messy_dir])
+        .set_tree_watched_dirs("test", messy_root, vec![messy_dir])
         .expect("non-canonical inputs must be normalized, not rejected");
     // The stored set must contain the canonical form of `sub`.
     let stored = state.tree_watched_dirs.lock().unwrap();
-    assert!(stored.contains(&canonicalize_no_verbatim(&sub).unwrap()));
+    assert!(stored.get("test").unwrap().contains(&canonicalize_no_verbatim(&sub).unwrap()));
 }
 
 #[test]
@@ -133,4 +136,83 @@ fn file_changed_still_fires_for_watched_paths_independently() {
         folder_dir.is_none(),
         "folder-changed must not fire when parent is not in tree_dirs"
     );
+}
+
+#[test]
+fn per_window_isolation() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let root_a = canonicalize_no_verbatim(dir_a.path()).unwrap();
+    let root_b = canonicalize_no_verbatim(dir_b.path()).unwrap();
+    let state = make_state();
+
+    state
+        .set_tree_watched_dirs(
+            "window-a",
+            root_a.to_string_lossy().into_owned(),
+            vec![root_a.to_string_lossy().into_owned()],
+        )
+        .unwrap();
+    state
+        .set_tree_watched_dirs(
+            "window-b",
+            root_b.to_string_lossy().into_owned(),
+            vec![root_b.to_string_lossy().into_owned()],
+        )
+        .unwrap();
+
+    // Both stored independently.
+    {
+        let guard = state.tree_watched_dirs.lock().unwrap();
+        assert!(guard.get("window-a").unwrap().contains(&root_a));
+        assert!(guard.get("window-b").unwrap().contains(&root_b));
+        assert!(!guard.get("window-a").unwrap().contains(&root_b));
+    }
+
+    // Remove window-a; window-b survives.
+    state.remove_window("window-a");
+    {
+        let guard = state.tree_watched_dirs.lock().unwrap();
+        assert!(!guard.contains_key("window-a"));
+        assert!(guard.get("window-b").unwrap().contains(&root_b));
+    }
+}
+
+#[test]
+fn is_path_allowed_checks_all_windows() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let root_a = canonicalize_no_verbatim(dir_a.path()).unwrap();
+    let root_b = canonicalize_no_verbatim(dir_b.path()).unwrap();
+    let state = make_state();
+
+    // Create files inside each workspace.
+    let file_a = root_a.join("a.md");
+    let file_b = root_b.join("b.md");
+    std::fs::write(&file_a, "a").unwrap();
+    std::fs::write(&file_b, "b").unwrap();
+
+    state
+        .set_tree_watched_dirs(
+            "win-a",
+            root_a.to_string_lossy().into_owned(),
+            vec![root_a.to_string_lossy().into_owned()],
+        )
+        .unwrap();
+    state
+        .set_tree_watched_dirs(
+            "win-b",
+            root_b.to_string_lossy().into_owned(),
+            vec![root_b.to_string_lossy().into_owned()],
+        )
+        .unwrap();
+
+    // Both files allowed via their respective windows.
+    assert!(state.is_path_allowed(&file_a));
+    assert!(state.is_path_allowed(&file_b));
+
+    // After removing win-a, file_a is no longer allowed.
+    state.remove_window("win-a");
+    assert!(!state.is_path_allowed(&file_a));
+    assert!(state.is_path_allowed(&file_b));
 }

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -663,6 +663,7 @@ fn watcher_state_allowing(dir: &std::path::Path) -> mdown_review_lib::watcher::W
     let state = mdown_review_lib::watcher::WatcherState::new(tx);
     state
         .set_tree_watched_dirs(
+            "test",
             canonical.to_string_lossy().into_owned(),
             vec![canonical.to_string_lossy().into_owned()],
         )

--- a/src-tauri/tests/comments_emit_test.rs
+++ b/src-tauri/tests/comments_emit_test.rs
@@ -70,6 +70,7 @@ fn watcher_allowing(dir: &Path) -> WatcherState {
     let state = WatcherState::new(tx);
     state
         .set_tree_watched_dirs(
+            "test",
             canonical.to_string_lossy().into_owned(),
             vec![canonical.to_string_lossy().into_owned()],
         )

--- a/src-tauri/tests/path_form_test.rs
+++ b/src-tauri/tests/path_form_test.rs
@@ -140,6 +140,7 @@ fn is_path_or_parent_allowed_accepts_8dot3_short_name_input() {
     let state = WatcherState::new(tx);
     state
         .set_tree_watched_dirs(
+            "test",
             workspace.to_string_lossy().into_owned(),
             vec![workspace.to_string_lossy().into_owned()],
         )


### PR DESCRIPTION
## Summary

Fixes shared watcher state between windows. Both tree_watched_dirs and watched_paths are now per-window (HashMap keyed by window label), with sync_dirs computing the union.

## Changes

- **watcher.rs**: Both maps become `HashMap<String, HashSet<PathBuf>>`. New `remove_window()` cleanup method. `is_path_allowed` / `is_path_or_parent_allowed` check union of all windows. `lock_watched_union` flattens per-window sets. `MAX_TREE_WATCHED_DIRS` cap enforced on merged union.
- **commands/fs.rs**: `update_tree_watched_dirs` accepts `window: tauri::Window` (auto-injected by Tauri)
- **watcher.rs**: `update_watched_files` accepts `window: tauri::Window`
- **lib.rs**: Window destroy also cleans up `WatcherState`
- **Tests**: All existing tests updated + 2 new tests (per_window_isolation, is_path_allowed_checks_all_windows)

## Frontend impact

None  `window` params in Tauri commands are auto-injected and don't appear in frontend invoke calls.