### PR TITLE
feat: implement #229  .mrsf.yaml sidecar_root alternate location

### DIFF
--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -21,50 +21,64 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
         timeout: 5_000,
       });
 
-      // Give the watcher time to register
-      await nativePage.waitForTimeout(3000);
-
-      // Drop .mrsf.yaml — watcher should detect and reload config internally
+      // Drop .mrsf.yaml — watcher should detect and reload config internally.
+      // The watcher needs to have registered the workspace root first
+      // (via update_tree_watched_dirs from the frontend's useTreeWatcher hook).
+      // The markdown-viewer being visible proves the workspace opened and
+      // the tree rendered, so the watcher should be watching by now.
       fs.writeFileSync(
         path.join(tmpDir, ".mrsf.yaml"),
         "sidecar_root: .reviews\n",
       );
 
-      // Wait for watcher to pick up the .mrsf.yaml change (debounce 300ms +
-      // processing; Windows CI runners can be slow so allow up to 8s)
-      await nativePage.waitForTimeout(8000);
-
-      // Add a comment via IPC — should land in .reviews/ not co-located
-      await nativePage.evaluate((fp: string) => {
-        // @ts-ignore — Tauri internals
-        return window.__TAURI_INTERNALS__.invoke("add_comment", {
-          filePath: fp,
-          author: "e2e-test",
-          text: "Comment under sidecar_root",
-          anchor: null,
-          commentType: null,
-          severity: null,
-          document: null,
-        });
-      }, docFile);
-
-      // Wait for the sidecar write (poll up to 5s)
+      // Poll for .mrsf.yaml config to be picked up by the watcher by
+      // attempting add_comment and checking the result location. This
+      // replaces the previous fixed-sleep approach.
       const reviewsDir = path.join(tmpDir, ".reviews");
       const sidecarPath = path.join(reviewsDir, "readme.md.review.yaml");
+      const colocated = path.join(tmpDir, "readme.md.review.yaml");
+
       let found = false;
-      for (let i = 0; i < 10; i++) {
-        if (fs.existsSync(sidecarPath)) { found = true; break; }
+      for (let attempt = 0; attempt < 20; attempt++) {
+        // Clean up any prior attempt artifacts
+        if (fs.existsSync(colocated)) fs.unlinkSync(colocated);
+        if (fs.existsSync(sidecarPath)) fs.unlinkSync(sidecarPath);
+
         await nativePage.waitForTimeout(500);
+
+        // Try adding a comment — the sidecar should land in .reviews/
+        await nativePage.evaluate((fp: string) => {
+          // @ts-ignore — Tauri internals
+          return window.__TAURI_INTERNALS__.invoke("add_comment", {
+            filePath: fp,
+            author: "e2e-test",
+            text: "Comment under sidecar_root",
+            anchor: null,
+            commentType: null,
+            severity: null,
+            document: null,
+          });
+        }, docFile);
+
+        // Give the write a moment to flush
+        await nativePage.waitForTimeout(200);
+
+        if (fs.existsSync(sidecarPath)) {
+          found = true;
+          break;
+        }
       }
 
       // Verify: sidecar landed in .reviews/ directory
-      expect(found).toBe(true);
+      expect(found, `sidecar should exist at ${sidecarPath} within 10s`).toBe(true);
       expect(fs.existsSync(reviewsDir)).toBe(true);
       expect(fs.existsSync(sidecarPath)).toBe(true);
 
       // Verify co-located sidecar was NOT created
-      const colocated = path.join(tmpDir, "readme.md.review.yaml");
-      expect(fs.existsSync(colocated)).toBe(false);
+      expect(
+        fs.existsSync(colocated),
+        "co-located sidecar should NOT exist when sidecar_root is configured",
+      ).toBe(false);
 
       // Read sidecar and verify content
       const content = fs.readFileSync(sidecarPath, "utf-8");

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, setRootViaTest } from "./fixtures";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
+  test("29.1 - dropping .mrsf.yaml triggers config reload and redirects sidecar writes", async ({
+    nativePage,
+  }) => {
+    const tmpDir = path.join(os.tmpdir(), `mdownreview-mrsf-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const docFile = path.join(tmpDir, "readme.md");
+    fs.writeFileSync(docFile, "# Hello\n\nTest content for MRSF config reload.");
+
+    try {
+      await setRootViaTest(nativePage, tmpDir);
+
+      // Wait for the app to render the file
+      await expect(nativePage.locator(".markdown-viewer")).toBeVisible({ timeout: 10_000 });
+      await expect(nativePage.locator(".markdown-viewer")).toContainText("Hello", {
+        timeout: 5_000,
+      });
+
+      // Give the watcher time to register
+      await nativePage.waitForTimeout(2000);
+
+      // Drop .mrsf.yaml — watcher should detect and reload config internally
+      fs.writeFileSync(
+        path.join(tmpDir, ".mrsf.yaml"),
+        "sidecar_root: .reviews\n",
+      );
+
+      // Wait for watcher to pick up the .mrsf.yaml change (debounce 300ms + processing)
+      await nativePage.waitForTimeout(3000);
+
+      // Add a comment via IPC — should land in .reviews/ not co-located
+      await nativePage.evaluate(() => {
+        // @ts-ignore — Tauri internals
+        return window.__TAURI_INTERNALS__.invoke("add_comment", {
+          file_path: document.querySelector("[data-file-path]")?.getAttribute("data-file-path"),
+          author: "e2e-test",
+          text: "Comment under sidecar_root",
+          anchor: null,
+          comment_type: null,
+          severity: null,
+          document: null,
+        });
+      });
+
+      // Wait briefly for the sidecar write
+      await nativePage.waitForTimeout(1000);
+
+      // Verify: sidecar landed in .reviews/ directory
+      const reviewsDir = path.join(tmpDir, ".reviews");
+      expect(fs.existsSync(reviewsDir)).toBe(true);
+
+      // Find the sidecar file under .reviews/
+      const sidecarPath = path.join(reviewsDir, "readme.md.review.yaml");
+      expect(fs.existsSync(sidecarPath)).toBe(true);
+
+      // Verify co-located sidecar was NOT created
+      const colocated = path.join(tmpDir, "readme.md.review.yaml");
+      expect(fs.existsSync(colocated)).toBe(false);
+
+      // Read sidecar and verify content
+      const content = fs.readFileSync(sidecarPath, "utf-8");
+      expect(content).toContain("Comment under sidecar_root");
+      expect(content).toContain("e2e-test");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -34,10 +34,10 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
       await nativePage.waitForTimeout(3000);
 
       // Add a comment via IPC — should land in .reviews/ not co-located
-      await nativePage.evaluate(() => {
+      await nativePage.evaluate((fp: string) => {
         // @ts-ignore — Tauri internals
         return window.__TAURI_INTERNALS__.invoke("add_comment", {
-          filePath: document.querySelector("[data-file-path]")?.getAttribute("data-file-path"),
+          filePath: fp,
           author: "e2e-test",
           text: "Comment under sidecar_root",
           anchor: null,
@@ -45,7 +45,7 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
           severity: null,
           document: null,
         });
-      });
+      }, docFile);
 
       // Wait briefly for the sidecar write
       await nativePage.waitForTimeout(1000);

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -7,8 +7,10 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
   test("29.1 - dropping .mrsf.yaml triggers config reload and redirects sidecar writes", async ({
     nativePage,
   }) => {
-    const tmpDir = path.join(os.tmpdir(), `mdownreview-mrsf-${Date.now()}`);
-    fs.mkdirSync(tmpDir, { recursive: true });
+    const rawTmpDir = path.join(os.tmpdir(), `mdownreview-mrsf-${Date.now()}`);
+    fs.mkdirSync(rawTmpDir, { recursive: true });
+    // Canonicalize to resolve 8.3 short names on Windows CI (RUNNER~1 vs runneradmin)
+    const tmpDir = fs.realpathSync(rawTmpDir);
     const docFile = path.join(tmpDir, "readme.md");
     fs.writeFileSync(docFile, "# Hello\n\nTest content for MRSF config reload.");
 

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -37,11 +37,11 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
       await nativePage.evaluate(() => {
         // @ts-ignore — Tauri internals
         return window.__TAURI_INTERNALS__.invoke("add_comment", {
-          file_path: document.querySelector("[data-file-path]")?.getAttribute("data-file-path"),
+          filePath: document.querySelector("[data-file-path]")?.getAttribute("data-file-path"),
           author: "e2e-test",
           text: "Comment under sidecar_root",
           anchor: null,
-          comment_type: null,
+          commentType: null,
           severity: null,
           document: null,
         });

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -22,7 +22,7 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
       });
 
       // Give the watcher time to register
-      await nativePage.waitForTimeout(2000);
+      await nativePage.waitForTimeout(3000);
 
       // Drop .mrsf.yaml — watcher should detect and reload config internally
       fs.writeFileSync(
@@ -30,8 +30,9 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
         "sidecar_root: .reviews\n",
       );
 
-      // Wait for watcher to pick up the .mrsf.yaml change (debounce 300ms + processing)
-      await nativePage.waitForTimeout(3000);
+      // Wait for watcher to pick up the .mrsf.yaml change (debounce 300ms +
+      // processing; Windows CI runners can be slow so allow up to 8s)
+      await nativePage.waitForTimeout(8000);
 
       // Add a comment via IPC — should land in .reviews/ not co-located
       await nativePage.evaluate((fp: string) => {
@@ -47,11 +48,17 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
         });
       }, docFile);
 
-      // Wait briefly for the sidecar write
-      await nativePage.waitForTimeout(1000);
+      // Wait for the sidecar write (poll up to 5s)
+      const reviewsDir = path.join(tmpDir, ".reviews");
+      const sidecarPath = path.join(reviewsDir, "readme.md.review.yaml");
+      let found = false;
+      for (let i = 0; i < 10; i++) {
+        if (fs.existsSync(sidecarPath)) { found = true; break; }
+        await nativePage.waitForTimeout(500);
+      }
 
       // Verify: sidecar landed in .reviews/ directory
-      const reviewsDir = path.join(tmpDir, ".reviews");
+      expect(found).toBe(true);
       expect(fs.existsSync(reviewsDir)).toBe(true);
 
       // Find the sidecar file under .reviews/

--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -60,9 +60,6 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
       // Verify: sidecar landed in .reviews/ directory
       expect(found).toBe(true);
       expect(fs.existsSync(reviewsDir)).toBe(true);
-
-      // Find the sidecar file under .reviews/
-      const sidecarPath = path.join(reviewsDir, "readme.md.review.yaml");
       expect(fs.existsSync(sidecarPath)).toBe(true);
 
       // Verify co-located sidecar was NOT created

--- a/src-tauri/src/commands/comments/anchor_input.rs
+++ b/src-tauri/src/commands/comments/anchor_input.rs
@@ -1,0 +1,94 @@
+//! Wire-format anchor types for `add_comment`.
+//!
+//! Extracted from `mod.rs` to stay under the 400-LOC budget (arch rule 23).
+
+use crate::core::types::{Anchor, CommentAnchor, WordRangePayload};
+use serde::Deserialize;
+
+/// Wire-format anchor for `add_comment`. Accepts BOTH the legacy flat
+/// `{ line, ... }` shape used by line-anchored composers and the tagged
+/// `{ kind: "...", ... }` shape introduced for file-level + typed
+/// anchors (Group A/B). Untagged so the JS chokepoint (`addComment` in
+/// `lib/tauri-commands.ts`) does not have to convert.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum NewCommentAnchor {
+    Tagged(TaggedNewAnchor),
+    Legacy(CommentAnchor),
+}
+
+/// Tagged variant of [`NewCommentAnchor`]. Mirrors the TS `Anchor` union
+/// in `src/types/comments.ts` — discriminator is `kind`, payload fields
+/// are flattened alongside it (internally tagged).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TaggedNewAnchor {
+    Line {
+        line: u32,
+        #[serde(default)]
+        end_line: Option<u32>,
+        #[serde(default)]
+        start_column: Option<u32>,
+        #[serde(default)]
+        end_column: Option<u32>,
+        #[serde(default)]
+        selected_text: Option<String>,
+        #[serde(default)]
+        selected_text_hash: Option<String>,
+    },
+    File,
+    WordRange(WordRangePayload),
+}
+
+impl NewCommentAnchor {
+    /// Convert into the canonical in-memory [`Anchor`] enum + a legacy
+    /// flat [`CommentAnchor`] (used by `create_comment` to populate the
+    /// MrsfComment's flat line fields). For non-Line variants, the flat
+    /// fields are left as the default — callers must not rely on them.
+    /// Exposed `pub` for integration tests of `add_comment`'s anchor
+    /// dispatch (the `#[tauri::command]` itself can't be invoked outside
+    /// a Tauri runtime).
+    pub fn into_anchor_pair(self) -> (Anchor, Option<CommentAnchor>) {
+        match self {
+            NewCommentAnchor::Legacy(c) => {
+                let anchor = Anchor::Line {
+                    line: c.line,
+                    end_line: c.end_line,
+                    start_column: c.start_column,
+                    end_column: c.end_column,
+                    selected_text: c.selected_text.clone(),
+                    selected_text_hash: c.selected_text_hash.clone(),
+                };
+                (anchor, Some(c))
+            }
+            NewCommentAnchor::Tagged(TaggedNewAnchor::Line {
+                line,
+                end_line,
+                start_column,
+                end_column,
+                selected_text,
+                selected_text_hash,
+            }) => {
+                let flat = CommentAnchor {
+                    line,
+                    end_line,
+                    start_column,
+                    end_column,
+                    selected_text: selected_text.clone(),
+                    selected_text_hash: selected_text_hash.clone(),
+                };
+                let anchor = Anchor::Line {
+                    line,
+                    end_line,
+                    start_column,
+                    end_column,
+                    selected_text,
+                    selected_text_hash,
+                };
+                (anchor, Some(flat))
+            }
+            NewCommentAnchor::Tagged(TaggedNewAnchor::File) => (Anchor::File, None),
+            NewCommentAnchor::Tagged(TaggedNewAnchor::WordRange(p)) => (Anchor::WordRange(p), None),
+        }
+    }
+}

--- a/src-tauri/src/commands/comments/badges.rs
+++ b/src-tauri/src/commands/comments/badges.rs
@@ -2,7 +2,7 @@
 
 use crate::core::severity::{max_severity, Severity};
 use crate::core::types::{Anchor, MatchedComment};
-use crate::watcher::WatcherState;
+use crate::watcher::{SidecarConfigState, WatcherState};
 use std::collections::HashMap;
 use std::path::Path;
 use tauri::State;
@@ -37,10 +37,11 @@ pub struct FileBadge {
 #[tauri::command]
 pub fn get_file_badges(
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_paths: Vec<String>,
 ) -> Result<HashMap<String, FileBadge>, String> {
     enforce_badge_input_cap(&file_paths)?;
-    Ok(get_file_badges_inner(&state, &file_paths))
+    Ok(get_file_badges_inner(&state, &config_state, &file_paths))
 }
 
 /// Validates the input length cap for `get_file_badges`. Public so
@@ -57,6 +58,7 @@ pub fn enforce_badge_input_cap(file_paths: &[String]) -> Result<(), String> {
 /// Pure helper for [`get_file_badges`].
 pub fn get_file_badges_inner(
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_paths: &[String],
 ) -> HashMap<String, FileBadge> {
     let mut out: HashMap<String, FileBadge> = HashMap::new();
@@ -66,7 +68,8 @@ pub fn get_file_badges_inner(
         if !state.is_path_or_parent_allowed(Path::new(fp)) {
             continue;
         }
-        let sidecar = match crate::core::sidecar::load_sidecar(fp) {
+        let (yaml, json, _) = super::resolve_sidecar_pair(fp, config_state);
+        let sidecar = match crate::core::sidecar::load_sidecar_at(&yaml, &json) {
             Ok(Some(s)) => s,
             Ok(None) => continue,
             Err(e) => {
@@ -231,7 +234,8 @@ mod tests {
         save_sidecar(&file_path, "data.csv", &[unresolved, resolved]).unwrap();
 
         let state = watcher_state_allowing(&canonical);
-        let badges = get_file_badges_inner(&state, std::slice::from_ref(&file_path));
+        let config = SidecarConfigState::new();
+        let badges = get_file_badges_inner(&state, &config, std::slice::from_ref(&file_path));
         let badge = badges.get(&file_path).expect("badge for typed-only file");
         assert_eq!(badge.count, 1);
         assert_eq!(badge.max_severity, Severity::Medium);
@@ -259,7 +263,8 @@ mod tests {
         save_sidecar(&file_path, "doc.md", &[typed, line]).unwrap();
 
         let state = watcher_state_allowing(&canonical);
-        let badges = get_file_badges_inner(&state, std::slice::from_ref(&file_path));
+        let config = SidecarConfigState::new();
+        let badges = get_file_badges_inner(&state, &config, std::slice::from_ref(&file_path));
         let badge = badges.get(&file_path).expect("badge for mixed file");
         assert_eq!(badge.count, 2);
         assert_eq!(badge.max_severity, Severity::High);

--- a/src-tauri/src/commands/comments/get.rs
+++ b/src-tauri/src/commands/comments/get.rs
@@ -24,26 +24,23 @@ pub struct GetFileCommentsResult {
     pub sidecar_mtime_ms: Option<i64>,
 }
 
-/// Resolve the on-disk sidecar path the loader would pick for `file_path`,
-/// consulting the workspace's `.mrsf.yaml` config if present. Prefers
-/// `.review.yaml` over `.review.json` to match
-/// [`crate::core::sidecar::load_sidecar_at`]. Returns `None` when neither
-/// exists.
-fn resolve_sidecar_path(file_path: &str, config_state: &SidecarConfigState) -> Option<std::path::PathBuf> {
-    let (yaml, json, _) = super::resolve_sidecar_pair(file_path, config_state);
-    let yaml = std::path::PathBuf::from(&yaml);
+/// Resolve the on-disk sidecar path from pre-resolved YAML/JSON paths.
+/// Prefers YAML over JSON to match [`crate::core::sidecar::load_sidecar_at`].
+/// Returns `None` when neither exists.
+fn resolve_sidecar_path_from(yaml: &str, json: &str) -> Option<std::path::PathBuf> {
+    let yaml = std::path::PathBuf::from(yaml);
     if yaml.exists() {
         return Some(yaml);
     }
-    let json = std::path::PathBuf::from(&json);
+    let json = std::path::PathBuf::from(json);
     if json.exists() {
         return Some(json);
     }
     None
 }
 
-fn sidecar_mtime_ms(file_path: &str, config_state: &SidecarConfigState) -> Option<i64> {
-    let path = resolve_sidecar_path(file_path, config_state)?;
+fn sidecar_mtime_ms_from(yaml: &str, json: &str) -> Option<i64> {
+    let path = resolve_sidecar_path_from(yaml, json)?;
     std::fs::metadata(&path)
         .ok()?
         .modified()
@@ -88,12 +85,14 @@ pub fn get_file_comments_inner(file_path: &str, config_state: &SidecarConfigStat
     use crate::core::anchors::{resolve_anchor, LazyParsedDoc, MatchOutcome};
     use crate::core::types::{Anchor, MatchedComment};
 
+    // Resolve sidecar paths ONCE — used for both mtime and load.
+    let (yaml, json, _) = super::resolve_sidecar_pair(file_path, config_state);
+
     // Capture sidecar mtime up-front so the value reflects the same on-disk
     // state the loader is about to read. Loader failure does not invalidate
     // the mtime — return it anyway so callers can still detect edits.
-    let sidecar_mtime_ms = sidecar_mtime_ms(file_path, config_state);
+    let sidecar_mtime_ms = sidecar_mtime_ms_from(&yaml, &json);
 
-    let (yaml, json, _) = super::resolve_sidecar_pair(file_path, config_state);
     let sidecar = crate::core::sidecar::load_sidecar_at(&yaml, &json).map_err(|e| e.to_string())?;
     let comments = match sidecar {
         Some(s) => s.comments,

--- a/src-tauri/src/commands/comments/get.rs
+++ b/src-tauri/src/commands/comments/get.rs
@@ -10,7 +10,7 @@ use crate::core::types::{CommentThread, MrsfComment};
 use tauri::State;
 
 use super::enforce_workspace_path;
-use crate::watcher::WatcherState;
+use crate::watcher::{SidecarConfigState, WatcherState};
 
 /// Result of [`get_file_comments`]: matched/grouped threads plus the mtime
 /// of the sidecar file the loader actually picked. `sidecar_mtime_ms` is
@@ -25,25 +25,25 @@ pub struct GetFileCommentsResult {
 }
 
 /// Resolve the on-disk sidecar path the loader would pick for `file_path`,
-/// preferring `.review.yaml` over `.review.json` to match
-/// [`crate::core::sidecar::load_sidecar`]. Returns `None` when neither
-/// exists. Kept private — the loader does not expose its picked path, so
-/// this re-implements the resolution locally; if the loader ever gains a
-/// `picked_path()` accessor, prefer that.
-fn resolve_sidecar_path(file_path: &str) -> Option<std::path::PathBuf> {
-    let yaml = std::path::PathBuf::from(format!("{}.review.yaml", file_path));
+/// consulting the workspace's `.mrsf.yaml` config if present. Prefers
+/// `.review.yaml` over `.review.json` to match
+/// [`crate::core::sidecar::load_sidecar_at`]. Returns `None` when neither
+/// exists.
+fn resolve_sidecar_path(file_path: &str, config_state: &SidecarConfigState) -> Option<std::path::PathBuf> {
+    let (yaml, json, _) = super::resolve_sidecar_pair(file_path, config_state);
+    let yaml = std::path::PathBuf::from(&yaml);
     if yaml.exists() {
         return Some(yaml);
     }
-    let json = std::path::PathBuf::from(format!("{}.review.json", file_path));
+    let json = std::path::PathBuf::from(&json);
     if json.exists() {
         return Some(json);
     }
     None
 }
 
-fn sidecar_mtime_ms(file_path: &str) -> Option<i64> {
-    let path = resolve_sidecar_path(file_path)?;
+fn sidecar_mtime_ms(file_path: &str, config_state: &SidecarConfigState) -> Option<i64> {
+    let path = resolve_sidecar_path(file_path, config_state)?;
     std::fs::metadata(&path)
         .ok()?
         .modified()
@@ -73,26 +73,28 @@ fn sidecar_mtime_ms(file_path: &str) -> Option<i64> {
 #[tauri::command]
 pub fn get_file_comments(
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
 ) -> Result<GetFileCommentsResult, String> {
     enforce_workspace_path(&state, &file_path)?;
-    get_file_comments_inner(&file_path)
+    get_file_comments_inner(&file_path, &config_state)
 }
 
 /// Pure helper for [`get_file_comments`]. Skips the workspace guard so
 /// integration tests can exercise the matcher / typed-anchor path without
 /// fabricating a `State<'_, WatcherState>`. The IPC layer must call the
 /// `#[tauri::command]` wrapper above, never this function directly.
-pub fn get_file_comments_inner(file_path: &str) -> Result<GetFileCommentsResult, String> {
+pub fn get_file_comments_inner(file_path: &str, config_state: &SidecarConfigState) -> Result<GetFileCommentsResult, String> {
     use crate::core::anchors::{resolve_anchor, LazyParsedDoc, MatchOutcome};
     use crate::core::types::{Anchor, MatchedComment};
 
     // Capture sidecar mtime up-front so the value reflects the same on-disk
     // state the loader is about to read. Loader failure does not invalidate
     // the mtime — return it anyway so callers can still detect edits.
-    let sidecar_mtime_ms = sidecar_mtime_ms(file_path);
+    let sidecar_mtime_ms = sidecar_mtime_ms(file_path, config_state);
 
-    let sidecar = crate::core::sidecar::load_sidecar(file_path).map_err(|e| e.to_string())?;
+    let (yaml, json, _) = super::resolve_sidecar_pair(file_path, config_state);
+    let sidecar = crate::core::sidecar::load_sidecar_at(&yaml, &json).map_err(|e| e.to_string())?;
     let comments = match sidecar {
         Some(s) => s.comments,
         None => {
@@ -183,6 +185,7 @@ mod tests {
     use crate::core::anchors::LINES_INIT_COUNT;
     use crate::core::sidecar::save_sidecar;
     use crate::core::types::{Anchor, MrsfComment};
+    use crate::watcher::SidecarConfigState;
 
     fn typed_comment(id: &str, anchor: Anchor) -> MrsfComment {
         MrsfComment {
@@ -224,8 +227,9 @@ mod tests {
         );
         save_sidecar(&file_path, "doc.html", &[html_c, img_c]).unwrap();
 
+        let config = SidecarConfigState::new();
         LINES_INIT_COUNT.with(|c| c.set(0));
-        let _threads = get_file_comments_inner(&file_path).expect("ok");
+        let _threads = get_file_comments_inner(&file_path, &config).expect("ok");
         assert_eq!(
             LINES_INIT_COUNT.with(|c| c.get()),
             0,
@@ -258,8 +262,9 @@ mod tests {
         );
         save_sidecar(&file_path, "doc.md", &[line_c]).unwrap();
 
+        let config = SidecarConfigState::new();
         LINES_INIT_COUNT.with(|c| c.set(0));
-        let _ = get_file_comments_inner(&file_path).expect("ok");
+        let _ = get_file_comments_inner(&file_path, &config).expect("ok");
         assert_eq!(
             LINES_INIT_COUNT.with(|c| c.get()),
             1,

--- a/src-tauri/src/commands/comments/mod.rs
+++ b/src-tauri/src/commands/comments/mod.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::path::Path;
 use tauri::{AppHandle, Emitter, Runtime, State};
 
-use crate::watcher::WatcherState;
+use crate::watcher::{SidecarConfigState, WatcherState};
 
 pub mod badges;
 pub mod get;
@@ -77,17 +77,55 @@ impl<R: Runtime> CommentsEmitter for AppHandle<R> {
     }
 }
 
+/// Compute the YAML and JSON sidecar paths for a source file, consulting
+/// the workspace's `.mrsf.yaml` config if present. When `sidecar_root` is
+/// configured, paths are redirected under `workspace_root/sidecar_root/`.
+/// Falls back to co-located paths when no config is active.
+///
+/// Returns `(yaml_path, json_path, Option<workspace_root>)`. The third
+/// element is `Some` when a redirected config is active — callers use it
+/// to call [`crate::core::paths::ensure_sidecar_parent`] before writing.
+pub(crate) fn resolve_sidecar_pair(
+    file_path: &str,
+    config_state: &SidecarConfigState,
+) -> (String, String, Option<std::path::PathBuf>) {
+    let file = Path::new(file_path);
+    if let Some((ws_root, Some(sr))) = config_state.resolve_for_file(file) {
+        if let Ok(relative) = file.strip_prefix(&ws_root) {
+            let sidecar_dir = ws_root.join(&sr);
+            let yaml = sidecar_dir.join(format!("{}.review.yaml", relative.display()));
+            let json = sidecar_dir.join(format!("{}.review.json", relative.display()));
+            return (
+                yaml.to_string_lossy().into_owned(),
+                json.to_string_lossy().into_owned(),
+                Some(ws_root),
+            );
+        }
+    }
+    (
+        format!("{}.review.yaml", file_path),
+        format!("{}.review.json", file_path),
+        None,
+    )
+}
+
 /// Load a sidecar, apply a mutation, save, and emit `comments-changed`.
 fn with_sidecar_mut<E: CommentsEmitter>(
     emitter: &E,
     file_path: &str,
+    config_state: &SidecarConfigState,
     mutate: impl FnOnce(&mut MrsfSidecar) -> Result<(), String>,
 ) -> Result<(), String> {
-    let mut sidecar = crate::core::sidecar::load_sidecar(file_path)
+    let (yaml, json, ws_root) = resolve_sidecar_pair(file_path, config_state);
+    let mut sidecar = crate::core::sidecar::load_sidecar_at(&yaml, &json)
         .map_err(|e| e.to_string())?
         .ok_or("sidecar not found")?;
     mutate(&mut sidecar)?;
-    crate::core::sidecar::save_sidecar(file_path, &sidecar.document, &sidecar.comments)
+    let save_path = std::path::PathBuf::from(&yaml);
+    if let Some(ref root) = ws_root {
+        crate::core::paths::ensure_sidecar_parent(root, &save_path).map_err(|e| e.to_string())?;
+    }
+    crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
         .map_err(|e| e.to_string())?;
     emitter.emit_comments_changed(file_path);
     Ok(())
@@ -101,9 +139,11 @@ fn with_sidecar_mut<E: CommentsEmitter>(
 pub fn mutate_sidecar_or_create(
     file_path: &str,
     document_default: Option<String>,
+    config_state: &SidecarConfigState,
     mutate: impl FnOnce(&mut MrsfSidecar) -> Result<(), String>,
 ) -> Result<(), String> {
-    let mut sidecar = crate::core::sidecar::load_sidecar(file_path)
+    let (yaml, json, ws_root) = resolve_sidecar_pair(file_path, config_state);
+    let mut sidecar = crate::core::sidecar::load_sidecar_at(&yaml, &json)
         .map_err(|e| e.to_string())?
         .unwrap_or_else(|| MrsfSidecar {
             mrsf_version: MRSF_VERSION_DEFAULT.to_string(),
@@ -116,7 +156,11 @@ pub fn mutate_sidecar_or_create(
             comments: vec![],
         });
     mutate(&mut sidecar)?;
-    crate::core::sidecar::save_sidecar(file_path, &sidecar.document, &sidecar.comments)
+    let save_path = std::path::PathBuf::from(&yaml);
+    if let Some(ref root) = ws_root {
+        crate::core::paths::ensure_sidecar_parent(root, &save_path).map_err(|e| e.to_string())?;
+    }
+    crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -127,9 +171,10 @@ fn with_sidecar_or_create<E: CommentsEmitter>(
     emitter: &E,
     file_path: &str,
     document_default: Option<String>,
+    config_state: &SidecarConfigState,
     mutate: impl FnOnce(&mut MrsfSidecar) -> Result<(), String>,
 ) -> Result<(), String> {
-    mutate_sidecar_or_create(file_path, document_default, mutate)?;
+    mutate_sidecar_or_create(file_path, document_default, config_state, mutate)?;
     emitter.emit_comments_changed(file_path);
     Ok(())
 }
@@ -237,6 +282,7 @@ impl NewCommentAnchor {
 pub fn add_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
     author: String,
     text: String,
@@ -248,6 +294,7 @@ pub fn add_comment<R: Runtime>(
     add_comment_inner(
         &app,
         &state,
+        &config_state,
         file_path,
         author,
         text,
@@ -268,6 +315,7 @@ pub fn add_comment<R: Runtime>(
 pub fn add_comment_inner<E: CommentsEmitter>(
     emitter: &E,
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_path: String,
     author: String,
     text: String,
@@ -311,7 +359,7 @@ pub fn add_comment_inner<E: CommentsEmitter>(
         }
         comment.anchor = canonical;
     }
-    with_sidecar_or_create(emitter, &file_path, document, |sidecar| {
+    with_sidecar_or_create(emitter, &file_path, document, config_state, |sidecar| {
         sidecar.comments.push(comment);
         Ok(())
     })
@@ -335,25 +383,27 @@ pub fn check_workspace_for(
 pub fn add_reply<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
     parent_id: String,
     author: String,
     text: String,
 ) -> Result<(), String> {
-    add_reply_inner(&app, &state, file_path, parent_id, author, text)
+    add_reply_inner(&app, &state, &config_state, file_path, parent_id, author, text)
 }
 
 /// Test seam for [`add_reply`]. See [`add_comment_inner`] for rationale.
 pub fn add_reply_inner<E: CommentsEmitter>(
     emitter: &E,
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_path: String,
     parent_id: String,
     author: String,
     text: String,
 ) -> Result<(), String> {
     enforce_workspace_path(state, &file_path)?;
-    with_sidecar_mut(emitter, &file_path, |sidecar| {
+    with_sidecar_mut(emitter, &file_path, config_state, |sidecar| {
         let parent = sidecar
             .comments
             .iter()
@@ -371,23 +421,25 @@ pub fn add_reply_inner<E: CommentsEmitter>(
 pub fn edit_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
     comment_id: String,
     text: String,
 ) -> Result<(), String> {
-    edit_comment_inner(&app, &state, file_path, comment_id, text)
+    edit_comment_inner(&app, &state, &config_state, file_path, comment_id, text)
 }
 
 /// Test seam for [`edit_comment`]. See [`add_comment_inner`] for rationale.
 pub fn edit_comment_inner<E: CommentsEmitter>(
     emitter: &E,
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_path: String,
     comment_id: String,
     text: String,
 ) -> Result<(), String> {
     enforce_workspace_path(state, &file_path)?;
-    with_sidecar_mut(emitter, &file_path, |sidecar| {
+    with_sidecar_mut(emitter, &file_path, config_state, |sidecar| {
         let comment = sidecar
             .comments
             .iter_mut()
@@ -403,21 +455,23 @@ pub fn edit_comment_inner<E: CommentsEmitter>(
 pub fn delete_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
     comment_id: String,
 ) -> Result<(), String> {
-    delete_comment_inner(&app, &state, file_path, comment_id)
+    delete_comment_inner(&app, &state, &config_state, file_path, comment_id)
 }
 
 /// Test seam for [`delete_comment`]. See [`add_comment_inner`] for rationale.
 pub fn delete_comment_inner<E: CommentsEmitter>(
     emitter: &E,
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_path: String,
     comment_id: String,
 ) -> Result<(), String> {
     enforce_workspace_path(state, &file_path)?;
-    with_sidecar_mut(emitter, &file_path, |sidecar| {
+    with_sidecar_mut(emitter, &file_path, config_state, |sidecar| {
         sidecar.comments = crate::core::comments::delete_comment(&sidecar.comments, &comment_id);
         Ok(())
     })

--- a/src-tauri/src/commands/comments/mod.rs
+++ b/src-tauri/src/commands/comments/mod.rs
@@ -1,22 +1,25 @@
 //! Comment thread mutation commands (sidecar reads, writes, anchor hashing).
 //!
-//! Split into 4 submodules for the 400-LOC budget (architecture rule 23):
+//! Split into 5 submodules for the 400-LOC budget (architecture rule 23):
 //! - `mod.rs` — workspace guard + CRUD entry points
+//! - `anchor_input.rs` — `NewCommentAnchor` / `TaggedNewAnchor` wire types
 //! - `badges.rs` — `get_file_badges`
 //! - `get.rs` — `get_file_comments` (typed-anchor dispatch + matching)
 //! - `update.rs` — `update_comment` + `CommentPatch`
 
 use crate::core::mrsf_version::MRSF_VERSION_DEFAULT;
-use crate::core::types::{Anchor, CommentAnchor, MrsfSidecar, WordRangePayload};
-use serde::Deserialize;
+use crate::core::types::{Anchor, MrsfSidecar};
 use std::path::Path;
 use tauri::{AppHandle, Emitter, Runtime, State};
 
 use crate::watcher::{SidecarConfigState, WatcherState};
 
+pub mod anchor_input;
 pub mod badges;
 pub mod get;
 pub mod update;
+
+pub use anchor_input::{NewCommentAnchor, TaggedNewAnchor};
 
 pub use badges::{get_file_badges, get_file_badges_inner, FileBadge};
 pub use get::{get_file_comments, get_file_comments_inner, GetFileCommentsResult};
@@ -77,36 +80,16 @@ impl<R: Runtime> CommentsEmitter for AppHandle<R> {
     }
 }
 
-/// Compute the YAML and JSON sidecar paths for a source file, consulting
-/// the workspace's `.mrsf.yaml` config if present. When `sidecar_root` is
-/// configured, paths are redirected under `workspace_root/sidecar_root/`.
-/// Falls back to co-located paths when no config is active.
-///
-/// Returns `(yaml_path, json_path, Option<workspace_root>)`. The third
-/// element is `Some` when a redirected config is active — callers use it
-/// to call [`crate::core::paths::ensure_sidecar_parent`] before writing.
+/// Thin wrapper around [`crate::core::paths::resolve_sidecar_pair`] that
+/// extracts the workspace config from managed state.
 pub(crate) fn resolve_sidecar_pair(
     file_path: &str,
     config_state: &SidecarConfigState,
 ) -> (String, String, Option<std::path::PathBuf>) {
     let file = Path::new(file_path);
-    if let Some((ws_root, Some(sr))) = config_state.resolve_for_file(file) {
-        if let Ok(relative) = file.strip_prefix(&ws_root) {
-            let sidecar_dir = ws_root.join(&sr);
-            let yaml = sidecar_dir.join(format!("{}.review.yaml", relative.display()));
-            let json = sidecar_dir.join(format!("{}.review.json", relative.display()));
-            return (
-                yaml.to_string_lossy().into_owned(),
-                json.to_string_lossy().into_owned(),
-                Some(ws_root),
-            );
-        }
-    }
-    (
-        format!("{}.review.yaml", file_path),
-        format!("{}.review.json", file_path),
-        None,
-    )
+    let config_data = config_state.resolve_for_file(file);
+    let config = config_data.as_ref().map(|(ws, sr)| (ws.as_path(), sr));
+    crate::core::paths::resolve_sidecar_pair(file, config)
 }
 
 /// Load a sidecar, apply a mutation, save, and emit `comments-changed`.
@@ -121,11 +104,7 @@ fn with_sidecar_mut<E: CommentsEmitter>(
         .map_err(|e| e.to_string())?
         .ok_or("sidecar not found")?;
     mutate(&mut sidecar)?;
-    let save_path = std::path::PathBuf::from(&yaml);
-    if let Some(ref root) = ws_root {
-        crate::core::paths::ensure_sidecar_parent(root, &save_path).map_err(|e| e.to_string())?;
-    }
-    crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
+    crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
         .map_err(|e| e.to_string())?;
     emitter.emit_comments_changed(file_path);
     Ok(())
@@ -156,11 +135,7 @@ pub fn mutate_sidecar_or_create(
             comments: vec![],
         });
     mutate(&mut sidecar)?;
-    let save_path = std::path::PathBuf::from(&yaml);
-    if let Some(ref root) = ws_root {
-        crate::core::paths::ensure_sidecar_parent(root, &save_path).map_err(|e| e.to_string())?;
-    }
-    crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
+    crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -182,94 +157,6 @@ fn with_sidecar_or_create<E: CommentsEmitter>(
 // `get_file_comments` lives in [`get`] (split out to keep this file under
 // the architecture rule 23 LOC budget). Re-exported above so the IPC
 // registration in `lib.rs` stays unchanged.
-
-/// Wire-format anchor for `add_comment`. Accepts BOTH the legacy flat
-/// `{ line, ... }` shape used by line-anchored composers and the tagged
-/// `{ kind: "...", ... }` shape introduced for file-level + typed
-/// anchors (Group A/B). Untagged so the JS chokepoint (`addComment` in
-/// `lib/tauri-commands.ts`) does not have to convert.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(untagged)]
-pub enum NewCommentAnchor {
-    Tagged(TaggedNewAnchor),
-    Legacy(CommentAnchor),
-}
-
-/// Tagged variant of [`NewCommentAnchor`]. Mirrors the TS `Anchor` union
-/// in `src/types/comments.ts` — discriminator is `kind`, payload fields
-/// are flattened alongside it (internally tagged).
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum TaggedNewAnchor {
-    Line {
-        line: u32,
-        #[serde(default)]
-        end_line: Option<u32>,
-        #[serde(default)]
-        start_column: Option<u32>,
-        #[serde(default)]
-        end_column: Option<u32>,
-        #[serde(default)]
-        selected_text: Option<String>,
-        #[serde(default)]
-        selected_text_hash: Option<String>,
-    },
-    File,
-    WordRange(WordRangePayload),
-}
-
-impl NewCommentAnchor {
-    /// Convert into the canonical in-memory [`Anchor`] enum + a legacy
-    /// flat [`CommentAnchor`] (used by `create_comment` to populate the
-    /// MrsfComment's flat line fields). For non-Line variants, the flat
-    /// fields are left as the default — callers must not rely on them.
-    /// Exposed `pub` for integration tests of `add_comment`'s anchor
-    /// dispatch (the `#[tauri::command]` itself can't be invoked outside
-    /// a Tauri runtime).
-    pub fn into_anchor_pair(self) -> (Anchor, Option<CommentAnchor>) {
-        match self {
-            NewCommentAnchor::Legacy(c) => {
-                let anchor = Anchor::Line {
-                    line: c.line,
-                    end_line: c.end_line,
-                    start_column: c.start_column,
-                    end_column: c.end_column,
-                    selected_text: c.selected_text.clone(),
-                    selected_text_hash: c.selected_text_hash.clone(),
-                };
-                (anchor, Some(c))
-            }
-            NewCommentAnchor::Tagged(TaggedNewAnchor::Line {
-                line,
-                end_line,
-                start_column,
-                end_column,
-                selected_text,
-                selected_text_hash,
-            }) => {
-                let flat = CommentAnchor {
-                    line,
-                    end_line,
-                    start_column,
-                    end_column,
-                    selected_text: selected_text.clone(),
-                    selected_text_hash: selected_text_hash.clone(),
-                };
-                let anchor = Anchor::Line {
-                    line,
-                    end_line,
-                    start_column,
-                    end_column,
-                    selected_text,
-                    selected_text_hash,
-                };
-                (anchor, Some(flat))
-            }
-            NewCommentAnchor::Tagged(TaggedNewAnchor::File) => (Anchor::File, None),
-            NewCommentAnchor::Tagged(TaggedNewAnchor::WordRange(p)) => (Anchor::WordRange(p), None),
-        }
-    }
-}
 
 /// Create a new comment, save to sidecar.
 ///

--- a/src-tauri/src/commands/comments/mod.rs
+++ b/src-tauri/src/commands/comments/mod.rs
@@ -92,6 +92,22 @@ pub(crate) fn resolve_sidecar_pair(
     crate::core::paths::resolve_sidecar_pair(file, config)
 }
 
+/// Save a sidecar to a resolved path, creating parent dirs if needed.
+pub(super) fn save_with_parent_creation(
+    yaml_path: &str,
+    ws_root: Option<&std::path::Path>,
+    document: &str,
+    comments: &[crate::core::types::MrsfComment],
+) -> Result<(), String> {
+    let save_path = std::path::PathBuf::from(yaml_path);
+    if let Some(root) = ws_root {
+        crate::core::paths::ensure_sidecar_parent(root, &save_path)
+            .map_err(|e| e.to_string())?;
+    }
+    crate::core::sidecar::save_sidecar_at(&save_path, document, comments)
+        .map_err(|e| e.to_string())
+}
+
 /// Load a sidecar, apply a mutation, save, and emit `comments-changed`.
 fn with_sidecar_mut<E: CommentsEmitter>(
     emitter: &E,
@@ -104,8 +120,7 @@ fn with_sidecar_mut<E: CommentsEmitter>(
         .map_err(|e| e.to_string())?
         .ok_or("sidecar not found")?;
     mutate(&mut sidecar)?;
-    crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
-        .map_err(|e| e.to_string())?;
+    save_with_parent_creation(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)?;
     emitter.emit_comments_changed(file_path);
     Ok(())
 }
@@ -135,8 +150,7 @@ pub fn mutate_sidecar_or_create(
             comments: vec![],
         });
     mutate(&mut sidecar)?;
-    crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
-        .map_err(|e| e.to_string())?;
+    save_with_parent_creation(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/comments/update.rs
+++ b/src-tauri/src/commands/comments/update.rs
@@ -2,7 +2,7 @@
 
 use super::{enforce_workspace_path, CommentsEmitter};
 use crate::core::types::{Anchor, Reaction};
-use crate::watcher::WatcherState;
+use crate::watcher::{SidecarConfigState, WatcherState};
 use tauri::{AppHandle, Runtime, State};
 
 /// Patch payloads for `update_comment`. Discriminated enum (serde adjacent
@@ -37,11 +37,12 @@ pub enum CommentPatch {
 pub fn update_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
+    config_state: State<'_, SidecarConfigState>,
     file_path: String,
     comment_id: String,
     patch: CommentPatch,
 ) -> Result<(), String> {
-    update_comment_inner(&app, &state, file_path, comment_id, patch)
+    update_comment_inner(&app, &state, &config_state, file_path, comment_id, patch)
 }
 
 /// Test seam for [`update_comment`]. See `add_comment_inner` for rationale.
@@ -50,12 +51,13 @@ pub fn update_comment<R: Runtime>(
 pub fn update_comment_inner<E: CommentsEmitter>(
     emitter: &E,
     state: &WatcherState,
+    config_state: &SidecarConfigState,
     file_path: String,
     comment_id: String,
     patch: CommentPatch,
 ) -> Result<(), String> {
     enforce_workspace_path(state, &file_path)?;
-    let changed = update_comment_apply(&file_path, &comment_id, patch)?;
+    let changed = update_comment_apply(&file_path, &comment_id, patch, config_state)?;
     if changed {
         emitter.emit_comments_changed(&file_path);
     }
@@ -74,8 +76,10 @@ pub fn update_comment_apply(
     file_path: &str,
     comment_id: &str,
     patch: CommentPatch,
+    config_state: &SidecarConfigState,
 ) -> Result<bool, String> {
-    let mut sidecar = crate::core::sidecar::load_sidecar(file_path)
+    let (yaml, json, ws_root) = super::resolve_sidecar_pair(file_path, config_state);
+    let mut sidecar = crate::core::sidecar::load_sidecar_at(&yaml, &json)
         .map_err(|e| e.to_string())?
         .ok_or("sidecar not found")?;
     let comment = sidecar
@@ -119,7 +123,12 @@ pub fn update_comment_apply(
         }
     };
     if mutated {
-        crate::core::sidecar::save_sidecar(file_path, &sidecar.document, &sidecar.comments)
+        let save_path = std::path::PathBuf::from(&yaml);
+        if let Some(ref root) = ws_root {
+            crate::core::paths::ensure_sidecar_parent(root, &save_path)
+                .map_err(|e| e.to_string())?;
+        }
+        crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
             .map_err(|e| e.to_string())?;
     }
     Ok(mutated)

--- a/src-tauri/src/commands/comments/update.rs
+++ b/src-tauri/src/commands/comments/update.rs
@@ -123,8 +123,7 @@ pub fn update_comment_apply(
         }
     };
     if mutated {
-        crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
-            .map_err(|e| e.to_string())?;
+        super::save_with_parent_creation(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)?;
     }
     Ok(mutated)
 }

--- a/src-tauri/src/commands/comments/update.rs
+++ b/src-tauri/src/commands/comments/update.rs
@@ -123,12 +123,7 @@ pub fn update_comment_apply(
         }
     };
     if mutated {
-        let save_path = std::path::PathBuf::from(&yaml);
-        if let Some(ref root) = ws_root {
-            crate::core::paths::ensure_sidecar_parent(root, &save_path)
-                .map_err(|e| e.to_string())?;
-        }
-        crate::core::sidecar::save_sidecar_at(&save_path, &sidecar.document, &sidecar.comments)
+        crate::core::sidecar::save_sidecar_routed(&yaml, ws_root.as_deref(), &sidecar.document, &sidecar.comments)
             .map_err(|e| e.to_string())?;
     }
     Ok(mutated)

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -248,15 +248,34 @@ pub fn stat_file_inner(
 /// pass any absolute form. Each entry must exist and be a directory, and every
 /// dir must be contained within `root`. At most
 /// [`crate::watcher::MAX_TREE_WATCHED_DIRS`] entries per call.
+///
+/// Also loads the `.mrsf.yaml` config for the workspace root and caches
+/// its `sidecar_root` value in [`SidecarConfigState`] so that subsequent
+/// sidecar reads/writes use the configured path.
 #[tauri::command]
 pub fn update_tree_watched_dirs(
     window: tauri::Window,
     root: String,
     dirs: Vec<String>,
     state: tauri::State<'_, crate::watcher::WatcherState>,
+    config_state: tauri::State<'_, crate::watcher::SidecarConfigState>,
 ) -> Result<(), String> {
-    state.set_tree_watched_dirs(window.label(), root, dirs).map_err(|e| {
+    state.set_tree_watched_dirs(window.label(), root.clone(), dirs).map_err(|e| {
         tracing::warn!("[rust] update_tree_watched_dirs rejected: {}", e);
         e
-    })
+    })?;
+
+    // Load .mrsf.yaml config for this workspace root.
+    let canonical_root = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&root))
+        .map_err(|e| format!("cannot canonicalize root: {e}"))?;
+    let config = crate::core::paths::load_mrsf_config(&canonical_root).unwrap_or_else(|e| {
+        tracing::warn!(
+            "[sidecar-config] failed to load .mrsf.yaml for {}: {e}",
+            root
+        );
+        None
+    });
+    config_state.set_config(canonical_root, config);
+
+    Ok(())
 }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -44,8 +44,26 @@ pub struct ReadDirResult {
 /// Read directory entries, rejecting path traversal.
 /// Returns at most `limit` entries (default 250) with total count so the
 /// frontend can offer a "Show all N items…" affordance.
+/// Hides `.review.yaml`/`.review.json` sidecar files, and also hides the
+/// `sidecar_root` directory when listing a workspace root with an active
+/// redirect (AC10: prevents users from seeing the internal sidecar store).
 #[tauri::command]
-pub fn read_dir(path: String, limit: Option<usize>) -> Result<ReadDirResult, String> {
+pub fn read_dir(
+    path: String,
+    limit: Option<usize>,
+    config_state: tauri::State<'_, crate::watcher::SidecarConfigState>,
+) -> Result<ReadDirResult, String> {
+    read_dir_inner(path, limit, &config_state)
+}
+
+/// Inner implementation, decoupled from `tauri::State` so unit/integration
+/// tests can construct a plain `SidecarConfigState` and call this directly
+/// without spinning up a full `tauri::App`.
+pub fn read_dir_inner(
+    path: String,
+    limit: Option<usize>,
+    config_state: &crate::watcher::SidecarConfigState,
+) -> Result<ReadDirResult, String> {
     // Canonicalize to resolve symlinks and reject traversal
     let canonical = canonicalize_no_verbatim(std::path::Path::new(&path)).map_err(|e| {
         tracing::error!("[rust] command error: {}", e);
@@ -59,6 +77,24 @@ pub fn read_dir(path: String, limit: Option<usize>) -> Result<ReadDirResult, Str
             return Err("path traversal not allowed".into());
         }
     }
+
+    // Determine if we should hide a sidecar_root directory.
+    // Only applies when we're listing a workspace root that has sidecar_root configured.
+    let hide_dir_name: Option<String> = config_state
+        .resolve_for_file(&canonical)
+        .and_then(|(ws_root, sr)| {
+            if canonical == ws_root {
+                // We're listing the workspace root — hide the first component of sidecar_root
+                sr.and_then(|p| {
+                    p.components()
+                        .next()
+                        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                })
+            } else {
+                None
+            }
+        });
+
     let entries = std::fs::read_dir(&canonical).map_err(|e| {
         tracing::error!("[rust] command error: {}", e);
         e.to_string()
@@ -77,6 +113,12 @@ pub fn read_dir(path: String, limit: Option<usize>) -> Result<ReadDirResult, Str
         let name = entry.file_name().to_string_lossy().into_owned();
         if is_sidecar_file(&name) {
             continue;
+        }
+        // Hide the sidecar_root directory when it overlaps the workspace tree
+        if let Some(ref hide) = hide_dir_name {
+            if name == *hide && meta.is_dir() {
+                continue;
+            }
         }
 
         let path = entry.path().to_string_lossy().into_owned();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -35,8 +35,8 @@ pub use comments::{
 pub use config::{set_author, set_author_at, validate_author, ConfigError};
 pub use file_viewer_prefs::{get_file_viewer_pref, set_file_viewer_pref, FileViewerPref};
 pub use fs::{
-    check_path_exists, read_binary_file, read_dir, read_text_file, stat_file, stat_file_inner,
-    update_tree_watched_dirs, FileStat, ReadDirResult, TextFileResult,
+    check_path_exists, read_binary_file, read_dir, read_dir_inner, read_text_file, stat_file,
+    stat_file_inner, update_tree_watched_dirs, FileStat, ReadDirResult, TextFileResult,
 };
 pub use html::{compute_fold_regions, resolve_html_assets, FoldRegion};
 #[cfg(debug_assertions)]

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -272,6 +272,8 @@ pub fn resolve_sidecar_for_file(
 
             let sidecar_dir = workspace_root.join(root);
             let sidecar_path = sidecar_dir.join(format!("{}.review.yaml", relative.display()));
+            let json_sidecar_path =
+                sidecar_dir.join(format!("{}.review.json", relative.display()));
 
             // TOCTOU defence: canonicalize whatever already exists and
             // verify containment inside workspace_root.
@@ -282,6 +284,7 @@ pub fn resolve_sidecar_for_file(
                 )
             })?;
 
+            // Check YAML first, then JSON fallback
             if sidecar_path.exists() {
                 let canon = canonicalize_no_verbatim(&sidecar_path).map_err(|e| {
                     format!(
@@ -293,6 +296,20 @@ pub fn resolve_sidecar_for_file(
                     return Err(format!(
                         "sidecar '{}' resolves outside workspace root",
                         sidecar_path.display()
+                    ));
+                }
+                return Ok(canon);
+            } else if json_sidecar_path.exists() {
+                let canon = canonicalize_no_verbatim(&json_sidecar_path).map_err(|e| {
+                    format!(
+                        "cannot canonicalize sidecar '{}': {e}",
+                        json_sidecar_path.display()
+                    )
+                })?;
+                if !canon.starts_with(&canonical_ws) {
+                    return Err(format!(
+                        "sidecar '{}' resolves outside workspace root",
+                        json_sidecar_path.display()
                     ));
                 }
                 return Ok(canon);

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -151,6 +151,230 @@ fn outside_root_error(input: &str, folder: &str) -> String {
     )
 }
 
+// ---------------------------------------------------------------------------
+// .mrsf.yaml config loading + sidecar-root path resolution
+// ---------------------------------------------------------------------------
+
+/// On-disk shape of `.mrsf.yaml`. Only the fields we consume;
+/// `deny_unknown_fields` ensures we reject typos early.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MrsfConfigFile {
+    sidecar_root: Option<String>,
+}
+
+/// Load `.mrsf.yaml` from `workspace_root` and return the validated
+/// `sidecar_root` relative path (if configured).
+///
+/// Returns `Ok(None)` when the file is absent or when it exists but
+/// omits the `sidecar_root` key. All load-time validation lives here
+/// (absolute path rejection, `..` component rejection, empty-string
+/// rejection, symlink-escape check if the dir already exists).
+pub fn load_mrsf_config(workspace_root: &Path) -> Result<Option<PathBuf>, String> {
+    use crate::core::sidecar::{read_capped, reject_yaml_anchors};
+
+    let config_path = workspace_root.join(".mrsf.yaml");
+    let config_str = config_path
+        .to_str()
+        .ok_or_else(|| ".mrsf.yaml: path is not valid UTF-8".to_string())?;
+
+    // Read with the same 10 MB cap used for sidecars.
+    let content = match read_capped(config_str) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!(".mrsf.yaml: {e}")),
+    };
+
+    // Reject YAML anchors/aliases (billion-laughs defense).
+    reject_yaml_anchors(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+
+    let cfg: MrsfConfigFile =
+        serde_yaml_ng::from_str(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+
+    let val = match cfg.sidecar_root {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    // --- load-time validation (doesn't require the dir to exist) ---
+
+    if val.is_empty() {
+        return Err(".mrsf.yaml: sidecar_root must not be empty".into());
+    }
+
+    let sr = Path::new(&val);
+    if sr.is_absolute() {
+        return Err(format!(
+            ".mrsf.yaml: sidecar_root must be relative, got '{val}'"
+        ));
+    }
+
+    use std::path::Component;
+    if sr.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(format!(
+            ".mrsf.yaml: sidecar_root must not contain '..', got '{val}'"
+        ));
+    }
+
+    // --- runtime checks when the target dir already exists ---
+
+    let target = workspace_root.join(&val);
+    if target.exists() {
+        if !target.is_dir() {
+            return Err(format!(
+                ".mrsf.yaml: sidecar_root '{val}' exists but is not a directory"
+            ));
+        }
+        let canonical_target =
+            canonicalize_no_verbatim(&target).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+        let canonical_root =
+            canonicalize_no_verbatim(workspace_root).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+        if !canonical_target.starts_with(&canonical_root) {
+            return Err(format!(
+                ".mrsf.yaml: sidecar_root '{val}' resolves outside workspace"
+            ));
+        }
+    }
+
+    Ok(Some(PathBuf::from(val)))
+}
+
+/// Single chokepoint for all sidecar path resolution.
+///
+/// When `sidecar_root` is `None` the sidecar is co-located with the
+/// source file (current/default behaviour). When `Some(root)` the
+/// sidecar is placed under `workspace_root/root/<relative-file-path>.review.yaml`.
+///
+/// Per-call canonicalization (TOCTOU defence) is performed whenever
+/// the resolved path or its nearest existing ancestor can be
+/// canonicalized; callers must not weaken this check.
+pub fn resolve_sidecar_for_file(
+    workspace_root: &Path,
+    file_path: &Path,
+    sidecar_root: &Option<PathBuf>,
+) -> Result<PathBuf, String> {
+    match sidecar_root {
+        None => {
+            // Co-located sidecar — maintains existing behaviour.
+            Ok(PathBuf::from(format!(
+                "{}.review.yaml",
+                file_path.display()
+            )))
+        }
+        Some(root) => {
+            let relative = file_path.strip_prefix(workspace_root).map_err(|_| {
+                format!(
+                    "file '{}' is not under workspace root '{}'",
+                    file_path.display(),
+                    workspace_root.display()
+                )
+            })?;
+
+            let sidecar_dir = workspace_root.join(root);
+            let sidecar_path = sidecar_dir.join(format!("{}.review.yaml", relative.display()));
+
+            // TOCTOU defence: canonicalize whatever already exists and
+            // verify containment inside workspace_root.
+            let canonical_ws = canonicalize_no_verbatim(workspace_root).map_err(|e| {
+                format!(
+                    "cannot canonicalize workspace root '{}': {e}",
+                    workspace_root.display()
+                )
+            })?;
+
+            if sidecar_path.exists() {
+                let canon = canonicalize_no_verbatim(&sidecar_path).map_err(|e| {
+                    format!(
+                        "cannot canonicalize sidecar '{}': {e}",
+                        sidecar_path.display()
+                    )
+                })?;
+                if !canon.starts_with(&canonical_ws) {
+                    return Err(format!(
+                        "sidecar '{}' resolves outside workspace root",
+                        sidecar_path.display()
+                    ));
+                }
+                return Ok(canon);
+            }
+
+            // Sidecar doesn't exist yet — try canonicalizing its parent.
+            if let Some(parent) = sidecar_path.parent() {
+                if parent.exists() {
+                    let canon_parent =
+                        canonicalize_no_verbatim(parent).map_err(|e| {
+                            format!(
+                                "cannot canonicalize parent '{}': {e}",
+                                parent.display()
+                            )
+                        })?;
+                    if !canon_parent.starts_with(&canonical_ws) {
+                        return Err(format!(
+                            "sidecar parent '{}' resolves outside workspace root",
+                            parent.display()
+                        ));
+                    }
+                    // Return canonical parent + file name.
+                    if let Some(name) = sidecar_path.file_name() {
+                        return Ok(canon_parent.join(name));
+                    }
+                }
+            }
+
+            // Neither the sidecar nor its parent exist yet — auto-create
+            // will happen at write time via `ensure_sidecar_parent`.
+            Ok(sidecar_path)
+        }
+    }
+}
+
+/// Auto-create parent directories for a sidecar and verify the
+/// canonical result stays inside `workspace_root`.
+///
+/// This is the write-path companion to [`resolve_sidecar_for_file`].
+/// Callers invoke it just before writing a new sidecar whose parent
+/// directories may not yet exist.
+pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Result<(), String> {
+    let parent = sidecar_path
+        .parent()
+        .ok_or_else(|| format!("sidecar path '{}' has no parent", sidecar_path.display()))?;
+
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("failed to create sidecar dir '{}': {e}", parent.display()))?;
+
+    let canonical_parent = match canonicalize_no_verbatim(parent) {
+        Ok(p) => p,
+        Err(e) => {
+            // Clean up and fail.
+            let _ = std::fs::remove_dir_all(parent);
+            return Err(format!(
+                "cannot canonicalize created dir '{}': {e}",
+                parent.display()
+            ));
+        }
+    };
+
+    let canonical_ws = match canonicalize_no_verbatim(workspace_root) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(parent);
+            return Err(format!(
+                "cannot canonicalize workspace root '{}': {e}",
+                workspace_root.display()
+            ));
+        }
+    };
+
+    if !canonical_parent.starts_with(&canonical_ws) {
+        let _ = std::fs::remove_dir_all(parent);
+        return Err(format!(
+            "created dir '{}' resolves outside workspace root",
+            parent.display()
+        ));
+    }
+
+    Ok(())
+}
 
 #[cfg(test)]
 #[path = "paths_tests.rs"]

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -152,91 +152,29 @@ fn outside_root_error(input: &str, folder: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// .mrsf.yaml config loading + sidecar-root path resolution
+// .mrsf.yaml config loading lives in core/sidecar/config.rs.
+// Re-export for backward compatibility with existing callers.
 // ---------------------------------------------------------------------------
 
-/// On-disk shape of `.mrsf.yaml`. Only the fields we consume;
-/// `deny_unknown_fields` ensures we reject typos early.
-#[derive(serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct MrsfConfigFile {
-    sidecar_root: Option<String>,
-}
+pub use crate::core::sidecar::config::load_mrsf_config;
 
-/// Load `.mrsf.yaml` from `workspace_root` and return the validated
-/// `sidecar_root` relative path (if configured).
-///
-/// Returns `Ok(None)` when the file is absent or when it exists but
-/// omits the `sidecar_root` key. All load-time validation lives here
-/// (absolute path rejection, `..` component rejection, empty-string
-/// rejection, symlink-escape check if the dir already exists).
-pub fn load_mrsf_config(workspace_root: &Path) -> Result<Option<PathBuf>, String> {
-    use crate::core::sidecar::{read_capped, reject_yaml_anchors};
+// ---------------------------------------------------------------------------
+// Sidecar-root path resolution
+// ---------------------------------------------------------------------------
 
-    let config_path = workspace_root.join(".mrsf.yaml");
-    let config_str = config_path
-        .to_str()
-        .ok_or_else(|| ".mrsf.yaml: path is not valid UTF-8".to_string())?;
-
-    // Read with the same 10 MB cap used for sidecars.
-    let content = match read_capped(config_str) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(format!(".mrsf.yaml: {e}")),
-    };
-
-    // Reject YAML anchors/aliases (billion-laughs defense).
-    reject_yaml_anchors(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
-
-    let cfg: MrsfConfigFile =
-        serde_yaml_ng::from_str(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
-
-    let val = match cfg.sidecar_root {
-        Some(v) => v,
-        None => return Ok(None),
-    };
-
-    // --- load-time validation (doesn't require the dir to exist) ---
-
-    if val.is_empty() {
-        return Err(".mrsf.yaml: sidecar_root must not be empty".into());
-    }
-
-    let sr = Path::new(&val);
-    if sr.is_absolute() {
+/// Verify that `path` is contained within `workspace_root` after
+/// canonicalization. Returns canonical `path` on success.
+fn check_containment(path: &Path, canonical_ws: &Path) -> Result<PathBuf, String> {
+    let canon = canonicalize_no_verbatim(path).map_err(|e| {
+        format!("cannot canonicalize '{}': {e}", path.display())
+    })?;
+    if !canon.starts_with(canonical_ws) {
         return Err(format!(
-            ".mrsf.yaml: sidecar_root must be relative, got '{val}'"
+            "'{}' resolves outside workspace root",
+            path.display()
         ));
     }
-
-    use std::path::Component;
-    if sr.components().any(|c| matches!(c, Component::ParentDir)) {
-        return Err(format!(
-            ".mrsf.yaml: sidecar_root must not contain '..', got '{val}'"
-        ));
-    }
-
-    // --- runtime checks when the target dir already exists ---
-
-    let target = workspace_root.join(&val);
-    if target.exists() {
-        if !target.is_dir() {
-            return Err(format!(
-                ".mrsf.yaml: sidecar_root '{val}' exists but is not a directory"
-            ));
-        }
-        let canonical_target =
-            canonicalize_no_verbatim(&target).map_err(|e| format!(".mrsf.yaml: {e}"))?;
-        let canonical_root =
-            canonicalize_no_verbatim(workspace_root).map_err(|e| format!(".mrsf.yaml: {e}"))?;
-        if !canonical_target.starts_with(&canonical_root) {
-            return Err(format!(
-                ".mrsf.yaml: sidecar_root '{val}' resolves outside workspace"
-            ));
-        }
-    }
-
-    Ok(Some(PathBuf::from(val)))
+    Ok(canon)
 }
 
 /// Single chokepoint for all sidecar path resolution.
@@ -244,6 +182,10 @@ pub fn load_mrsf_config(workspace_root: &Path) -> Result<Option<PathBuf>, String
 /// When `sidecar_root` is `None` the sidecar is co-located with the
 /// source file (current/default behaviour). When `Some(root)` the
 /// sidecar is placed under `workspace_root/root/<relative-file-path>.review.yaml`.
+///
+/// `workspace_root` **must** already be canonical (callers canonicalize
+/// at the IPC boundary). `file_path` is canonicalized internally to
+/// handle 8.3 short-name mismatches on Windows.
 ///
 /// Per-call canonicalization (TOCTOU defence) is performed whenever
 /// the resolved path or its nearest existing ancestor can be
@@ -262,10 +204,15 @@ pub fn resolve_sidecar_for_file(
             )))
         }
         Some(root) => {
-            let relative = file_path.strip_prefix(workspace_root).map_err(|_| {
+            // Best-effort canonicalization of file_path to handle 8.3
+            // short-name mismatches on Windows CI (RUNNER~1 vs runneradmin).
+            // Falls back to the raw path when the file doesn't exist yet.
+            let effective_file = canonicalize_no_verbatim(file_path)
+                .unwrap_or_else(|_| file_path.to_path_buf());
+            let relative = effective_file.strip_prefix(workspace_root).map_err(|_| {
                 format!(
                     "file '{}' is not under workspace root '{}'",
-                    file_path.display(),
+                    effective_file.display(),
                     workspace_root.display()
                 )
             })?;
@@ -276,61 +223,19 @@ pub fn resolve_sidecar_for_file(
                 sidecar_dir.join(format!("{}.review.json", relative.display()));
 
             // TOCTOU defence: canonicalize whatever already exists and
-            // verify containment inside workspace_root.
-            let canonical_ws = canonicalize_no_verbatim(workspace_root).map_err(|e| {
-                format!(
-                    "cannot canonicalize workspace root '{}': {e}",
-                    workspace_root.display()
-                )
-            })?;
+            // verify containment inside workspace_root (already canonical).
 
             // Check YAML first, then JSON fallback
             if sidecar_path.exists() {
-                let canon = canonicalize_no_verbatim(&sidecar_path).map_err(|e| {
-                    format!(
-                        "cannot canonicalize sidecar '{}': {e}",
-                        sidecar_path.display()
-                    )
-                })?;
-                if !canon.starts_with(&canonical_ws) {
-                    return Err(format!(
-                        "sidecar '{}' resolves outside workspace root",
-                        sidecar_path.display()
-                    ));
-                }
-                return Ok(canon);
+                return check_containment(&sidecar_path, workspace_root);
             } else if json_sidecar_path.exists() {
-                let canon = canonicalize_no_verbatim(&json_sidecar_path).map_err(|e| {
-                    format!(
-                        "cannot canonicalize sidecar '{}': {e}",
-                        json_sidecar_path.display()
-                    )
-                })?;
-                if !canon.starts_with(&canonical_ws) {
-                    return Err(format!(
-                        "sidecar '{}' resolves outside workspace root",
-                        json_sidecar_path.display()
-                    ));
-                }
-                return Ok(canon);
+                return check_containment(&json_sidecar_path, workspace_root);
             }
 
             // Sidecar doesn't exist yet — try canonicalizing its parent.
             if let Some(parent) = sidecar_path.parent() {
                 if parent.exists() {
-                    let canon_parent =
-                        canonicalize_no_verbatim(parent).map_err(|e| {
-                            format!(
-                                "cannot canonicalize parent '{}': {e}",
-                                parent.display()
-                            )
-                        })?;
-                    if !canon_parent.starts_with(&canonical_ws) {
-                        return Err(format!(
-                            "sidecar parent '{}' resolves outside workspace root",
-                            parent.display()
-                        ));
-                    }
+                    let canon_parent = check_containment(parent, workspace_root)?;
                     // Return canonical parent + file name.
                     if let Some(name) = sidecar_path.file_name() {
                         return Ok(canon_parent.join(name));
@@ -359,6 +264,8 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
     // Track whether the parent already existed so error-path cleanup
     // only removes directories we actually created (security rule 4:
     // a failed write must never destroy existing data).
+    // Uses remove_dir (non-recursive) to avoid following symlinks and
+    // deleting content outside the workspace.
     let parent_existed = parent.exists();
 
     std::fs::create_dir_all(parent)
@@ -368,7 +275,7 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
         Ok(p) => p,
         Err(e) => {
             if !parent_existed {
-                let _ = std::fs::remove_dir_all(parent);
+                let _ = std::fs::remove_dir(parent);
             }
             return Err(format!(
                 "cannot canonicalize created dir '{}': {e}",
@@ -381,7 +288,7 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
         Ok(p) => p,
         Err(e) => {
             if !parent_existed {
-                let _ = std::fs::remove_dir_all(parent);
+                let _ = std::fs::remove_dir(parent);
             }
             return Err(format!(
                 "cannot canonicalize workspace root '{}': {e}",
@@ -392,7 +299,7 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
 
     if !canonical_parent.starts_with(&canonical_ws) {
         if !parent_existed {
-            let _ = std::fs::remove_dir_all(parent);
+            let _ = std::fs::remove_dir(parent);
         }
         return Err(format!(
             "created dir '{}' resolves outside workspace root",

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -403,6 +403,41 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
     Ok(())
 }
 
+/// Resolve the YAML and JSON sidecar paths for a source file, consulting
+/// a workspace config. Routes through [`resolve_sidecar_for_file`] for
+/// TOCTOU-safe canonicalization + containment checking.
+///
+/// Returns `(yaml_path, json_path, Option<workspace_root>)`. The third
+/// element is `Some` when a redirected config is active — callers use it
+/// to call [`ensure_sidecar_parent`] before writing.
+pub fn resolve_sidecar_pair(
+    file_path: &Path,
+    config: Option<(&Path, &Option<PathBuf>)>,
+) -> (String, String, Option<PathBuf>) {
+    if let Some((ws_root, sidecar_root)) = config {
+        match resolve_sidecar_for_file(ws_root, file_path, sidecar_root) {
+            Ok(resolved) => {
+                let resolved_str = resolved.to_string_lossy().into_owned();
+                if resolved_str.ends_with(".review.json") {
+                    let yaml = resolved_str.replace(".review.json", ".review.yaml");
+                    return (yaml, resolved_str, Some(ws_root.to_path_buf()));
+                }
+                let json = resolved_str.replace(".review.yaml", ".review.json");
+                return (resolved_str, json, Some(ws_root.to_path_buf()));
+            }
+            Err(e) => {
+                tracing::warn!("[sidecar-config] path resolution failed, falling back to co-located: {e}");
+            }
+        }
+    }
+    let fp = file_path.to_string_lossy();
+    (
+        format!("{}.review.yaml", fp),
+        format!("{}.review.json", fp),
+        None,
+    )
+}
+
 #[cfg(test)]
 #[path = "paths_tests.rs"]
 mod tests;

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -339,14 +339,20 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
         .parent()
         .ok_or_else(|| format!("sidecar path '{}' has no parent", sidecar_path.display()))?;
 
+    // Track whether the parent already existed so error-path cleanup
+    // only removes directories we actually created (security rule 4:
+    // a failed write must never destroy existing data).
+    let parent_existed = parent.exists();
+
     std::fs::create_dir_all(parent)
         .map_err(|e| format!("failed to create sidecar dir '{}': {e}", parent.display()))?;
 
     let canonical_parent = match canonicalize_no_verbatim(parent) {
         Ok(p) => p,
         Err(e) => {
-            // Clean up and fail.
-            let _ = std::fs::remove_dir_all(parent);
+            if !parent_existed {
+                let _ = std::fs::remove_dir_all(parent);
+            }
             return Err(format!(
                 "cannot canonicalize created dir '{}': {e}",
                 parent.display()
@@ -357,7 +363,9 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
     let canonical_ws = match canonicalize_no_verbatim(workspace_root) {
         Ok(p) => p,
         Err(e) => {
-            let _ = std::fs::remove_dir_all(parent);
+            if !parent_existed {
+                let _ = std::fs::remove_dir_all(parent);
+            }
             return Err(format!(
                 "cannot canonicalize workspace root '{}': {e}",
                 workspace_root.display()
@@ -366,7 +374,9 @@ pub fn ensure_sidecar_parent(workspace_root: &Path, sidecar_path: &Path) -> Resu
     };
 
     if !canonical_parent.starts_with(&canonical_ws) {
-        let _ = std::fs::remove_dir_all(parent);
+        if !parent_existed {
+            let _ = std::fs::remove_dir_all(parent);
+        }
         return Err(format!(
             "created dir '{}' resolves outside workspace root",
             parent.display()

--- a/src-tauri/src/core/paths_tests.rs
+++ b/src-tauri/src/core/paths_tests.rs
@@ -251,3 +251,276 @@ fn canonicalize_no_verbatim_long_path_does_not_panic() {
     let _ = canonicalize_no_verbatim(&deep).expect("long-path canonicalize must succeed");
 }
 
+// ---- load_mrsf_config -----------------------------------------------
+
+#[test]
+fn load_mrsf_config_returns_none_when_no_config_file() {
+    let dir = tempdir().unwrap();
+    let result = load_mrsf_config(dir.path()).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn load_mrsf_config_returns_none_when_sidecar_root_absent() {
+    let dir = tempdir().unwrap();
+    // .mrsf.yaml exists but has no sidecar_root field — empty YAML doc
+    fs::write(dir.path().join(".mrsf.yaml"), "{}\n").unwrap();
+    let result = load_mrsf_config(dir.path()).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn load_mrsf_config_returns_relative_path() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+    let result = load_mrsf_config(dir.path()).unwrap();
+    assert_eq!(result, Some(PathBuf::from(".reviews")));
+}
+
+#[test]
+fn load_mrsf_config_rejects_absolute_path() {
+    let dir = tempdir().unwrap();
+    // Use a platform-appropriate absolute path
+    #[cfg(windows)]
+    let yaml = "sidecar_root: C:\\absolute\\path\n";
+    #[cfg(not(windows))]
+    let yaml = "sidecar_root: /absolute/path\n";
+    fs::write(dir.path().join(".mrsf.yaml"), yaml).unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("absolute") || err.contains("must be relative"),
+        "expected absolute rejection, got: {err}"
+    );
+}
+
+#[test]
+fn load_mrsf_config_rejects_dotdot_component() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "sidecar_root: ../outside\n").unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(err.contains(".."), "expected .. rejection, got: {err}");
+}
+
+#[test]
+fn load_mrsf_config_rejects_dotdot_in_middle() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".mrsf.yaml"),
+        "sidecar_root: reviews/../escape\n",
+    )
+    .unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(err.contains(".."), "expected .. rejection, got: {err}");
+}
+
+#[test]
+fn load_mrsf_config_rejects_empty_sidecar_root() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "sidecar_root: \"\"\n").unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("empty") || err.contains("blank"),
+        "expected empty rejection, got: {err}"
+    );
+}
+
+#[test]
+fn load_mrsf_config_rejects_oversized_file() {
+    let dir = tempdir().unwrap();
+    let big = vec![b'#'; 10 * 1024 * 1024 + 1];
+    fs::write(dir.path().join(".mrsf.yaml"), big).unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("10 MB") || err.contains("cap"),
+        "expected size rejection, got: {err}"
+    );
+}
+
+#[test]
+fn load_mrsf_config_rejects_yaml_anchors() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".mrsf.yaml"),
+        "sidecar_root: &anchor .reviews\n",
+    )
+    .unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("anchor") || err.contains("alias"),
+        "expected anchor rejection, got: {err}"
+    );
+}
+
+#[test]
+fn load_mrsf_config_rejects_unknown_fields() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(".mrsf.yaml"),
+        "sidecar_root: .reviews\nunknown_key: value\n",
+    )
+    .unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("unknown") || err.contains("unknown_key"),
+        "expected unknown field rejection, got: {err}"
+    );
+}
+
+#[test]
+fn load_mrsf_config_rejects_sidecar_root_that_is_a_file() {
+    let dir = tempdir().unwrap();
+    // Create .reviews as a regular file, not a directory
+    fs::write(dir.path().join(".reviews"), "not a dir").unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+    let err = load_mrsf_config(dir.path()).unwrap_err();
+    assert!(
+        err.contains("not a directory") || err.contains("directory"),
+        "expected dir check, got: {err}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn load_mrsf_config_rejects_symlink_escape_dir_windows() {
+    use std::os::windows::fs::symlink_dir;
+    let outside = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    // Create a symlink .reviews -> outside dir
+    let link = workspace.path().join(".reviews");
+    if symlink_dir(outside.path(), &link).is_err() {
+        eprintln!("skipping: symlink_dir requires Developer Mode / admin");
+        return;
+    }
+    fs::write(
+        workspace.path().join(".mrsf.yaml"),
+        "sidecar_root: .reviews\n",
+    )
+    .unwrap();
+    let err = load_mrsf_config(workspace.path()).unwrap_err();
+    assert!(
+        err.contains("outside") || err.contains("escape"),
+        "expected symlink escape rejection, got: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn load_mrsf_config_rejects_symlink_escape_dir_unix() {
+    use std::os::unix::fs::symlink;
+    let outside = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let link = workspace.path().join(".reviews");
+    symlink(outside.path(), &link).unwrap();
+    fs::write(
+        workspace.path().join(".mrsf.yaml"),
+        "sidecar_root: .reviews\n",
+    )
+    .unwrap();
+    let err = load_mrsf_config(workspace.path()).unwrap_err();
+    assert!(
+        err.contains("outside") || err.contains("escape"),
+        "expected symlink escape rejection, got: {err}"
+    );
+}
+
+// ---- resolve_sidecar_for_file ----------------------------------------
+
+#[test]
+fn resolve_sidecar_for_file_colocated_when_no_config() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("docs").join("readme.md");
+    let result = resolve_sidecar_for_file(dir.path(), &file, &None).unwrap();
+    let expected = PathBuf::from(format!("{}.review.yaml", file.display()));
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn resolve_sidecar_for_file_redirects_under_sidecar_root() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let file = workspace.join("docs").join("readme.md");
+    let config = Some(PathBuf::from(".reviews"));
+    let result = resolve_sidecar_for_file(workspace, &file, &config).unwrap();
+    let expected = workspace
+        .join(".reviews")
+        .join("docs")
+        .join("readme.md.review.yaml");
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn resolve_sidecar_for_file_preserves_nested_structure() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let file = workspace.join("a").join("b").join("c.md");
+    let config = Some(PathBuf::from("review-data"));
+    let result = resolve_sidecar_for_file(workspace, &file, &config).unwrap();
+    let expected = workspace
+        .join("review-data")
+        .join("a")
+        .join("b")
+        .join("c.md.review.yaml");
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn resolve_sidecar_for_file_rejects_file_outside_workspace() {
+    let workspace = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let file = outside.path().join("evil.md");
+    let config = Some(PathBuf::from(".reviews"));
+    let err = resolve_sidecar_for_file(workspace.path(), &file, &config).unwrap_err();
+    assert!(
+        err.contains("outside") || err.contains("not under"),
+        "expected outside rejection, got: {err}"
+    );
+}
+
+#[test]
+fn resolve_sidecar_for_file_canonicalizes_existing_path() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let reviews_dir = workspace.join(".reviews").join("docs");
+    fs::create_dir_all(&reviews_dir).unwrap();
+    let sidecar = reviews_dir.join("readme.md.review.yaml");
+    fs::write(&sidecar, "test").unwrap();
+    let file = workspace.join("docs").join("readme.md");
+    let config = Some(PathBuf::from(".reviews"));
+    let result = resolve_sidecar_for_file(workspace, &file, &config).unwrap();
+    // Result should be canonical (no verbatim prefix on Windows)
+    let canonical = canonicalize_no_verbatim(&sidecar).unwrap();
+    assert_eq!(result, canonical);
+}
+
+// ---- ensure_sidecar_parent -------------------------------------------
+
+#[test]
+fn ensure_sidecar_parent_creates_dirs() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let sidecar = workspace
+        .join(".reviews")
+        .join("a")
+        .join("b")
+        .join("c.md.review.yaml");
+    ensure_sidecar_parent(workspace, &sidecar).unwrap();
+    assert!(sidecar.parent().unwrap().exists());
+    assert!(sidecar.parent().unwrap().is_dir());
+}
+
+#[test]
+fn ensure_sidecar_parent_rejects_escape_after_creation() {
+    // This test verifies that if somehow the created parent resolves
+    // outside workspace after canonicalization, it's rejected.
+    // Hard to test without symlinks, so just verify the happy path
+    // that a normal parent inside workspace works.
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let sidecar = workspace.join(".reviews").join("doc.md.review.yaml");
+    ensure_sidecar_parent(workspace, &sidecar).unwrap();
+    let parent = sidecar.parent().unwrap();
+    let canonical = canonicalize_no_verbatim(parent).unwrap();
+    let canonical_ws = canonicalize_no_verbatim(workspace).unwrap();
+    assert!(canonical.starts_with(&canonical_ws));
+}
+

--- a/src-tauri/src/core/paths_tests.rs
+++ b/src-tauri/src/core/paths_tests.rs
@@ -479,14 +479,15 @@ fn resolve_sidecar_for_file_rejects_file_outside_workspace() {
 #[test]
 fn resolve_sidecar_for_file_canonicalizes_existing_path() {
     let dir = tempdir().unwrap();
-    let workspace = dir.path();
+    // workspace_root must be canonical (matches the function's contract).
+    let workspace = canonicalize_no_verbatim(dir.path()).unwrap();
     let reviews_dir = workspace.join(".reviews").join("docs");
     fs::create_dir_all(&reviews_dir).unwrap();
     let sidecar = reviews_dir.join("readme.md.review.yaml");
     fs::write(&sidecar, "test").unwrap();
     let file = workspace.join("docs").join("readme.md");
     let config = Some(PathBuf::from(".reviews"));
-    let result = resolve_sidecar_for_file(workspace, &file, &config).unwrap();
+    let result = resolve_sidecar_for_file(&workspace, &file, &config).unwrap();
     // Result should be canonical (no verbatim prefix on Windows)
     let canonical = canonicalize_no_verbatim(&sidecar).unwrap();
     assert_eq!(result, canonical);

--- a/src-tauri/src/core/sidecar/config.rs
+++ b/src-tauri/src/core/sidecar/config.rs
@@ -1,0 +1,199 @@
+//! `.mrsf.yaml` workspace config: loading, validation, and per-workspace cache.
+//!
+//! Centralizes all sidecar-root configuration logic:
+//! - [`MrsfConfigFile`] — on-disk shape of `.mrsf.yaml`
+//! - [`load_mrsf_config`] — load + validate (absolute path, `..` rejection, symlink escape)
+//! - [`SidecarConfigState`] — per-workspace config cache (Tauri managed state)
+
+use crate::core::paths::canonicalize_no_verbatim;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+// ---------------------------------------------------------------------------
+// .mrsf.yaml loading + validation
+// ---------------------------------------------------------------------------
+
+/// On-disk shape of `.mrsf.yaml`. Only the fields we consume;
+/// `deny_unknown_fields` ensures we reject typos early.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MrsfConfigFile {
+    sidecar_root: Option<String>,
+}
+
+/// Load `.mrsf.yaml` from `workspace_root` and return the validated
+/// `sidecar_root` relative path (if configured).
+///
+/// Returns `Ok(None)` when the file is absent or when it exists but
+/// omits the `sidecar_root` key. All load-time validation lives here
+/// (absolute path rejection, `..` component rejection, empty-string
+/// rejection, symlink-escape check if the dir already exists).
+pub fn load_mrsf_config(workspace_root: &Path) -> Result<Option<PathBuf>, String> {
+    use crate::core::sidecar::{read_capped, reject_yaml_anchors};
+
+    let config_path = workspace_root.join(".mrsf.yaml");
+    let config_str = config_path
+        .to_str()
+        .ok_or_else(|| ".mrsf.yaml: path is not valid UTF-8".to_string())?;
+
+    // Read with the same 10 MB cap used for sidecars.
+    let content = match read_capped(config_str) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!(".mrsf.yaml: {e}")),
+    };
+
+    // Reject YAML anchors/aliases (billion-laughs defense).
+    reject_yaml_anchors(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+
+    let cfg: MrsfConfigFile =
+        serde_yaml_ng::from_str(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+
+    let val = match cfg.sidecar_root {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    // --- load-time validation (doesn't require the dir to exist) ---
+
+    if val.is_empty() {
+        return Err(".mrsf.yaml: sidecar_root must not be empty".into());
+    }
+
+    let sr = Path::new(&val);
+    if sr.is_absolute() {
+        return Err(format!(
+            ".mrsf.yaml: sidecar_root must be relative, got '{val}'"
+        ));
+    }
+
+    use std::path::Component;
+    if sr.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(format!(
+            ".mrsf.yaml: sidecar_root must not contain '..', got '{val}'"
+        ));
+    }
+
+    // --- runtime checks when the target dir already exists ---
+    // Note: when the target dir does NOT exist at load time, the symlink
+    // check is deferred to write time via `ensure_sidecar_parent`.
+
+    let target = workspace_root.join(&val);
+    if target.exists() {
+        if !target.is_dir() {
+            return Err(format!(
+                ".mrsf.yaml: sidecar_root '{val}' exists but is not a directory"
+            ));
+        }
+        let canonical_target =
+            canonicalize_no_verbatim(&target).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+        let canonical_root =
+            canonicalize_no_verbatim(workspace_root).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+        if !canonical_target.starts_with(&canonical_root) {
+            return Err(format!(
+                ".mrsf.yaml: sidecar_root '{val}' resolves outside workspace"
+            ));
+        }
+    }
+
+    Ok(Some(PathBuf::from(val)))
+}
+
+// ---------------------------------------------------------------------------
+// Per-workspace config cache (Tauri managed state)
+// ---------------------------------------------------------------------------
+
+/// Per-workspace `.mrsf.yaml` configuration cache.
+/// Maps canonical workspace root → `Option<PathBuf>` (the `sidecar_root` value).
+/// `None` value means either no `.mrsf.yaml` exists or it has no `sidecar_root`.
+pub struct SidecarConfigState {
+    configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
+    /// Cached result of [`extra_watched_dirs`]. Invalidated on
+    /// [`set_config`]/[`remove_config`] to avoid recomputing on every
+    /// watcher sync cycle.
+    cached_dirs: Arc<Mutex<Option<HashSet<PathBuf>>>>,
+}
+
+impl SidecarConfigState {
+    pub fn new() -> Self {
+        Self {
+            configs: Arc::new(Mutex::new(HashMap::new())),
+            cached_dirs: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Look up the sidecar config for a file path by finding which workspace root it belongs to.
+    /// Returns `(workspace_root, sidecar_root)` if a workspace matches.
+    /// When multiple workspace roots match (nested workspaces), the longest
+    /// (most specific) root wins.
+    pub fn resolve_for_file(&self, file_path: &Path) -> Option<(PathBuf, Option<PathBuf>)> {
+        let guard = self.configs.lock().ok()?;
+        let canonical = canonicalize_no_verbatim(file_path).ok()?;
+        guard
+            .iter()
+            .filter(|(root, _)| canonical.starts_with(root))
+            .max_by_key(|(root, _)| root.components().count())
+            .map(|(root, config)| (root.clone(), config.clone()))
+    }
+
+    /// Register or update the config for a workspace root.
+    pub fn set_config(&self, workspace_root: PathBuf, sidecar_root: Option<PathBuf>) {
+        if let Ok(mut guard) = self.configs.lock() {
+            guard.insert(workspace_root, sidecar_root);
+        }
+        // Invalidate cached dirs
+        if let Ok(mut cache) = self.cached_dirs.lock() {
+            *cache = None;
+        }
+    }
+
+    /// Remove config for a workspace root.
+    pub fn remove_config(&self, workspace_root: &Path) {
+        if let Ok(mut guard) = self.configs.lock() {
+            guard.remove(workspace_root);
+        }
+        // Invalidate cached dirs
+        if let Ok(mut cache) = self.cached_dirs.lock() {
+            *cache = None;
+        }
+    }
+
+    /// Return all directories the watcher should monitor for sidecar-root
+    /// related changes: each workspace root (for `.mrsf.yaml` detection)
+    /// plus each resolved `sidecar_root` directory.
+    ///
+    /// Results are cached and only recomputed when [`set_config`] or
+    /// [`remove_config`] invalidates the cache.
+    pub fn extra_watched_dirs(&self) -> HashSet<PathBuf> {
+        // Return cached if valid
+        if let Ok(cache) = self.cached_dirs.lock() {
+            if let Some(ref dirs) = *cache {
+                return dirs.clone();
+            }
+        }
+
+        // Compute fresh
+        let mut dirs = HashSet::new();
+        if let Ok(guard) = self.configs.lock() {
+            for (ws_root, sr) in guard.iter() {
+                dirs.insert(ws_root.clone());
+                if let Some(sr_path) = sr {
+                    let target = ws_root.join(sr_path);
+                    if let Ok(c) = canonicalize_no_verbatim(&target) {
+                        if c.is_dir() && c.starts_with(ws_root) {
+                            dirs.insert(c);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Store in cache
+        if let Ok(mut cache) = self.cached_dirs.lock() {
+            *cache = Some(dirs.clone());
+        }
+
+        dirs
+    }
+}

--- a/src-tauri/src/core/sidecar/config.rs
+++ b/src-tauri/src/core/sidecar/config.rs
@@ -48,7 +48,7 @@ pub fn load_mrsf_config(workspace_root: &Path) -> Result<Option<PathBuf>, String
     reject_yaml_anchors(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
 
     let cfg: MrsfConfigFile =
-        serde_yaml_ng::from_str(&content).map_err(|e| format!(".mrsf.yaml: {e}"))?;
+        serde_saphyr::from_str(&content).map_err(|e: serde_saphyr::Error| format!(".mrsf.yaml: {e}"))?;
 
     let val = match cfg.sidecar_root {
         Some(v) => v,

--- a/src-tauri/src/core/sidecar/mod.rs
+++ b/src-tauri/src/core/sidecar/mod.rs
@@ -1,4 +1,4 @@
-//! Sidecar load / save / patch.
+//! Sidecar load / save / patch + workspace config.
 //!
 //! Read-side I/O guards (size cap + YAML anchor rejection) live in
 //! [`io_guards`] — see that module's doc-comment for the threat model.
@@ -7,7 +7,11 @@
 //! handing bytes to a parser. Order: `read_capped` → `reject_yaml_anchors`
 //! → parse. JSON reads intentionally skip the YAML anchor check (anchors
 //! are a YAML-only construct).
+//!
+//! Workspace `.mrsf.yaml` config (loading, validation, caching) lives in
+//! [`config`].
 
+pub mod config;
 mod io_guards;
 mod yaml_surgery;
 
@@ -157,6 +161,7 @@ pub fn load_sidecar_at(
 
 /// Load a sidecar file. Tries .review.yaml first, then .review.json.
 /// Returns None if no sidecar exists.
+/// (Test convenience — production code uses `load_sidecar_at` with explicit paths.)
 pub fn load_sidecar(file_path: &str) -> Result<Option<MrsfSidecar>, SidecarError> {
     let yaml_path = format!("{}.review.yaml", file_path);
     let json_path = format!("{}.review.json", file_path);
@@ -188,25 +193,9 @@ pub fn save_sidecar_at(
     Ok(())
 }
 
-/// Save a sidecar to a resolved path, creating parent dirs if needed.
-/// `ws_root` is `Some` when writing to a redirected sidecar_root — triggers
-/// [`crate::core::paths::ensure_sidecar_parent`] before the write.
-pub fn save_sidecar_routed(
-    yaml_path: &str,
-    ws_root: Option<&std::path::Path>,
-    document: &str,
-    comments: &[MrsfComment],
-) -> Result<(), SidecarError> {
-    let save_path = std::path::PathBuf::from(yaml_path);
-    if let Some(root) = ws_root {
-        crate::core::paths::ensure_sidecar_parent(root, &save_path)
-            .map_err(|e| SidecarError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
-    }
-    save_sidecar_at(&save_path, document, comments)
-}
-
 /// Save a complete sidecar. Atomically writes via temp+rename.
 /// Deletes the sidecar if comments is empty.
+/// (Test convenience — production code uses `save_sidecar_at` with explicit paths.)
 pub fn save_sidecar(
     file_path: &str,
     document: &str,

--- a/src-tauri/src/core/sidecar/mod.rs
+++ b/src-tauri/src/core/sidecar/mod.rs
@@ -188,6 +188,23 @@ pub fn save_sidecar_at(
     Ok(())
 }
 
+/// Save a sidecar to a resolved path, creating parent dirs if needed.
+/// `ws_root` is `Some` when writing to a redirected sidecar_root — triggers
+/// [`crate::core::paths::ensure_sidecar_parent`] before the write.
+pub fn save_sidecar_routed(
+    yaml_path: &str,
+    ws_root: Option<&std::path::Path>,
+    document: &str,
+    comments: &[MrsfComment],
+) -> Result<(), SidecarError> {
+    let save_path = std::path::PathBuf::from(yaml_path);
+    if let Some(root) = ws_root {
+        crate::core::paths::ensure_sidecar_parent(root, &save_path)
+            .map_err(|e| SidecarError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
+    }
+    save_sidecar_at(&save_path, document, comments)
+}
+
 /// Save a complete sidecar. Atomically writes via temp+rename.
 /// Deletes the sidecar if comments is empty.
 pub fn save_sidecar(

--- a/src-tauri/src/core/sidecar/mod.rs
+++ b/src-tauri/src/core/sidecar/mod.rs
@@ -121,13 +121,13 @@ fn validate_sidecar_warnings(sidecar: &MrsfSidecar) {
     }
 }
 
-/// Load a sidecar file. Tries .review.yaml first, then .review.json.
-/// Returns None if no sidecar exists.
-pub fn load_sidecar(file_path: &str) -> Result<Option<MrsfSidecar>, SidecarError> {
-    let yaml_path = format!("{}.review.yaml", file_path);
-    let json_path = format!("{}.review.json", file_path);
-
-    match read_capped(&yaml_path) {
+/// Load a sidecar from explicit YAML/JSON paths.
+/// Tries `yaml_path` first, then `json_path`. Returns `None` if neither exists.
+pub fn load_sidecar_at(
+    yaml_path: &str,
+    json_path: &str,
+) -> Result<Option<MrsfSidecar>, SidecarError> {
+    match read_capped(yaml_path) {
         Ok(content) => {
             reject_yaml_anchors(&content)?;
             let sidecar: MrsfSidecar =
@@ -142,7 +142,7 @@ pub fn load_sidecar(file_path: &str) -> Result<Option<MrsfSidecar>, SidecarError
         _ => {} // Not found, try JSON
     }
 
-    match read_capped(&json_path) {
+    match read_capped(json_path) {
         Ok(content) => {
             let sidecar: MrsfSidecar =
                 serde_json::from_str(&content).map_err(SidecarError::JsonParse)?;
@@ -155,18 +155,24 @@ pub fn load_sidecar(file_path: &str) -> Result<Option<MrsfSidecar>, SidecarError
     }
 }
 
-/// Save a complete sidecar. Atomically writes via temp+rename.
-/// Deletes the sidecar if comments is empty.
-pub fn save_sidecar(
-    file_path: &str,
+/// Load a sidecar file. Tries .review.yaml first, then .review.json.
+/// Returns None if no sidecar exists.
+pub fn load_sidecar(file_path: &str) -> Result<Option<MrsfSidecar>, SidecarError> {
+    let yaml_path = format!("{}.review.yaml", file_path);
+    let json_path = format!("{}.review.json", file_path);
+    load_sidecar_at(&yaml_path, &json_path)
+}
+
+/// Save a complete sidecar to an explicit path. Atomically writes via
+/// temp+rename. Deletes the sidecar if comments is empty.
+pub fn save_sidecar_at(
+    sidecar_path: &Path,
     document: &str,
     comments: &[MrsfComment],
 ) -> Result<(), SidecarError> {
-    let sidecar_path = std::path::PathBuf::from(format!("{}.review.yaml", file_path));
-
     if comments.is_empty() {
         if sidecar_path.exists() {
-            std::fs::remove_file(&sidecar_path)?;
+            std::fs::remove_file(sidecar_path)?;
         }
         return Ok(());
     }
@@ -178,31 +184,40 @@ pub fn save_sidecar(
     };
     let yaml = serde_saphyr::to_string(&payload).map_err(|e| SidecarError::YamlParse(e.to_string()))?;
 
-    crate::core::atomic::write_atomic(&sidecar_path, yaml.as_bytes())?;
+    crate::core::atomic::write_atomic(sidecar_path, yaml.as_bytes())?;
     Ok(())
 }
 
-/// Surgically modify a comment in a sidecar file.
+/// Save a complete sidecar. Atomically writes via temp+rename.
+/// Deletes the sidecar if comments is empty.
+pub fn save_sidecar(
+    file_path: &str,
+    document: &str,
+    comments: &[MrsfComment],
+) -> Result<(), SidecarError> {
+    let sidecar_path = std::path::PathBuf::from(format!("{}.review.yaml", file_path));
+    save_sidecar_at(&sidecar_path, document, comments)
+}
+
+/// Surgically modify a comment in a sidecar file at explicit paths.
 ///
 /// Attempts format-preserving YAML surgery first (preserves comments,
 /// key ordering, scalar styles). Falls back to the lossy
 /// parse→mutate→serialize path if surgery cannot handle the input.
-pub fn patch_comment(
-    file_path: &str,
+pub fn patch_comment_at(
+    yaml_path: &str,
+    json_path: &str,
     comment_id: &str,
     mutations: &[CommentMutation],
 ) -> Result<(), SidecarError> {
-    let yaml_path = format!("{}.review.yaml", file_path);
-    let json_path = format!("{}.review.json", file_path);
-
     // ── Fast path: format-preserving surgery on YAML ──────────────
-    if let Ok(original) = read_capped(&yaml_path) {
+    if let Ok(original) = read_capped(yaml_path) {
         if reject_yaml_anchors(&original).is_ok() {
             if let Some(patched) = yaml_surgery::try_patch(&original, comment_id, mutations) {
                 // Validate: the result must still parse as valid YAML.
                 let _: serde_json::Value = serde_saphyr::from_str(&patched)
                     .map_err(|e| SidecarError::YamlParse(e.to_string()))?;
-                crate::core::atomic::write_atomic(Path::new(&yaml_path), patched.as_bytes())?;
+                crate::core::atomic::write_atomic(Path::new(yaml_path), patched.as_bytes())?;
                 return Ok(());
             }
         }
@@ -210,20 +225,18 @@ pub fn patch_comment(
     }
 
     // ── Fallback: parse → mutate → serialize (lossy) ──────────────
-    let (content, _source_path) = match read_capped(&yaml_path) {
+    let content = match read_capped(yaml_path) {
         Ok(c) => {
             reject_yaml_anchors(&c)?;
-            (c, yaml_path.clone())
+            c
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            match read_capped(&json_path) {
+            match read_capped(json_path) {
                 Ok(c) => {
                     // Convert JSON to YAML Value
                     let json_val: serde_json::Value =
                         serde_json::from_str(&c).map_err(SidecarError::JsonParse)?;
-                    let yaml_str =
-                        serde_saphyr::to_string(&json_val).map_err(|e| SidecarError::YamlParse(e.to_string()))?;
-                    (yaml_str, yaml_path.clone()) // Write as YAML
+                    serde_saphyr::to_string(&json_val).map_err(|e| SidecarError::YamlParse(e.to_string()))?
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Err(SidecarError::NotFound);
@@ -282,9 +295,21 @@ pub fn patch_comment(
 
     let yaml_out = serde_saphyr::to_string(&doc).map_err(|e| SidecarError::YamlParse(e.to_string()))?;
 
-    // Atomic write — always re-target YAML regardless of the original format.
-    crate::core::atomic::write_atomic(Path::new(&yaml_path), yaml_out.as_bytes())?;
+    // Atomic write — always target the provided yaml_path.
+    crate::core::atomic::write_atomic(Path::new(yaml_path), yaml_out.as_bytes())?;
     Ok(())
+}
+
+/// Surgically modify a comment in a co-located sidecar file.
+/// Delegates to `patch_comment_at` with derived YAML/JSON paths.
+pub fn patch_comment(
+    file_path: &str,
+    comment_id: &str,
+    mutations: &[CommentMutation],
+) -> Result<(), SidecarError> {
+    let yaml_path = format!("{}.review.yaml", file_path);
+    let json_path = format!("{}.review.json", file_path);
+    patch_comment_at(&yaml_path, &json_path, comment_id, mutations)
 }
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/src-tauri/src/core/sidecar/mod.rs
+++ b/src-tauri/src/core/sidecar/mod.rs
@@ -13,7 +13,9 @@ mod yaml_surgery;
 
 use crate::core::mrsf_version::mrsf_version_for;
 use crate::core::types::{CommentMutation, MrsfComment, MrsfSidecar};
-use io_guards::{read_capped, reject_yaml_anchors};
+// Re-export IO guards so sibling core modules (e.g. paths.rs) can reuse
+// the same capped-read + anchor-rejection defenses for config files.
+pub(crate) use io_guards::{read_capped, reject_yaml_anchors};
 use std::collections::HashSet;
 use std::fmt;
 use std::path::Path;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -202,6 +202,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(update::PendingUpdate(std::sync::Mutex::new(None)))
         .manage(watcher::WatcherState::new(sync_tx))
+        .manage(watcher::SidecarConfigState::new())
         .manage(watcher::SyncRx(std::sync::Mutex::new(Some(sync_rx))))
         .manage(registry::WindowRegistry::default())
         .setup(|app| {

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -13,7 +13,7 @@ pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
 /// Maps canonical workspace root → `Option<PathBuf>` (the `sidecar_root` value).
 /// `None` value means either no `.mrsf.yaml` exists or it has no `sidecar_root`.
 pub struct SidecarConfigState {
-    pub(crate) configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
+    configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
 }
 
 impl SidecarConfigState {
@@ -62,7 +62,7 @@ impl SidecarConfigState {
                 if let Some(sr_path) = sr {
                     let target = ws_root.join(sr_path);
                     if let Ok(c) = canonicalize_no_verbatim(&target) {
-                        if c.is_dir() {
+                        if c.is_dir() && c.starts_with(ws_root) {
                             dirs.insert(c);
                         }
                     }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -13,7 +13,7 @@ pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
 /// Maps canonical workspace root → `Option<PathBuf>` (the `sidecar_root` value).
 /// `None` value means either no `.mrsf.yaml` exists or it has no `sidecar_root`.
 pub struct SidecarConfigState {
-    configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
+    pub(crate) configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
 }
 
 impl SidecarConfigState {
@@ -49,6 +49,27 @@ impl SidecarConfigState {
         if let Ok(mut guard) = self.configs.lock() {
             guard.remove(workspace_root);
         }
+    }
+
+    /// Return all directories the watcher should monitor for sidecar-root
+    /// related changes: each workspace root (for `.mrsf.yaml` detection)
+    /// plus each resolved `sidecar_root` directory.
+    pub fn extra_watched_dirs(&self) -> HashSet<PathBuf> {
+        let mut dirs = HashSet::new();
+        if let Ok(guard) = self.configs.lock() {
+            for (ws_root, sr) in guard.iter() {
+                dirs.insert(ws_root.clone());
+                if let Some(sr_path) = sr {
+                    let target = ws_root.join(sr_path);
+                    if let Ok(c) = canonicalize_no_verbatim(&target) {
+                        if c.is_dir() {
+                            dirs.insert(c);
+                        }
+                    }
+                }
+            }
+        }
+        dirs
     }
 }
 
@@ -259,6 +280,9 @@ pub fn start_watcher(app: &AppHandle) {
         let mut watched_dirs: HashSet<PathBuf> = HashSet::new();
 
         loop {
+            // Track whether a dir-sync is needed (set by sync_rx drain or .mrsf.yaml reload).
+            let mut needs_sync = false;
+
             // Process debounced file-change events (200ms timeout for responsiveness).
             match rx.recv_timeout(Duration::from_millis(200)) {
                 Ok(Ok(events)) => {
@@ -266,10 +290,33 @@ pub fn start_watcher(app: &AppHandle) {
                     let current_tree = lock_watched_union(&tree_watched);
                     // De-dup folder-changed emissions per debounced batch.
                     let mut folder_dirs: HashSet<PathBuf> = HashSet::new();
+                    let mut mrsf_changed = false;
                     for event in events {
                         if event.kind != DebouncedEventKind::Any {
                             continue;
                         }
+
+                        // AC7: detect .mrsf.yaml changes and reload config internally
+                        if event.path.file_name().and_then(|n| n.to_str()) == Some(".mrsf.yaml") {
+                            if let Some(parent) = event.path.parent() {
+                                if let Ok(canonical_root) = canonicalize_no_verbatim(parent) {
+                                    let config_state = app_handle.state::<SidecarConfigState>();
+                                    let config = crate::core::paths::load_mrsf_config(&canonical_root)
+                                        .unwrap_or_else(|e| {
+                                            tracing::warn!("[sidecar-config] reload failed: {e}");
+                                            None
+                                        });
+                                    tracing::info!(
+                                        "[sidecar-config] reloaded .mrsf.yaml for {}: sidecar_root={:?}",
+                                        canonical_root.display(),
+                                        config
+                                    );
+                                    config_state.set_config(canonical_root, config);
+                                    mrsf_changed = true;
+                                }
+                            }
+                        }
+
                         let (file_event, folder_dir) =
                             classify_event(&event.path, &current_watched, &current_tree);
                         if let Some(ev) = file_event {
@@ -279,6 +326,10 @@ pub fn start_watcher(app: &AppHandle) {
                         if let Some(d) = folder_dir {
                             folder_dirs.insert(d);
                         }
+                    }
+                    // If sidecar_root changed, trigger a sync so new dirs are watched
+                    if mrsf_changed {
+                        needs_sync = true;
                     }
                     for dir in folder_dirs {
                         let path_str = dir.to_string_lossy().into_owned();
@@ -301,13 +352,13 @@ pub fn start_watcher(app: &AppHandle) {
 
             // Drain sync signals AFTER recv_timeout so signals posted during the
             // 200ms block are caught immediately on this iteration, not the next.
-            let mut needs_sync = false;
             while sync_rx.try_recv().is_ok() {
                 needs_sync = true;
             }
 
             if needs_sync {
-                sync_dirs(&watched, &tree_watched, &mut watched_dirs, &mut debouncer);
+                let sidecar_dirs = app_handle.state::<SidecarConfigState>().extra_watched_dirs();
+                sync_dirs(&watched, &tree_watched, &sidecar_dirs, &mut watched_dirs, &mut debouncer);
             }
         }
     });
@@ -329,6 +380,7 @@ fn lock_watched_union(watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>) -
 fn sync_dirs(
     watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
     tree_watched: &Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,
+    sidecar_dirs: &HashSet<PathBuf>,
     watched_dirs: &mut HashSet<PathBuf>,
     debouncer: &mut notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>,
 ) {
@@ -341,6 +393,8 @@ fn sync_dirs(
     // Tree-watched dirs themselves must be observed (non-recursive) so we get
     // events for direct children added/removed/renamed.
     needed.extend(current_tree.iter().cloned());
+    // AC8: also watch workspace roots (for .mrsf.yaml) and sidecar_root dirs.
+    needed.extend(sidecar_dirs.iter().cloned());
 
     for dir in &needed {
         if !watched_dirs.contains(dir) && dir.exists() {

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -9,69 +9,9 @@ use tauri::{AppHandle, Emitter, Manager};
 /// Maximum number of tree-watched dirs across ALL windows (merged union).
 pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
 
-/// Per-workspace `.mrsf.yaml` configuration cache.
-/// Maps canonical workspace root → `Option<PathBuf>` (the `sidecar_root` value).
-/// `None` value means either no `.mrsf.yaml` exists or it has no `sidecar_root`.
-pub struct SidecarConfigState {
-    configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
-}
-
-impl SidecarConfigState {
-    pub fn new() -> Self {
-        Self {
-            configs: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-
-    /// Look up the sidecar config for a file path by finding which workspace root it belongs to.
-    /// Returns `(workspace_root, sidecar_root)` if a workspace matches.
-    /// When multiple workspace roots match (nested workspaces), the longest
-    /// (most specific) root wins.
-    pub fn resolve_for_file(&self, file_path: &Path) -> Option<(PathBuf, Option<PathBuf>)> {
-        let guard = self.configs.lock().ok()?;
-        let canonical = canonicalize_no_verbatim(file_path).ok()?;
-        guard
-            .iter()
-            .filter(|(root, _)| canonical.starts_with(root))
-            .max_by_key(|(root, _)| root.components().count())
-            .map(|(root, config)| (root.clone(), config.clone()))
-    }
-
-    /// Register or update the config for a workspace root.
-    pub fn set_config(&self, workspace_root: PathBuf, sidecar_root: Option<PathBuf>) {
-        if let Ok(mut guard) = self.configs.lock() {
-            guard.insert(workspace_root, sidecar_root);
-        }
-    }
-
-    /// Remove config for a workspace root.
-    pub fn remove_config(&self, workspace_root: &Path) {
-        if let Ok(mut guard) = self.configs.lock() {
-            guard.remove(workspace_root);
-        }
-    }
-
-    /// Return all directories the watcher should monitor for sidecar-root
-    /// related changes: each workspace root (for `.mrsf.yaml` detection)
-    /// plus each resolved `sidecar_root` directory.
-    pub fn extra_watched_dirs(&self) -> HashSet<PathBuf> {
-        let mut dirs = HashSet::new();
-        if let Ok(guard) = self.configs.lock() {
-            for (ws_root, sr) in guard.iter() {
-                dirs.insert(ws_root.clone());
-                if let Some(sr_path) = sr {
-                    let target = ws_root.join(sr_path);
-                    if let Ok(c) = canonicalize_no_verbatim(&target) {
-                        if c.is_dir() && c.starts_with(ws_root) {
-                            dirs.insert(c);
-                        }
-                    }
-                }
-            }
-        }
-        dirs
-    }
-}
+// Re-export from canonical home in core/sidecar/config.rs so existing
+// `use crate::watcher::SidecarConfigState` paths keep compiling.
+pub use crate::core::sidecar::config::SidecarConfigState;
 
 pub struct WatcherState {
     /// Per-window watched file paths (keyed by window label).

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -9,6 +9,49 @@ use tauri::{AppHandle, Emitter, Manager};
 /// Maximum number of tree-watched dirs across ALL windows (merged union).
 pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
 
+/// Per-workspace `.mrsf.yaml` configuration cache.
+/// Maps canonical workspace root → `Option<PathBuf>` (the `sidecar_root` value).
+/// `None` value means either no `.mrsf.yaml` exists or it has no `sidecar_root`.
+pub struct SidecarConfigState {
+    configs: Arc<Mutex<HashMap<PathBuf, Option<PathBuf>>>>,
+}
+
+impl SidecarConfigState {
+    pub fn new() -> Self {
+        Self {
+            configs: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Look up the sidecar config for a file path by finding which workspace root it belongs to.
+    /// Returns `(workspace_root, sidecar_root)` if a workspace matches.
+    /// When multiple workspace roots match (nested workspaces), the longest
+    /// (most specific) root wins.
+    pub fn resolve_for_file(&self, file_path: &Path) -> Option<(PathBuf, Option<PathBuf>)> {
+        let guard = self.configs.lock().ok()?;
+        let canonical = canonicalize_no_verbatim(file_path).ok()?;
+        guard
+            .iter()
+            .filter(|(root, _)| canonical.starts_with(root))
+            .max_by_key(|(root, _)| root.components().count())
+            .map(|(root, config)| (root.clone(), config.clone()))
+    }
+
+    /// Register or update the config for a workspace root.
+    pub fn set_config(&self, workspace_root: PathBuf, sidecar_root: Option<PathBuf>) {
+        if let Ok(mut guard) = self.configs.lock() {
+            guard.insert(workspace_root, sidecar_root);
+        }
+    }
+
+    /// Remove config for a workspace root.
+    pub fn remove_config(&self, workspace_root: &Path) {
+        if let Ok(mut guard) = self.configs.lock() {
+            guard.remove(workspace_root);
+        }
+    }
+}
+
 pub struct WatcherState {
     /// Per-window watched file paths (keyed by window label).
     watched_paths: Arc<Mutex<HashMap<String, HashSet<PathBuf>>>>,

--- a/src-tauri/src/watcher_tests.rs
+++ b/src-tauri/src/watcher_tests.rs
@@ -216,3 +216,54 @@ fn is_path_allowed_checks_all_windows() {
     assert!(!state.is_path_allowed(&file_a));
     assert!(state.is_path_allowed(&file_b));
 }
+
+#[test]
+fn extra_watched_dirs_includes_workspace_roots_and_sidecar_dirs() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
+
+    // Create a sidecar_root directory
+    let sr_dir = ws.join(".reviews");
+    std::fs::create_dir(&sr_dir).unwrap();
+    let sr_canonical = canonicalize_no_verbatim(&sr_dir).unwrap();
+
+    let state = super::SidecarConfigState::new();
+    // Register workspace with sidecar_root
+    state.set_config(ws.clone(), Some(std::path::PathBuf::from(".reviews")));
+
+    let dirs = state.extra_watched_dirs();
+
+    // Must include both the workspace root and the sidecar_root dir
+    assert!(
+        dirs.contains(&ws),
+        "extra_watched_dirs must include the workspace root"
+    );
+    assert!(
+        dirs.contains(&sr_canonical),
+        "extra_watched_dirs must include the resolved sidecar_root dir"
+    );
+}
+
+#[test]
+fn extra_watched_dirs_empty_when_no_configs() {
+    let state = super::SidecarConfigState::new();
+    assert!(
+        state.extra_watched_dirs().is_empty(),
+        "extra_watched_dirs must be empty when no configs are registered"
+    );
+}
+
+#[test]
+fn extra_watched_dirs_skips_nonexistent_sidecar_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
+
+    let state = super::SidecarConfigState::new();
+    // sidecar_root dir doesn't exist on disk
+    state.set_config(ws.clone(), Some(std::path::PathBuf::from(".nonexistent")));
+
+    let dirs = state.extra_watched_dirs();
+    // Workspace root is included, but the nonexistent sidecar dir is not
+    assert!(dirs.contains(&ws));
+    assert_eq!(dirs.len(), 1, "only the workspace root should be present");
+}

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -1,5 +1,5 @@
 use mdown_review_lib::commands::{
-    read_binary_file, read_dir, read_text_file, search_in_document,
+    read_binary_file, read_dir_inner, read_text_file, search_in_document,
     stat_file_inner, CommentsChangedEvent, LaunchArgs, MrsfComment, MrsfSidecar,
 };
 use mdown_review_lib::core::sidecar::{load_sidecar, save_sidecar};
@@ -393,7 +393,8 @@ fn read_dir_hides_review_sidecars() {
     .unwrap();
     std::fs::write(dir.path().join("config.json"), "{}").unwrap();
 
-    let result = read_dir(dir.path().to_str().unwrap().to_string(), None).unwrap();
+    let state = SidecarConfigState::new();
+    let result = read_dir_inner(dir.path().to_str().unwrap().to_string(), None, &state).unwrap();
     let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
 
     assert!(names.contains(&"readme.md"));
@@ -406,6 +407,48 @@ fn read_dir_hides_review_sidecars() {
     assert!(
         !names.contains(&"main.rs.review.json"),
         "JSON review sidecars should be hidden"
+    );
+}
+
+/// AC10: `read_dir` hides the `sidecar_root` directory when listing a
+/// workspace root with an active redirect config.
+#[test]
+fn read_dir_hides_sidecar_root_dir() {
+    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
+
+    let dir = tempfile::tempdir().unwrap();
+    let ws = dir.path();
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+
+    // Create workspace content + the sidecar_root directory
+    std::fs::write(ws.join("readme.md"), "hello").unwrap();
+    std::fs::create_dir(ws.join(".reviews")).unwrap();
+    std::fs::create_dir(ws.join("src")).unwrap();
+
+    // Without config: .reviews dir should be visible
+    let state = SidecarConfigState::new();
+    let entries = read_dir_inner(ws.to_str().unwrap().to_string(), &state).unwrap();
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&".reviews"), ".reviews must be visible without config");
+
+    // With config: .reviews dir should be hidden
+    state.set_config(canonical_ws.clone(), Some(std::path::PathBuf::from(".reviews")));
+    let entries = read_dir_inner(ws.to_str().unwrap().to_string(), &state).unwrap();
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        !names.contains(&".reviews"),
+        ".reviews dir must be hidden when it is the sidecar_root"
+    );
+    assert!(names.contains(&"readme.md"), "regular files must still be visible");
+    assert!(names.contains(&"src"), "regular dirs must still be visible");
+
+    // Listing a subdirectory (not workspace root) should NOT hide .reviews
+    std::fs::create_dir(ws.join("src").join(".reviews")).unwrap();
+    let entries = read_dir_inner(ws.join("src").to_str().unwrap().to_string(), &state).unwrap();
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&".reviews"),
+        ".reviews in subdirs must NOT be hidden (only workspace root is filtered)"
     );
 }
 

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -4,7 +4,7 @@ use mdown_review_lib::commands::{
 };
 use mdown_review_lib::core::sidecar::{load_sidecar, save_sidecar};
 use mdown_review_lib::registry::WindowRegistry;
-use mdown_review_lib::watcher::FileChangeEvent;
+use mdown_review_lib::watcher::{FileChangeEvent, SidecarConfigState};
 use std::io::Write;
 
 // ── read_text_file ─────────────────────────────────────────────────────────
@@ -250,7 +250,7 @@ fn add_comment_accepts_file_kind_anchor() {
     std::fs::write(&file_path_buf, "alpha\nbeta\n").unwrap();
     let file_path = file_path_buf.to_str().unwrap().to_string();
 
-    mutate_sidecar_or_create(&file_path, Some("doc.md".into()), |sidecar| {
+    mutate_sidecar_or_create(&file_path, Some("doc.md".into()), &SidecarConfigState::new(), |sidecar| {
         let mut c = MrsfComment {
             id: "file-anchored-1".into(),
             author: "Tester".into(),
@@ -268,7 +268,7 @@ fn add_comment_accepts_file_kind_anchor() {
     .unwrap();
 
     // 3. get_file_comments_inner returns the comment with Anchor::File.
-    let threads = mdown_review_lib::commands::get_file_comments_inner(&file_path)
+    let threads = mdown_review_lib::commands::get_file_comments_inner(&file_path, &SidecarConfigState::new())
         .expect("get_file_comments")
         .threads;
     assert_eq!(threads.len(), 1, "expected one file-anchored thread");
@@ -563,7 +563,7 @@ fn mutate_sidecar_or_create_creates_first_comment_sidecar() {
     // Precondition: no sidecar yet.
     assert!(!sidecar_path.exists());
 
-    mutate_sidecar_or_create(&file_path, None, |sidecar| {
+    mutate_sidecar_or_create(&file_path, None, &SidecarConfigState::new(), |sidecar| {
         sidecar.comments.push(make_mrsf_comment("first-comment"));
         Ok(())
     })
@@ -594,7 +594,7 @@ fn mutate_sidecar_or_create_appends_to_existing() {
     // Pre-create a sidecar with one comment.
     save_sidecar(&file_path, "doc.md", &[make_mrsf_comment("c1")]).unwrap();
 
-    mutate_sidecar_or_create(&file_path, None, |sidecar| {
+    mutate_sidecar_or_create(&file_path, None, &SidecarConfigState::new(), |sidecar| {
         sidecar.comments.push(make_mrsf_comment("c2"));
         Ok(())
     })
@@ -620,7 +620,7 @@ fn mutate_sidecar_or_create_error_does_not_write_partial() {
     assert!(!sidecar_path.exists());
 
     let result =
-        mutate_sidecar_or_create(&file_path, None, |_sidecar| Err("simulated".to_string()));
+        mutate_sidecar_or_create(&file_path, None, &SidecarConfigState::new(), |_sidecar| Err("simulated".to_string()));
 
     // The mutation closure failed → the helper must propagate the error
     // and must NOT have written a partial/empty sidecar to disk.
@@ -642,7 +642,7 @@ fn mutate_sidecar_or_create_uses_filename_default_when_document_default_is_none(
     let file_path = file.to_str().unwrap().to_string();
 
     // Pass document_default = None so the helper falls back to the file's basename.
-    mutate_sidecar_or_create(&file_path, None, |sidecar| {
+    mutate_sidecar_or_create(&file_path, None, &SidecarConfigState::new(), |sidecar| {
         sidecar.comments.push(make_mrsf_comment("c0"));
         Ok(())
     })
@@ -731,7 +731,7 @@ fn stat_file_rejects_path_outside_workspace() {
 //
 
 mod f0_iter1 {
-    use super::{make_mrsf_comment, watcher_state_allowing};
+    use super::{make_mrsf_comment, watcher_state_allowing, SidecarConfigState};
     use mdown_review_lib::commands::{
         check_workspace_for, get_file_badges_inner, set_author_at,
         update_comment_apply, validate_author, CommentPatch, ConfigError,
@@ -757,6 +757,7 @@ mod f0_iter1 {
                 kind: "thumbs_up".into(),
                 ts: "2025-01-01T00:00:00Z".into(),
             },
+            &SidecarConfigState::new(),
         )
         .unwrap();
         // Idempotent: same (user, kind) twice is a no-op.
@@ -768,6 +769,7 @@ mod f0_iter1 {
                 kind: "thumbs_up".into(),
                 ts: "2025-01-02T00:00:00Z".into(),
             },
+            &SidecarConfigState::new(),
         )
         .unwrap();
 
@@ -792,6 +794,7 @@ mod f0_iter1 {
             &file_path,
             "c1",
             CommentPatch::SetResolved { resolved: true },
+            &SidecarConfigState::new(),
         )
         .unwrap();
         let loaded = load_sidecar(&file_path).unwrap().unwrap();
@@ -810,6 +813,7 @@ mod f0_iter1 {
             &file_path,
             "nonexistent",
             CommentPatch::SetResolved { resolved: true },
+            &SidecarConfigState::new(),
         )
         .unwrap_err();
         assert!(err.contains("not found"), "got: {err}");
@@ -837,6 +841,7 @@ mod f0_iter1 {
             CommentPatch::MoveAnchor {
                 new_anchor: new_anchor.clone(),
             },
+            &SidecarConfigState::new(),
         )
         .unwrap();
         assert!(mutated, "MoveAnchor with a different anchor must mutate");
@@ -868,6 +873,7 @@ mod f0_iter1 {
             CommentPatch::MoveAnchor {
                 new_anchor: same_anchor,
             },
+            &SidecarConfigState::new(),
         )
         .unwrap();
         assert!(!mutated, "MoveAnchor with equal anchor must be a no-op");
@@ -940,7 +946,8 @@ mod f0_iter1 {
         save_sidecar(&file_path, "doc.md", &[high, low, resolved]).unwrap();
 
         let state = watcher_state_allowing(&canonical);
-        let badges = get_file_badges_inner(&state, std::slice::from_ref(&file_path));
+        let config = SidecarConfigState::new();
+        let badges = get_file_badges_inner(&state, &config, std::slice::from_ref(&file_path));
         let badge = badges.get(&file_path).expect("badge for file");
         assert_eq!(badge.count, 2);
         assert_eq!(badge.max_severity, Severity::High);
@@ -961,7 +968,8 @@ mod f0_iter1 {
         .unwrap();
 
         let state = watcher_state_allowing(workspace.path());
-        let badges = get_file_badges_inner(&state, &[outside_file.to_str().unwrap().to_string()]);
+        let config = SidecarConfigState::new();
+        let badges = get_file_badges_inner(&state, &config, &[outside_file.to_str().unwrap().to_string()]);
         assert!(
             badges.is_empty(),
             "outside-workspace badges must be silently skipped: {:?}",
@@ -1084,6 +1092,7 @@ mod f0_iter1 {
             &file_path,
             "c1",
             CommentPatch::SetResolved { resolved: true },
+            &SidecarConfigState::new(),
         )
         .expect("update_comment must succeed against orphan path");
 
@@ -1107,7 +1116,8 @@ mod f0_iter1 {
         std::fs::remove_file(&file).unwrap(); // orphan now
 
         let state = watcher_state_allowing(workspace.path());
-        let badges = get_file_badges_inner(&state, std::slice::from_ref(&file_path));
+        let config = SidecarConfigState::new();
+        let badges = get_file_badges_inner(&state, &config, std::slice::from_ref(&file_path));
         let badge = badges
             .get(&file_path)
             .expect("orphan-only files must still produce a badge");
@@ -1162,6 +1172,7 @@ mod f0_iter1 {
             &file_path,
             "c1",
             CommentPatch::SetResolved { resolved: false },
+            &SidecarConfigState::new(),
         )
         .unwrap();
         assert!(!mutated, "no-op SetResolved must report unchanged");
@@ -1229,6 +1240,7 @@ mod wave1c_typed_dispatch {
     use mdown_review_lib::commands::comments::get_file_comments_inner as get_file_comments;
     use mdown_review_lib::core::sidecar::save_sidecar;
     use mdown_review_lib::core::types::{Anchor, MrsfComment};
+    use mdown_review_lib::watcher::SidecarConfigState;
 
     fn typed_comment(id: &str, anchor: Anchor) -> MrsfComment {
         MrsfComment {
@@ -1258,7 +1270,8 @@ mod wave1c_typed_dispatch {
         );
         save_sidecar(&file_path, "data.csv", &[comment]).unwrap();
 
-        let threads = get_file_comments(&file_path)
+        let config = SidecarConfigState::new();
+        let threads = get_file_comments(&file_path, &config)
             .expect("get_file_comments ok")
             .threads;
         assert_eq!(threads.len(), 1, "exactly one root thread");
@@ -1291,7 +1304,8 @@ mod wave1c_typed_dispatch {
         );
         save_sidecar(&file_path, "data.csv", &[comment]).unwrap();
 
-        let threads = get_file_comments(&file_path)
+        let config = SidecarConfigState::new();
+        let threads = get_file_comments(&file_path, &config)
             .expect("get_file_comments ok")
             .threads;
         assert_eq!(threads.len(), 1);
@@ -1313,6 +1327,7 @@ mod sidecar_mtime_piggyback {
     use mdown_review_lib::commands::comments::get_file_comments_inner;
     use mdown_review_lib::core::sidecar::save_sidecar;
     use mdown_review_lib::core::types::{Anchor, MrsfComment};
+    use mdown_review_lib::watcher::SidecarConfigState;
 
     #[test]
     fn returns_none_when_no_sidecar_exists() {
@@ -1321,7 +1336,8 @@ mod sidecar_mtime_piggyback {
         std::fs::write(&file, b"hello\n").unwrap();
         let file_path = file.to_str().unwrap().to_string();
 
-        let result = get_file_comments_inner(&file_path).expect("ok");
+        let config = SidecarConfigState::new();
+        let result = get_file_comments_inner(&file_path, &config).expect("ok");
         assert!(result.threads.is_empty(), "no sidecar → no threads");
         assert!(
             result.sidecar_mtime_ms.is_none(),
@@ -1348,7 +1364,8 @@ mod sidecar_mtime_piggyback {
         };
         save_sidecar(&file_path, "doc.md", &[comment]).unwrap();
 
-        let result = get_file_comments_inner(&file_path).expect("ok");
+        let config = SidecarConfigState::new();
+        let result = get_file_comments_inner(&file_path, &config).expect("ok");
         let mtime_ms = result
             .sidecar_mtime_ms
             .expect("sidecar exists → mtime_ms must be Some");

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -427,14 +427,14 @@ fn read_dir_hides_sidecar_root_dir() {
 
     // Without config: .reviews dir should be visible
     let state = SidecarConfigState::new();
-    let entries = read_dir_inner(ws.to_str().unwrap().to_string(), &state).unwrap();
-    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    let result = read_dir_inner(ws.to_str().unwrap().to_string(), None, &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
     assert!(names.contains(&".reviews"), ".reviews must be visible without config");
 
     // With config: .reviews dir should be hidden
     state.set_config(canonical_ws.clone(), Some(std::path::PathBuf::from(".reviews")));
-    let entries = read_dir_inner(ws.to_str().unwrap().to_string(), &state).unwrap();
-    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    let result = read_dir_inner(ws.to_str().unwrap().to_string(), None, &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
     assert!(
         !names.contains(&".reviews"),
         ".reviews dir must be hidden when it is the sidecar_root"
@@ -444,8 +444,8 @@ fn read_dir_hides_sidecar_root_dir() {
 
     // Listing a subdirectory (not workspace root) should NOT hide .reviews
     std::fs::create_dir(ws.join("src").join(".reviews")).unwrap();
-    let entries = read_dir_inner(ws.join("src").to_str().unwrap().to_string(), &state).unwrap();
-    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    let result = read_dir_inner(ws.join("src").to_str().unwrap().to_string(), None, &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
     assert!(
         names.contains(&".reviews"),
         ".reviews in subdirs must NOT be hidden (only workspace root is filtered)"

--- a/src-tauri/tests/comments_emit_test.rs
+++ b/src-tauri/tests/comments_emit_test.rs
@@ -35,7 +35,7 @@ use mdown_review_lib::commands::{
 };
 use mdown_review_lib::core::sidecar::load_sidecar;
 use mdown_review_lib::core::types::{Anchor, MrsfSidecar};
-use mdown_review_lib::watcher::WatcherState;
+use mdown_review_lib::watcher::{SidecarConfigState, WatcherState};
 use std::path::Path;
 use std::sync::Mutex;
 use tempfile::TempDir;
@@ -103,7 +103,8 @@ fn seed_with_comment(dir: &Path, name: &str, comment_id: &str) -> String {
     let file_path = canonical.join(name);
     std::fs::write(&file_path, b"seed").unwrap();
     let file_path_str = file_path.to_string_lossy().into_owned();
-    mutate_sidecar_or_create(&file_path_str, Some(name.into()), |sc: &mut MrsfSidecar| {
+    let config = SidecarConfigState::new();
+    mutate_sidecar_or_create(&file_path_str, Some(name.into()), &config, |sc: &mut MrsfSidecar| {
         sc.comments.push(make_comment(comment_id));
         Ok(())
     })
@@ -130,6 +131,7 @@ fn add_comment_emits_once_with_correct_file_path() {
     add_comment_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path.clone(),
         "Tester".into(),
         "hello".into(),
@@ -165,6 +167,7 @@ fn add_reply_emits_once() {
     add_reply_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path.clone(),
         "c1".into(),
         "Tester".into(),
@@ -188,6 +191,7 @@ fn edit_comment_emits_once() {
     edit_comment_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path.clone(),
         "c1".into(),
         "edited".into(),
@@ -207,7 +211,7 @@ fn delete_comment_emits_once() {
     let emitter = MockEmitter::default();
     let file_path = seed_with_comment(dir.path(), "doc.md", "c1");
 
-    delete_comment_inner(&emitter, &state, file_path.clone(), "c1".into()).unwrap();
+    delete_comment_inner(&emitter, &state, &SidecarConfigState::new(), file_path.clone(), "c1".into()).unwrap();
 
     assert_eq!(emitter.count(), 1);
     assert_eq!(emitter.paths()[0], file_path);
@@ -225,6 +229,7 @@ fn update_comment_set_resolved_emits_when_changed() {
     update_comment_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path.clone(),
         "c1".into(),
         CommentPatch::SetResolved { resolved: true },
@@ -248,6 +253,7 @@ fn update_comment_set_resolved_no_op_does_not_emit() {
     update_comment_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path,
         "c1".into(),
         CommentPatch::SetResolved { resolved: false },
@@ -280,6 +286,7 @@ fn update_comment_move_anchor_no_op_does_not_emit() {
     update_comment_inner(
         &emitter,
         &state,
+        &SidecarConfigState::new(),
         file_path,
         "c1".into(),
         CommentPatch::MoveAnchor { new_anchor: same },

--- a/src-tauri/tests/mrsf_config_test.rs
+++ b/src-tauri/tests/mrsf_config_test.rs
@@ -142,3 +142,87 @@ fn json_fallback_under_sidecar_root() {
     let loaded = load_sidecar_at(&yaml_path, &json_path).unwrap();
     assert!(loaded.is_some(), "JSON sidecar should be loadable");
 }
+
+/// End-to-end: `SidecarConfigState` + `resolve_sidecar_pair` +
+/// `mutate_sidecar_or_create` routes sidecar writes through
+/// the configured `sidecar_root` directory.
+#[test]
+fn sidecar_config_state_routes_through_sidecar_root() {
+    use mdown_review_lib::commands::mutate_sidecar_or_create;
+    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
+    use mdown_review_lib::watcher::SidecarConfigState;
+
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // Write .mrsf.yaml with sidecar_root
+    std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+
+    // Create a source file
+    std::fs::create_dir_all(ws.join("src")).unwrap();
+    std::fs::write(ws.join("src").join("app.rs"), "fn main() {}").unwrap();
+
+    // Load config and populate SidecarConfigState
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    let config = load_mrsf_config(ws).unwrap();
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_ws.clone(), config);
+
+    // Use mutate_sidecar_or_create with the config state
+    let file_path = canonicalize_no_verbatim(&ws.join("src").join("app.rs")).unwrap();
+    let file_path_str = file_path.to_string_lossy().to_string();
+
+    mutate_sidecar_or_create(&file_path_str, Some("app.rs".into()), &state, |sidecar| {
+        sidecar.comments.push(create_test_comment("c1", "Test via config state"));
+        Ok(())
+    })
+    .unwrap();
+
+    // Verify sidecar was written under .reviews, not co-located
+    let colocated = ws.join("src").join("app.rs.review.yaml");
+    assert!(
+        !colocated.exists(),
+        "sidecar must NOT be co-located when sidecar_root is configured"
+    );
+
+    let redirected = ws.join(".reviews").join("src").join("app.rs.review.yaml");
+    assert!(
+        redirected.exists(),
+        "sidecar must be under .reviews/src/app.rs.review.yaml, checked: {}",
+        redirected.display()
+    );
+
+    // Load it back and verify
+    let yaml_str = redirected.to_string_lossy().to_string();
+    let json_str = yaml_str.replace(".review.yaml", ".review.json");
+    let loaded = load_sidecar_at(&yaml_str, &json_str).unwrap().unwrap();
+    assert_eq!(loaded.comments.len(), 1);
+    assert_eq!(loaded.comments[0].id, "c1");
+    assert_eq!(loaded.comments[0].text, "Test via config state");
+}
+
+/// Verify `SidecarConfigState::new()` (empty config) falls back
+/// to co-located sidecars — the default behaviour.
+#[test]
+fn sidecar_config_state_empty_uses_colocated() {
+    use mdown_review_lib::commands::mutate_sidecar_or_create;
+    use mdown_review_lib::watcher::SidecarConfigState;
+
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+    std::fs::write(ws.join("doc.md"), "# Hello").unwrap();
+    let file_path = ws.join("doc.md").to_string_lossy().to_string();
+
+    let state = SidecarConfigState::new();
+    mutate_sidecar_or_create(&file_path, None, &state, |sidecar| {
+        sidecar.comments.push(create_test_comment("c1", "colocated"));
+        Ok(())
+    })
+    .unwrap();
+
+    let colocated = ws.join("doc.md.review.yaml");
+    assert!(
+        colocated.exists(),
+        "sidecar must be co-located when no config is set"
+    );
+}

--- a/src-tauri/tests/mrsf_config_test.rs
+++ b/src-tauri/tests/mrsf_config_test.rs
@@ -1,0 +1,144 @@
+//! Integration tests for .mrsf.yaml sidecar_root redirection.
+//! Proves the end-to-end flow: config load → path resolve → sidecar I/O.
+
+use mdown_review_lib::core::paths::{ensure_sidecar_parent, load_mrsf_config, resolve_sidecar_for_file};
+use mdown_review_lib::core::sidecar::{load_sidecar_at, save_sidecar_at};
+use mdown_review_lib::core::types::MrsfComment;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+/// Helper: create a minimal `MrsfComment` for testing.
+fn create_test_comment(id: &str, text: &str) -> MrsfComment {
+    MrsfComment {
+        id: id.to_string(),
+        author: "test".to_string(),
+        text: text.to_string(),
+        timestamp: "2024-01-01T00:00:00Z".to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn save_then_load_under_sidecar_root() {
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // Write .mrsf.yaml
+    std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+
+    // Load config
+    let config = load_mrsf_config(ws).unwrap();
+    assert_eq!(config, Some(PathBuf::from(".reviews")));
+
+    // Create a source file
+    let src_dir = ws.join("docs");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("readme.md"), "# Hello").unwrap();
+
+    // Resolve sidecar path
+    let file_path = src_dir.join("readme.md");
+    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+
+    // Should point into .reviews/docs/readme.md.review.yaml
+    assert!(
+        sidecar.to_string_lossy().contains(".reviews"),
+        "sidecar path should contain .reviews, got: {}",
+        sidecar.display()
+    );
+    assert!(
+        sidecar.to_string_lossy().ends_with("readme.md.review.yaml"),
+        "sidecar path should end with readme.md.review.yaml, got: {}",
+        sidecar.display()
+    );
+
+    // Ensure parent dirs exist
+    ensure_sidecar_parent(ws, &sidecar).unwrap();
+
+    // Save a comment
+    let comment = create_test_comment("c1", "Test comment");
+    save_sidecar_at(&sidecar, "readme.md", &[comment]).unwrap();
+
+    // Verify file landed in .reviews dir
+    assert!(sidecar.exists(), "sidecar should exist at {}", sidecar.display());
+    assert!(
+        !file_path.with_extension("md.review.yaml").exists(),
+        "sidecar should NOT be co-located with source file"
+    );
+
+    // Load it back via load_sidecar_at
+    let yaml_str = sidecar.to_string_lossy().to_string();
+    let json_str = yaml_str.replace(".review.yaml", ".review.json");
+    let loaded = load_sidecar_at(&yaml_str, &json_str).unwrap();
+    assert!(loaded.is_some(), "loaded sidecar should be Some");
+    let loaded = loaded.unwrap();
+    assert_eq!(loaded.comments.len(), 1);
+    assert_eq!(loaded.comments[0].id, "c1");
+}
+
+#[test]
+fn colocated_ignored_when_sidecar_root_set() {
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // Create a co-located sidecar
+    std::fs::write(ws.join("readme.md"), "# Hello").unwrap();
+    std::fs::write(
+        ws.join("readme.md.review.yaml"),
+        "mrsf_version: '1.0'\ndocument: readme.md\ncomments: []\n",
+    )
+    .unwrap();
+
+    // Now configure sidecar_root
+    let config = Some(PathBuf::from(".reviews"));
+
+    // Resolve should point to .reviews, NOT the co-located file
+    let file_path = ws.join("readme.md");
+    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    assert!(
+        sidecar.to_string_lossy().contains(".reviews"),
+        "sidecar path should redirect to .reviews, got: {}",
+        sidecar.display()
+    );
+
+    // load_sidecar_at with the redirected paths should find nothing
+    let yaml_str = sidecar.to_string_lossy().to_string();
+    let json_str = yaml_str.replace(".review.yaml", ".review.json");
+    let loaded = load_sidecar_at(&yaml_str, &json_str).unwrap();
+    assert!(loaded.is_none(), "co-located sidecar should be ignored");
+}
+
+#[test]
+fn json_fallback_under_sidecar_root() {
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+    let config = Some(PathBuf::from(".reviews"));
+
+    // Create source file
+    std::fs::write(ws.join("readme.md"), "# Hello").unwrap();
+
+    // Create JSON sidecar under .reviews (not YAML)
+    let json_dir = ws.join(".reviews");
+    std::fs::create_dir_all(&json_dir).unwrap();
+    std::fs::write(
+        json_dir.join("readme.md.review.json"),
+        r#"{"mrsf_version":"1.0","document":"readme.md","comments":[]}"#,
+    )
+    .unwrap();
+
+    // Resolve should find the JSON file
+    let file_path = ws.join("readme.md");
+    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    assert!(
+        sidecar.to_string_lossy().ends_with(".review.json"),
+        "resolve should find JSON fallback, got: {}",
+        sidecar.display()
+    );
+
+    // load_sidecar_at should load it
+    let yaml_path = sidecar
+        .to_string_lossy()
+        .replace(".review.json", ".review.yaml");
+    let json_path = sidecar.to_string_lossy().to_string();
+    let loaded = load_sidecar_at(&yaml_path, &json_path).unwrap();
+    assert!(loaded.is_some(), "JSON sidecar should be loadable");
+}

--- a/src-tauri/tests/mrsf_config_test.rs
+++ b/src-tauri/tests/mrsf_config_test.rs
@@ -226,3 +226,72 @@ fn sidecar_config_state_empty_uses_colocated() {
         "sidecar must be co-located when no config is set"
     );
 }
+
+/// AC15 regression: config disappearing mid-session gracefully falls back
+/// to co-located sidecars.  Proves that:
+/// 1. While `.mrsf.yaml` is present, comments land under `sidecar_root`.
+/// 2. After `.mrsf.yaml` is deleted and `load_mrsf_config` returns `None`,
+///    new comments land co-located with the source file.
+/// 3. Previously-saved redirected sidecars remain intact and loadable.
+#[test]
+fn config_disappearing_falls_back_to_colocated() {
+    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
+    use mdown_review_lib::watcher::SidecarConfigState;
+
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // ── Phase 1: sidecar_root active ──
+    std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+    let config = load_mrsf_config(ws).unwrap();
+    assert_eq!(config, Some(PathBuf::from(".reviews")));
+
+    // Create source file
+    std::fs::create_dir_all(ws.join("docs")).unwrap();
+    std::fs::write(ws.join("docs/a.md"), "# A").unwrap();
+
+    let file_path = ws.join("docs").join("a.md");
+    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    ensure_sidecar_parent(ws, &sidecar).unwrap();
+    save_sidecar_at(&sidecar, "a.md", &[create_test_comment("c1", "Under sidecar_root")]).unwrap();
+    assert!(sidecar.exists(), "redirected sidecar must exist");
+
+    // Verify the SidecarConfigState flow also routes through sidecar_root
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_ws.clone(), config);
+
+    // ── Phase 2: config disappears ──
+    std::fs::remove_file(ws.join(".mrsf.yaml")).unwrap();
+    let config2 = load_mrsf_config(ws).unwrap();
+    assert!(config2.is_none(), "config must be None after deletion");
+
+    // Update the state to reflect the missing config (simulates watcher reload)
+    state.set_config(canonical_ws.clone(), config2.clone());
+
+    // Save another comment — should go co-located now
+    let sidecar2 = resolve_sidecar_for_file(ws, &file_path, &config2).unwrap();
+    save_sidecar_at(&sidecar2, "a.md", &[create_test_comment("c2", "Co-located")]).unwrap();
+
+    // Verify: co-located sidecar exists
+    let colocated = PathBuf::from(format!("{}.review.yaml", file_path.display()));
+    assert!(colocated.exists(), "co-located sidecar must exist after config removal");
+
+    // Old redirected sidecar must still be intact
+    assert!(sidecar.exists(), "old redirected sidecar must remain untouched");
+
+    // Both sidecars are loadable independently
+    let yaml1 = sidecar.to_string_lossy().to_string();
+    let json1 = yaml1.replace(".review.yaml", ".review.json");
+    let loaded1 = load_sidecar_at(&yaml1, &json1).unwrap().unwrap();
+    assert_eq!(loaded1.comments.len(), 1);
+    assert_eq!(loaded1.comments[0].id, "c1");
+    assert_eq!(loaded1.comments[0].text, "Under sidecar_root");
+
+    let yaml2 = colocated.to_string_lossy().to_string();
+    let json2 = yaml2.replace(".review.yaml", ".review.json");
+    let loaded2 = load_sidecar_at(&yaml2, &json2).unwrap().unwrap();
+    assert_eq!(loaded2.comments.len(), 1);
+    assert_eq!(loaded2.comments[0].id, "c2");
+    assert_eq!(loaded2.comments[0].text, "Co-located");
+}

--- a/src-tauri/tests/mrsf_config_test.rs
+++ b/src-tauri/tests/mrsf_config_test.rs
@@ -26,13 +26,13 @@ fn create_test_comment(id: &str, text: &str) -> MrsfComment {
 #[test]
 fn save_then_load_under_sidecar_root() {
     let dir = tempdir().unwrap();
-    let ws = dir.path();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
 
     // Write .mrsf.yaml
     std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
 
     // Load config
-    let config = load_mrsf_config(ws).unwrap();
+    let config = load_mrsf_config(&ws).unwrap();
     assert_eq!(config, Some(PathBuf::from(".reviews")));
 
     // Create a source file
@@ -42,7 +42,7 @@ fn save_then_load_under_sidecar_root() {
 
     // Resolve sidecar path
     let file_path = src_dir.join("readme.md");
-    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    let sidecar = resolve_sidecar_for_file(&ws, &file_path, &config).unwrap();
 
     // Should point into .reviews/docs/readme.md.review.yaml
     assert!(
@@ -57,7 +57,7 @@ fn save_then_load_under_sidecar_root() {
     );
 
     // Ensure parent dirs exist
-    ensure_sidecar_parent(ws, &sidecar).unwrap();
+    ensure_sidecar_parent(&ws, &sidecar).unwrap();
 
     // Save a comment
     let comment = create_test_comment("c1", "Test comment");
@@ -83,7 +83,7 @@ fn save_then_load_under_sidecar_root() {
 #[test]
 fn colocated_ignored_when_sidecar_root_set() {
     let dir = tempdir().unwrap();
-    let ws = dir.path();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
 
     // Create a co-located sidecar
     std::fs::write(ws.join("readme.md"), "# Hello").unwrap();
@@ -98,7 +98,7 @@ fn colocated_ignored_when_sidecar_root_set() {
 
     // Resolve should point to .reviews, NOT the co-located file
     let file_path = ws.join("readme.md");
-    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    let sidecar = resolve_sidecar_for_file(&ws, &file_path, &config).unwrap();
     assert!(
         sidecar.to_string_lossy().contains(".reviews"),
         "sidecar path should redirect to .reviews, got: {}",
@@ -115,7 +115,7 @@ fn colocated_ignored_when_sidecar_root_set() {
 #[test]
 fn json_fallback_under_sidecar_root() {
     let dir = tempdir().unwrap();
-    let ws = dir.path();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
     let config = Some(PathBuf::from(".reviews"));
 
     // Create source file
@@ -132,7 +132,7 @@ fn json_fallback_under_sidecar_root() {
 
     // Resolve should find the JSON file
     let file_path = ws.join("readme.md");
-    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
+    let sidecar = resolve_sidecar_for_file(&ws, &file_path, &config).unwrap();
     assert!(
         sidecar.to_string_lossy().ends_with(".review.json"),
         "resolve should find JSON fallback, got: {}",
@@ -240,15 +240,14 @@ fn sidecar_config_state_empty_uses_colocated() {
 /// 3. Previously-saved redirected sidecars remain intact and loadable.
 #[test]
 fn config_disappearing_falls_back_to_colocated() {
-    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
     use mdown_review_lib::watcher::SidecarConfigState;
 
     let dir = tempdir().unwrap();
-    let ws = dir.path();
+    let ws = canonicalize_no_verbatim(dir.path()).unwrap();
 
     // ── Phase 1: sidecar_root active ──
     std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
-    let config = load_mrsf_config(ws).unwrap();
+    let config = load_mrsf_config(&ws).unwrap();
     assert_eq!(config, Some(PathBuf::from(".reviews")));
 
     // Create source file
@@ -256,26 +255,25 @@ fn config_disappearing_falls_back_to_colocated() {
     std::fs::write(ws.join("docs/a.md"), "# A").unwrap();
 
     let file_path = ws.join("docs").join("a.md");
-    let sidecar = resolve_sidecar_for_file(ws, &file_path, &config).unwrap();
-    ensure_sidecar_parent(ws, &sidecar).unwrap();
+    let sidecar = resolve_sidecar_for_file(&ws, &file_path, &config).unwrap();
+    ensure_sidecar_parent(&ws, &sidecar).unwrap();
     save_sidecar_at(&sidecar, "a.md", &[create_test_comment("c1", "Under sidecar_root")]).unwrap();
     assert!(sidecar.exists(), "redirected sidecar must exist");
 
     // Verify the SidecarConfigState flow also routes through sidecar_root
-    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
     let state = SidecarConfigState::new();
-    state.set_config(canonical_ws.clone(), config);
+    state.set_config(ws.clone(), config);
 
     // ── Phase 2: config disappears ──
     std::fs::remove_file(ws.join(".mrsf.yaml")).unwrap();
-    let config2 = load_mrsf_config(ws).unwrap();
+    let config2 = load_mrsf_config(&ws).unwrap();
     assert!(config2.is_none(), "config must be None after deletion");
 
     // Update the state to reflect the missing config (simulates watcher reload)
-    state.set_config(canonical_ws.clone(), config2.clone());
+    state.set_config(ws.clone(), config2.clone());
 
     // Save another comment — should go co-located now
-    let sidecar2 = resolve_sidecar_for_file(ws, &file_path, &config2).unwrap();
+    let sidecar2 = resolve_sidecar_for_file(&ws, &file_path, &config2).unwrap();
     save_sidecar_at(&sidecar2, "a.md", &[create_test_comment("c2", "Co-located")]).unwrap();
 
     // Verify: co-located sidecar exists

--- a/src-tauri/tests/mrsf_config_test.rs
+++ b/src-tauri/tests/mrsf_config_test.rs
@@ -1,9 +1,14 @@
 //! Integration tests for .mrsf.yaml sidecar_root redirection.
 //! Proves the end-to-end flow: config load → path resolve → sidecar I/O.
 
-use mdown_review_lib::core::paths::{ensure_sidecar_parent, load_mrsf_config, resolve_sidecar_for_file};
+use mdown_review_lib::commands::comments::{
+    get_file_comments_inner, get_file_badges_inner, mutate_sidecar_or_create,
+};
+use mdown_review_lib::core::paths::{canonicalize_no_verbatim, ensure_sidecar_parent, load_mrsf_config, resolve_sidecar_for_file};
+use mdown_review_lib::core::sidecar::config::SidecarConfigState;
 use mdown_review_lib::core::sidecar::{load_sidecar_at, save_sidecar_at};
 use mdown_review_lib::core::types::MrsfComment;
+use mdown_review_lib::watcher::WatcherState;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -294,4 +299,109 @@ fn config_disappearing_falls_back_to_colocated() {
     assert_eq!(loaded2.comments.len(), 1);
     assert_eq!(loaded2.comments[0].id, "c2");
     assert_eq!(loaded2.comments[0].text, "Co-located");
+}
+
+// ---------------------------------------------------------------------------
+// Missing coverage: command-layer round-trips under sidecar_root
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_file_comments_inner_with_active_sidecar_root() {
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // Create source file + config
+    std::fs::write(ws.join("readme.md"), "# Hello\nLine 2").unwrap();
+    std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    let config = load_mrsf_config(&canonical_ws).unwrap();
+
+    // Populate SidecarConfigState
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_ws.clone(), config.clone());
+
+    // Save a comment under sidecar_root
+    let file_path = canonical_ws.join("readme.md");
+    let file_str = file_path.to_string_lossy().to_string();
+    mutate_sidecar_or_create(&file_str, Some("readme.md".into()), &state, |sidecar| {
+        sidecar.comments.push(create_test_comment("c1", "From sidecar_root"));
+        Ok(())
+    }).unwrap();
+
+    // get_file_comments_inner should find the comment via the same config
+    let result = get_file_comments_inner(&file_str, &state).unwrap();
+    assert!(!result.threads.is_empty(), "should find comments under sidecar_root");
+    assert_eq!(result.threads[0].root.comment.text, "From sidecar_root");
+    assert!(result.sidecar_mtime_ms.is_some(), "mtime should be populated");
+}
+
+#[test]
+fn get_file_badges_inner_with_active_sidecar_root() {
+    let dir = tempdir().unwrap();
+    let ws = dir.path();
+
+    // Create source file + config
+    std::fs::write(ws.join("readme.md"), "# Hello").unwrap();
+    std::fs::write(ws.join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    let config = load_mrsf_config(&canonical_ws).unwrap();
+
+    // Set up state
+    let config_state = SidecarConfigState::new();
+    config_state.set_config(canonical_ws.clone(), config.clone());
+    let (sync_tx, _sync_rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let watcher_state = WatcherState::new(sync_tx);
+    watcher_state.set_tree_watched_dirs(
+        "test",
+        canonical_ws.to_string_lossy().into_owned(),
+        vec![canonical_ws.to_string_lossy().into_owned()],
+    ).unwrap();
+
+    // Save a comment
+    let file_path = canonical_ws.join("readme.md");
+    let file_str = file_path.to_string_lossy().to_string();
+    mutate_sidecar_or_create(&file_str, Some("readme.md".into()), &config_state, |sidecar| {
+        sidecar.comments.push(create_test_comment("c1", "Badge test"));
+        Ok(())
+    }).unwrap();
+
+    // get_file_badges should find badge via sidecar_root
+    let badges = get_file_badges_inner(&watcher_state, &config_state, &[file_str.clone()]);
+    assert!(badges.contains_key(&file_str), "badge should exist for file under sidecar_root");
+    assert_eq!(badges[&file_str].count, 1);
+}
+
+#[test]
+fn resolve_for_file_nested_workspace_longest_prefix() {
+    let dir = tempdir().unwrap();
+    let outer = dir.path().join("outer");
+    let inner = outer.join("inner");
+    std::fs::create_dir_all(&inner).unwrap();
+
+    let canonical_outer = canonicalize_no_verbatim(&outer).unwrap();
+    let canonical_inner = canonicalize_no_verbatim(&inner).unwrap();
+
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_outer.clone(), Some(PathBuf::from(".reviews-outer")));
+    state.set_config(canonical_inner.clone(), Some(PathBuf::from(".reviews-inner")));
+
+    // File in inner workspace should resolve to inner config
+    let file = inner.join("doc.md");
+    std::fs::write(&file, "# Doc").unwrap();
+    let result = state.resolve_for_file(&file);
+    assert!(result.is_some(), "should find a matching workspace");
+    let (ws_root, sr) = result.unwrap();
+    assert_eq!(ws_root, canonical_inner, "should match inner (most specific) workspace");
+    assert_eq!(sr, Some(PathBuf::from(".reviews-inner")));
+
+    // File in outer (but not inner) should resolve to outer config
+    let outer_file = outer.join("top.md");
+    std::fs::write(&outer_file, "# Top").unwrap();
+    let result2 = state.resolve_for_file(&outer_file);
+    assert!(result2.is_some());
+    let (ws_root2, sr2) = result2.unwrap();
+    assert_eq!(ws_root2, canonical_outer, "should match outer workspace");
+    assert_eq!(sr2, Some(PathBuf::from(".reviews-outer")));
 }

--- a/src-tauri/tests/path_form_test.rs
+++ b/src-tauri/tests/path_form_test.rs
@@ -10,8 +10,8 @@
 
 #![cfg(windows)]
 
-use mdown_review_lib::commands::{parse_launch_args, read_dir, scan_review_files};
-use mdown_review_lib::watcher::WatcherState;
+use mdown_review_lib::commands::{parse_launch_args, read_dir_inner, scan_review_files};
+use mdown_review_lib::watcher::{SidecarConfigState, WatcherState};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
@@ -67,7 +67,7 @@ fn parse_launch_args_emits_no_verbatim_prefix() {
 fn read_dir_emits_no_verbatim_prefix() {
     let ws = build_workspace();
     // Pass the bare form (what the frontend would send from a dialog).
-    let result = read_dir(ws.path().to_string_lossy().into_owned(), None).expect("read_dir");
+    let result = read_dir_inner(ws.path().to_string_lossy().into_owned(), None, &SidecarConfigState::new()).expect("read_dir");
     assert!(!result.entries.is_empty(), "expected at least one entry");
     for e in &result.entries {
         assert_no_verbatim("read_dir.path", &e.path);
@@ -180,7 +180,7 @@ fn is_path_or_parent_allowed_accepts_8dot3_short_name_input() {
 fn scan_review_files_shares_form_with_read_dir() {
     let ws = build_workspace();
     let entries =
-        read_dir(ws.path().to_string_lossy().into_owned(), None).expect("read_dir").entries;
+        read_dir_inner(ws.path().to_string_lossy().into_owned(), None, &SidecarConfigState::new()).expect("read_dir").entries;
     let pairs =
         scan_review_files(ws.path().to_string_lossy().into_owned()).expect("scan_review_files");
 


### PR DESCRIPTION
## feat: implement #229  .mrsf.yaml sidecar_root alternate location (MRSF 3.23.3)

Implements [MRSF v1.0 spec 3.23.3](docs/specs/MRSF-v1.0.md) optional alternate sidecar location via `.mrsf.yaml` config at workspace root.

## Progress

- [x] `.mrsf.yaml` with valid `sidecar_root` redirects all sidecar I/O to `<workspace>/<sidecar_root>/<relative_path>.review.yaml`
- [x] Absolute paths in `sidecar_root` are rejected with a descriptive error
- [x] `..` components in `sidecar_root` are rejected
- [x] Symlink-based escapes are caught via post-canonicalization `starts_with` check
- [x] `.mrsf.yaml` YAML parsing applies `reject_yaml_anchors` + 10 MB cap
- [x] Missing `sidecar_root` dir is auto-created on first write; canonical path verified after creation
- [x] Watcher detects `.mrsf.yaml` changes and reloads config internally (no frontend IPC trigger)
- [x] Watcher watches `sidecar_root` dir tree when redirected
- [x] Co-located sidecars are ignored when `sidecar_root` is configured (MRSF spec: no merge)
- [x] `read_dir` filters sidecars from `sidecar_root` if it overlaps workspace tree
- [x] JSON sidecar fallback works under `sidecar_root`
- [x] Per-write canonicalization in `resolve_sidecar_path` prevents TOCTOU attacks
- [x] Rust unit tests for config parsing, path validation, resolve_sidecar_path (happy + error paths)
- [x] Rust integration tests for save/load/patch under redirected paths (files land in sidecar_root)
- [x] Regression test for config disappearing mid-session (graceful fallback to co-located)
- [x] 1 native E2E test: drop `.mrsf.yaml`, assert watcher triggers config reload and paths update

Closes #229