### PR TITLE
perf: cap readDir results at 250 entries with Show All option

### DIFF
--- a/e2e/browser/fixtures/error-tracking.ts
+++ b/e2e/browser/fixtures/error-tracking.ts
@@ -114,6 +114,12 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
                   : result.split("\n").length - (result.endsWith("\n") ? 1 : 0),
               };
             }
+            // read_dir changed shape from `DirEntry[]` to `{ entries, total, has_more }`.
+            // Tests authored before that change still return a plain array — wrap it
+            // transparently so the existing specs keep working without per-file edits.
+            if (cmd === "read_dir" && Array.isArray(result)) {
+              return { entries: result, total: result.length, has_more: false };
+            }
             // If the test mock returned null, apply safe defaults for
             // infrastructure commands that were added after the test was written.
             if (result === null) {
@@ -158,6 +164,7 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
           // Default fallback when no test-specific mock is set
           if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
           if (cmd === "scan_review_files") return [];
+          if (cmd === "read_dir") return { entries: [], total: 0, has_more: false };
           if (cmd === "update_watched_files") return undefined;
           if (cmd === "update_tree_watched_dirs") return undefined;
           if (cmd === "check_update") return null;

--- a/e2e/browser/helpers/mock-tauri.ts
+++ b/e2e/browser/helpers/mock-tauri.ts
@@ -6,7 +6,7 @@ interface MockConfig {
 
 const defaultMocks: MockConfig = {
   get_launch_args: () => ({ files: [], folders: [] }),
-  read_dir: () => [],
+  read_dir: () => ({ entries: [], total: 0, has_more: false }),
   read_text_file: () => ({ content: "", size_bytes: 0, line_count: 0 }),
   get_log_path: () => "/mock/path/mdownreview.log",
   save_review_comments: () => null,

--- a/e2e/native/02-ipc-commands.spec.ts
+++ b/e2e/native/02-ipc-commands.spec.ts
@@ -80,12 +80,12 @@ test.describe("Native IPC commands", () => {
     fs.writeFileSync(path.join(tmpDir, "other.md.review.json"), `{"mrsf_version":"1.0","document":"other.md","comments":[]}`);
 
     try {
-      const entries = await nativePage.evaluate((dirPath: string) => {
+      const result = await nativePage.evaluate((dirPath: string) => {
         // @ts-ignore
         return window.__TAURI_INTERNALS__.invoke("read_dir", { path: dirPath });
       }, tmpDir);
 
-      const names = (entries as Array<{ name: string }>).map((e) => e.name);
+      const names = ((result as { entries: Array<{ name: string }> }).entries).map((e) => e.name);
       expect(names).toContain("visible.md");
       expect(names).not.toContain("visible.md.review.yaml");
       expect(names).not.toContain("other.md.review.json");

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -31,9 +31,21 @@ pub fn check_path_exists(path: String) -> String {
     }
 }
 
+const DEFAULT_READ_DIR_LIMIT: usize = 250;
+
+/// Capped directory listing: entries + total count + overflow flag.
+#[derive(serde::Serialize, Debug)]
+pub struct ReadDirResult {
+    pub entries: Vec<DirEntry>,
+    pub total: usize,
+    pub has_more: bool,
+}
+
 /// Read directory entries, rejecting path traversal.
+/// Returns at most `limit` entries (default 250) with total count so the
+/// frontend can offer a "Show all N items…" affordance.
 #[tauri::command]
-pub fn read_dir(path: String) -> Result<Vec<DirEntry>, String> {
+pub fn read_dir(path: String, limit: Option<usize>) -> Result<ReadDirResult, String> {
     // Canonicalize to resolve symlinks and reject traversal
     let canonical = canonicalize_no_verbatim(std::path::Path::new(&path)).map_err(|e| {
         tracing::error!("[rust] command error: {}", e);
@@ -79,7 +91,11 @@ pub fn read_dir(path: String) -> Result<Vec<DirEntry>, String> {
         (false, true) => std::cmp::Ordering::Greater,
         _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
     });
-    Ok(result)
+    let total = result.len();
+    let cap = limit.unwrap_or(DEFAULT_READ_DIR_LIMIT);
+    let has_more = total > cap;
+    result.truncate(cap);
+    Ok(ReadDirResult { entries: result, total, has_more })
 }
 
 /// Result of [`read_text_file`]: file content plus cheap-to-compute metadata

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -36,7 +36,7 @@ pub use config::{set_author, set_author_at, validate_author, ConfigError};
 pub use file_viewer_prefs::{get_file_viewer_pref, set_file_viewer_pref, FileViewerPref};
 pub use fs::{
     check_path_exists, read_binary_file, read_dir, read_text_file, stat_file, stat_file_inner,
-    update_tree_watched_dirs, FileStat, TextFileResult,
+    update_tree_watched_dirs, FileStat, ReadDirResult, TextFileResult,
 };
 pub use html::{compute_fold_regions, resolve_html_assets, FoldRegion};
 #[cfg(debug_assertions)]

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -393,8 +393,8 @@ fn read_dir_hides_review_sidecars() {
     .unwrap();
     std::fs::write(dir.path().join("config.json"), "{}").unwrap();
 
-    let entries = read_dir(dir.path().to_str().unwrap().to_string()).unwrap();
-    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    let result = read_dir(dir.path().to_str().unwrap().to_string(), None).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
 
     assert!(names.contains(&"readme.md"));
     assert!(names.contains(&"main.rs"));

--- a/src-tauri/tests/path_form_test.rs
+++ b/src-tauri/tests/path_form_test.rs
@@ -67,9 +67,9 @@ fn parse_launch_args_emits_no_verbatim_prefix() {
 fn read_dir_emits_no_verbatim_prefix() {
     let ws = build_workspace();
     // Pass the bare form (what the frontend would send from a dialog).
-    let entries = read_dir(ws.path().to_string_lossy().into_owned()).expect("read_dir");
-    assert!(!entries.is_empty(), "expected at least one entry");
-    for e in &entries {
+    let result = read_dir(ws.path().to_string_lossy().into_owned(), None).expect("read_dir");
+    assert!(!result.entries.is_empty(), "expected at least one entry");
+    for e in &result.entries {
         assert_no_verbatim("read_dir.path", &e.path);
     }
 }
@@ -180,7 +180,7 @@ fn is_path_or_parent_allowed_accepts_8dot3_short_name_input() {
 fn scan_review_files_shares_form_with_read_dir() {
     let ws = build_workspace();
     let entries =
-        read_dir(ws.path().to_string_lossy().into_owned()).expect("read_dir");
+        read_dir(ws.path().to_string_lossy().into_owned(), None).expect("read_dir").entries;
     let pairs =
         scan_review_files(ws.path().to_string_lossy().into_owned()).expect("scan_review_files");
 

--- a/src/__mocks__/@tauri-apps/api/core.ts
+++ b/src/__mocks__/@tauri-apps/api/core.ts
@@ -12,6 +12,7 @@ import type {
   LaunchArgs,
   MatchedComment,
   MrsfSidecar,
+  ReadDirResult,
   SearchMatch,
   TextFileResult,
   WordSpan,
@@ -25,6 +26,7 @@ type InvokeResult =
   | string
   | string[]
   | DirEntry[]
+  | ReadDirResult
   | LaunchArgs
   | MrsfSidecar
   | CommentThread[]
@@ -157,6 +159,7 @@ async function defaultInvoke(
   }
   if (cmd === "get_file_viewer_pref") return null;
   if (cmd === "set_file_viewer_pref") return undefined;
+  if (cmd === "read_dir") return { entries: [], total: 0, has_more: false } satisfies ReadDirResult;
   return undefined;
 }
 

--- a/src/__tests__/zustand-selectors.test.tsx
+++ b/src/__tests__/zustand-selectors.test.tsx
@@ -9,7 +9,7 @@ import { resolve } from "path";
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
 vi.mock("@/lib/tauri-commands", () => ({
-  readDir: vi.fn().mockResolvedValue([]),
+  readDir: vi.fn().mockResolvedValue({ entries: [], total: 0, has_more: false }),
 }));
 
 const initialState = useStore.getState();

--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -364,9 +364,60 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
             </div>
           ))
         ) : (
-          treeList.map((n) =>
-            renderRow(n.path, n.name, { isDir: n.isDir, depth: n.depth, isGhost: n.isGhost })
-          )
+          (() => {
+            const result: React.ReactNode[] = [];
+            // Track truncated (hasMore) folders as a stack to insert
+            // "Show all N items…" after their last descendant.
+            const truncatedStack: { path: string; depth: number }[] = [];
+            for (let i = 0; i < treeList.length; i++) {
+              const n = treeList[i];
+              // Before adding this node, check if any truncated folders on the
+              // stack have ended (this node's depth <= their depth).
+              while (truncatedStack.length > 0) {
+                const top = truncatedStack[truncatedStack.length - 1];
+                if (n.depth <= top.depth) {
+                  truncatedStack.pop();
+                  result.push(
+                    <div
+                      key={`load-more-${top.path}`}
+                      className="tree-row load-more"
+                      style={{ paddingLeft: `${(top.depth + 1) * 16 + 8}px` }}
+                      onClick={() => {
+                        const total = childrenCache[top.path]?.total ?? 10000;
+                        loadChildren(top.path, total);
+                      }}
+                    >
+                      Show all {childrenCache[top.path]?.total} items…
+                    </div>
+                  );
+                } else {
+                  break;
+                }
+              }
+              result.push(renderRow(n.path, n.name, { isDir: n.isDir, depth: n.depth, isGhost: n.isGhost }));
+              if (n.isDir && expandedFolders[n.path] && childrenCache[n.path]?.hasMore) {
+                truncatedStack.push({ path: n.path, depth: n.depth });
+              }
+            }
+            // Flush remaining truncated folders at end of list
+            while (truncatedStack.length > 0) {
+              const top = truncatedStack.pop()!;
+              result.push(
+                <div
+                  key={`load-more-${top.path}`}
+                  className="tree-row load-more"
+                  style={{ paddingLeft: `${(top.depth + 1) * 16 + 8}px` }}
+                  onClick={() => {
+                    const total = childrenCache[top.path]?.total ?? 10000;
+                    loadChildren(top.path, total);
+                  }}
+                >
+                  Show all {childrenCache[top.path]?.total} items…
+                </div>
+              );
+            }
+            return result;
+          })()
         )}
       </div>
     </div>

--- a/src/components/FolderTree/__tests__/FolderTree.test.tsx
+++ b/src/components/FolderTree/__tests__/FolderTree.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { FolderTree } from "../FolderTree";
 import { useStore } from "@/store";
-import type { DirEntry } from "@/lib/tauri-commands";
+import type { DirEntry, ReadDirResult } from "@/lib/tauri-commands";
 
 // Auto-resolved mocks
 vi.mock("@tauri-apps/api/core");
@@ -23,6 +23,11 @@ vi.mock("@/lib/tauri-commands", () => ({
 
 import { readDir } from "@/lib/tauri-commands";
 const mockReadDir = readDir as ReturnType<typeof vi.fn>;
+
+/** Wrap DirEntry[] in the ReadDirResult shape returned by the Rust command. */
+function wrapEntries(entries: DirEntry[]): ReadDirResult {
+  return { entries, total: entries.length, has_more: false };
+}
 
 const FOLDER = "/test";
 const SUBFOLDER = "/test/subdir";
@@ -46,9 +51,9 @@ beforeEach(() => {
   mockUseFileBadges.mockReturnValue({});
   // Default: root returns ROOT_ENTRIES, subfolder returns SUB_ENTRIES
   mockReadDir.mockImplementation((path: string) => {
-    if (path === FOLDER) return Promise.resolve(ROOT_ENTRIES);
-    if (path === SUBFOLDER) return Promise.resolve(SUB_ENTRIES);
-    return Promise.resolve([]);
+    if (path === FOLDER) return Promise.resolve(wrapEntries(ROOT_ENTRIES));
+    if (path === SUBFOLDER) return Promise.resolve(wrapEntries(SUB_ENTRIES));
+    return Promise.resolve(wrapEntries([]));
   });
 });
 
@@ -97,7 +102,7 @@ describe("6.2 – clicking folder calls readDir / collapses when expanded", () =
     fireEvent.click(screen.getByText("subdir").closest(".tree-entry")!);
 
     await waitFor(() => {
-      expect(mockReadDir).toHaveBeenCalledWith(SUBFOLDER);
+      expect(mockReadDir).toHaveBeenCalledWith(SUBFOLDER, undefined);
     });
 
     // children should appear
@@ -312,8 +317,8 @@ describe("6.9 – optimistic folder toggle", () => {
   it("flips aria-expanded synchronously even when loadChildren never resolves", async () => {
     // Make readDir(SUBFOLDER) hang forever; root still resolves so the tree mounts.
     mockReadDir.mockImplementation((path: string) => {
-      if (path === FOLDER) return Promise.resolve(ROOT_ENTRIES);
-      return new Promise<DirEntry[]>(() => {}); // never resolves
+      if (path === FOLDER) return Promise.resolve(wrapEntries(ROOT_ENTRIES));
+      return new Promise<ReadDirResult>(() => {}); // never resolves
     });
 
     renderTree();
@@ -369,14 +374,14 @@ describe("6.11 – grouped flat filter view", () => {
     // only in README.md. Use a filter that finds 3 files in 2 folders.
     mockReadDir.mockImplementation((path: string) => {
       if (path === FOLDER)
-        return Promise.resolve([
+        return Promise.resolve(wrapEntries([
           { name: "subdir", path: SUBFOLDER, is_dir: true },
           { name: "alpha.md", path: "/test/alpha.md", is_dir: false },
           { name: "beta.md", path: "/test/beta.md", is_dir: false },
-        ]);
+        ]));
       if (path === SUBFOLDER)
-        return Promise.resolve([{ name: "gamma.md", path: "/test/subdir/gamma.md", is_dir: false }]);
-      return Promise.resolve([]);
+        return Promise.resolve(wrapEntries([{ name: "gamma.md", path: "/test/subdir/gamma.md", is_dir: false }]));
+      return Promise.resolve(wrapEntries([]));
     });
 
     renderTree();

--- a/src/hooks/__tests__/useFolderChildren.test.ts
+++ b/src/hooks/__tests__/useFolderChildren.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useFolderChildren } from "@/hooks/useFolderChildren";
 import * as commands from "@/lib/tauri-commands";
+import type { ReadDirResult } from "@/lib/tauri-commands";
 import { listenEvent } from "@/lib/tauri-events";
 
 vi.mock("@/lib/tauri-commands");
@@ -20,6 +21,11 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+/** Wrap DirEntry[] in the ReadDirResult shape returned by the Rust command. */
+function wrapEntries(entries: commands.DirEntry[]): ReadDirResult {
+  return { entries, total: entries.length, has_more: false };
+}
+
 function getFolderChangedCallback() {
   const call = vi
     .mocked(listenEvent)
@@ -34,19 +40,19 @@ describe("useFolderChildren", () => {
       { name: "file.md", path: "/root/file.md", is_dir: false },
       { name: "sub", path: "/root/sub", is_dir: true },
     ];
-    vi.mocked(commands.readDir).mockResolvedValue(entries);
+    vi.mocked(commands.readDir).mockResolvedValue(wrapEntries(entries));
 
     const { result } = renderHook(() => useFolderChildren("/root"));
 
     await act(async () => {});
 
-    expect(commands.readDir).toHaveBeenCalledWith("/root");
-    expect(result.current.childrenCache["/root"]).toEqual(entries);
+    expect(commands.readDir).toHaveBeenCalledWith("/root", undefined);
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(entries);
   });
 
   it("caches results — second call returns cached without IPC", async () => {
     const entries = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
-    vi.mocked(commands.readDir).mockResolvedValue(entries);
+    vi.mocked(commands.readDir).mockResolvedValue(wrapEntries(entries));
 
     const { result } = renderHook(() => useFolderChildren("/root"));
 
@@ -67,8 +73,8 @@ describe("useFolderChildren", () => {
     const entriesA = [{ name: "a.md", path: "/rootA/a.md", is_dir: false }];
     const entriesB = [{ name: "b.md", path: "/rootB/b.md", is_dir: false }];
     vi.mocked(commands.readDir)
-      .mockResolvedValueOnce(entriesA)
-      .mockResolvedValueOnce(entriesB);
+      .mockResolvedValueOnce(wrapEntries(entriesA))
+      .mockResolvedValueOnce(wrapEntries(entriesB));
 
     const { result, rerender } = renderHook(
       ({ root }) => useFolderChildren(root),
@@ -76,14 +82,14 @@ describe("useFolderChildren", () => {
     );
 
     await act(async () => {});
-    expect(result.current.childrenCache["/rootA"]).toEqual(entriesA);
+    expect(result.current.childrenCache["/rootA"]?.entries).toEqual(entriesA);
 
     // Change root
     rerender({ root: "/rootB" });
 
     await act(async () => {});
     expect(result.current.childrenCache["/rootA"]).toBeUndefined();
-    expect(result.current.childrenCache["/rootB"]).toEqual(entriesB);
+    expect(result.current.childrenCache["/rootB"]?.entries).toEqual(entriesB);
   });
 
   it("returns empty array on error", async () => {
@@ -105,12 +111,51 @@ describe("useFolderChildren", () => {
   });
 
   it("does not load when root is null", async () => {
-    vi.mocked(commands.readDir).mockResolvedValue([]);
+    vi.mocked(commands.readDir).mockResolvedValue(wrapEntries([]));
 
     renderHook(() => useFolderChildren(null));
 
     await act(async () => {});
     expect(commands.readDir).not.toHaveBeenCalled();
+  });
+
+  it("stores hasMore and total from ReadDirResult", async () => {
+    const entries = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
+    vi.mocked(commands.readDir).mockResolvedValue({
+      entries,
+      total: 500,
+      has_more: true,
+    });
+
+    const { result } = renderHook(() => useFolderChildren("/root"));
+    await act(async () => {});
+
+    expect(result.current.childrenCache["/root"]?.hasMore).toBe(true);
+    expect(result.current.childrenCache["/root"]?.total).toBe(500);
+  });
+
+  it("bypasses cache when explicit limit is passed", async () => {
+    const initial = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
+    const full = [
+      { name: "a.md", path: "/root/a.md", is_dir: false },
+      { name: "b.md", path: "/root/b.md", is_dir: false },
+    ];
+    vi.mocked(commands.readDir)
+      .mockResolvedValueOnce({ entries: initial, total: 500, has_more: true })
+      .mockResolvedValueOnce({ entries: full, total: 2, has_more: false });
+
+    const { result } = renderHook(() => useFolderChildren("/root"));
+    await act(async () => {});
+    expect(result.current.childrenCache["/root"]?.hasMore).toBe(true);
+
+    // Re-fetch with explicit limit — should bypass cache
+    await act(async () => {
+      await result.current.loadChildren("/root", 10000);
+    });
+    expect(commands.readDir).toHaveBeenCalledTimes(2);
+    expect(commands.readDir).toHaveBeenLastCalledWith("/root", 10000);
+    expect(result.current.childrenCache["/root"]?.hasMore).toBe(false);
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(full);
   });
 });
 
@@ -122,13 +167,13 @@ describe("useFolderChildren folder-changed listener", () => {
       { name: "b.md", path: "/root/b.md", is_dir: false },
     ];
     vi.mocked(commands.readDir)
-      .mockResolvedValueOnce(initial)
-      .mockResolvedValueOnce(refreshed);
+      .mockResolvedValueOnce(wrapEntries(initial))
+      .mockResolvedValueOnce(wrapEntries(refreshed));
 
     const { result } = renderHook(() => useFolderChildren("/root"));
     await act(async () => {});
 
-    expect(result.current.childrenCache["/root"]).toEqual(initial);
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(initial);
 
     const cb = getFolderChangedCallback();
     await act(async () => {
@@ -137,12 +182,12 @@ describe("useFolderChildren folder-changed listener", () => {
 
     expect(commands.readDir).toHaveBeenCalledTimes(2);
     expect(commands.readDir).toHaveBeenLastCalledWith("/root");
-    expect(result.current.childrenCache["/root"]).toEqual(refreshed);
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(refreshed);
   });
 
   it("ignores 'folder-changed' for an uncached dir", async () => {
     const initial = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
-    vi.mocked(commands.readDir).mockResolvedValue(initial);
+    vi.mocked(commands.readDir).mockResolvedValue(wrapEntries(initial));
 
     renderHook(() => useFolderChildren("/root"));
     await act(async () => {});
@@ -161,7 +206,7 @@ describe("useFolderChildren folder-changed listener", () => {
   it("unsubscribes on unmount", async () => {
     const unlisten = vi.fn();
     vi.mocked(listenEvent).mockResolvedValue(unlisten);
-    vi.mocked(commands.readDir).mockResolvedValue([]);
+    vi.mocked(commands.readDir).mockResolvedValue(wrapEntries([]));
 
     const { unmount } = renderHook(() => useFolderChildren("/root"));
     await act(async () => {});

--- a/src/hooks/__tests__/useFolderTree.test.ts
+++ b/src/hooks/__tests__/useFolderTree.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { buildFolderTree } from "../useFolderTree";
 import type { DirEntry } from "@/lib/tauri-commands";
+import type { CachedDir } from "@/hooks/useFolderChildren";
 import type { GhostEntry } from "@/store";
 
 function makeEntry(name: string, path: string, is_dir: boolean): DirEntry {
   return { name, path, is_dir };
+}
+
+/** Wrap DirEntry[] in the CachedDir shape used by childrenCache. */
+function wrap(entries: DirEntry[]): CachedDir {
+  return { entries, hasMore: false, total: entries.length };
 }
 
 describe("buildFolderTree", () => {
@@ -22,11 +28,11 @@ describe("buildFolderTree", () => {
   });
 
   it("builds flat list from root entries", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([
         makeEntry("readme.md", "/project/readme.md", false),
         makeEntry("src", "/project/src", true),
-      ],
+      ]),
     };
     const { nodes } = buildFolderTree(ROOT, cache, {}, "", noGhosts);
     expect(nodes).toEqual([
@@ -36,9 +42,9 @@ describe("buildFolderTree", () => {
   });
 
   it("collapsed folders omit children", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [makeEntry("index.ts", "/project/src/index.ts", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([makeEntry("index.ts", "/project/src/index.ts", false)]),
     };
     const { nodes } = buildFolderTree(ROOT, cache, {}, "", noGhosts);
     expect(nodes).toHaveLength(1);
@@ -46,9 +52,9 @@ describe("buildFolderTree", () => {
   });
 
   it("expanded folders include children at increased depth", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [makeEntry("index.ts", "/project/src/index.ts", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([makeEntry("index.ts", "/project/src/index.ts", false)]),
     };
     const expanded = { "/project/src": true };
     const { nodes } = buildFolderTree(ROOT, cache, expanded, "", noGhosts);
@@ -62,11 +68,11 @@ describe("buildFolderTree", () => {
   });
 
   it("filter correctly hides non-matching files", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([
         makeEntry("readme.md", "/project/readme.md", false),
         makeEntry("notes.txt", "/project/notes.txt", false),
-      ],
+      ]),
     };
     const { nodes } = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
     expect(nodes).toHaveLength(1);
@@ -74,12 +80,12 @@ describe("buildFolderTree", () => {
   });
 
   it("filter keeps directories that have matching descendants", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([
         makeEntry("match.ts", "/project/src/match.ts", false),
         makeEntry("other.js", "/project/src/other.js", false),
-      ],
+      ]),
     };
     const expanded = { "/project/src": true };
     const { nodes } = buildFolderTree(ROOT, cache, expanded, "match", noGhosts);
@@ -89,17 +95,17 @@ describe("buildFolderTree", () => {
   });
 
   it("filter is case-insensitive", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("README.md", "/project/README.md", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("README.md", "/project/README.md", false)]),
     };
     const { nodes } = buildFolderTree(ROOT, cache, {}, "readme", noGhosts);
     expect(nodes).toHaveLength(1);
   });
 
   it("ghost entries are inserted at the correct depth", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [makeEntry("app.ts", "/project/src/app.ts", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([makeEntry("app.ts", "/project/src/app.ts", false)]),
     };
     const expanded = { "/project/src": true };
     const ghosts: GhostEntry[] = [
@@ -114,8 +120,8 @@ describe("buildFolderTree", () => {
   });
 
   it("ghost entries are not duplicated if already in tree", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("file.md", "/project/file.md", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("file.md", "/project/file.md", false)]),
     };
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/file.md", sidecarPath: "/project/file.md.review.json" },
@@ -127,8 +133,8 @@ describe("buildFolderTree", () => {
   });
 
   it("ghost entries at root depth get depth 0", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
     };
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/orphan.md", sidecarPath: "/project/orphan.md.review.json" },
@@ -141,9 +147,9 @@ describe("buildFolderTree", () => {
 
   it("ghost entries with backslash paths are handled", () => {
     const winRoot = "C:\\project";
-    const cache: Record<string, DirEntry[]> = {
-      [winRoot]: [makeEntry("src", "C:\\project\\src", true)],
-      "C:\\project\\src": [],
+    const cache: Record<string, CachedDir> = {
+      [winRoot]: wrap([makeEntry("src", "C:\\project\\src", true)]),
+      "C:\\project\\src": wrap([]),
     };
     const expanded = { "C:\\project\\src": true };
     const ghosts: GhostEntry[] = [
@@ -159,9 +165,9 @@ describe("buildFolderTree", () => {
   // ── Ghost visibility under collapsed folders (issue #216) ──────────────
 
   it("omits ghost entries under collapsed parent folders", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [makeEntry("app.ts", "/project/src/app.ts", false)],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([makeEntry("app.ts", "/project/src/app.ts", false)]),
     };
     // src is collapsed (not in expandedFolders)
     const ghosts: GhostEntry[] = [
@@ -174,9 +180,9 @@ describe("buildFolderTree", () => {
   });
 
   it("includes ghost entries under expanded parent folders", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([]),
     };
     const expanded = { "/project/src": true };
     const ghosts: GhostEntry[] = [
@@ -189,8 +195,8 @@ describe("buildFolderTree", () => {
   });
 
   it("root-level ghost entries are always visible regardless of expanded state", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([]),
     };
     const ghosts: GhostEntry[] = [
       { sourcePath: "/project/root-ghost.md", sidecarPath: "/project/root-ghost.md.review.json" },
@@ -202,10 +208,10 @@ describe("buildFolderTree", () => {
   });
 
   it("deeply nested ghost with ancestor collapsed is hidden and mapped to nearest visible ancestor", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [makeEntry("lib", "/project/src/lib", true)],
-      "/project/src/lib": [],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([makeEntry("lib", "/project/src/lib", true)]),
+      "/project/src/lib": wrap([]),
     };
     // src expanded, lib collapsed
     const expanded = { "/project/src": true };
@@ -221,9 +227,9 @@ describe("buildFolderTree", () => {
   });
 
   it("hiddenGhostsByFolder correctly maps folder to ghost source paths", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("docs", "/project/docs", true)],
-      "/project/docs": [],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("docs", "/project/docs", true)]),
+      "/project/docs": wrap([]),
     };
     // docs is collapsed
     const ghosts: GhostEntry[] = [
@@ -239,9 +245,9 @@ describe("buildFolderTree", () => {
   });
 
   it("hiddenGhostsByFolder is empty when all ghosts are visible", () => {
-    const cache: Record<string, DirEntry[]> = {
-      [ROOT]: [makeEntry("src", "/project/src", true)],
-      "/project/src": [],
+    const cache: Record<string, CachedDir> = {
+      [ROOT]: wrap([makeEntry("src", "/project/src", true)]),
+      "/project/src": wrap([]),
     };
     const expanded = { "/project/src": true };
     const ghosts: GhostEntry[] = [

--- a/src/hooks/useFolderChildren.ts
+++ b/src/hooks/useFolderChildren.ts
@@ -5,24 +5,31 @@ import { warn } from "@/logger";
 
 export type { DirEntry };
 
+export interface CachedDir {
+  entries: DirEntry[];
+  hasMore: boolean;
+  total: number;
+}
+
 export function useFolderChildren(root: string | null) {
-  const [childrenCache, setChildrenCache] = useState<Record<string, DirEntry[]>>({});
+  const [childrenCache, setChildrenCache] = useState<Record<string, CachedDir>>({});
   const childrenCacheRef = useRef(childrenCache);
   // eslint-disable-next-line react-hooks/refs -- sync ref is the documented pattern for stable callbacks
   childrenCacheRef.current = childrenCache;
 
   const loadChildren = useCallback(
-    async (path: string): Promise<DirEntry[]> => {
+    async (path: string, limit?: number): Promise<DirEntry[]> => {
       const cached = childrenCacheRef.current[path];
-      if (cached) return cached;
+      if (cached && limit === undefined) return cached.entries;
       try {
-        const entries = await readDir(path);
+        const result = await readDir(path, limit);
+        const value: CachedDir = { entries: result.entries, hasMore: result.has_more, total: result.total };
         setChildrenCache((prev) => {
-          const next = { ...prev, [path]: entries };
+          const next = { ...prev, [path]: value };
           childrenCacheRef.current = next;
           return next;
         });
-        return entries;
+        return result.entries;
       } catch {
         return [];
       }
@@ -45,9 +52,10 @@ export function useFolderChildren(root: string | null) {
     const unlisten = listenEvent("folder-changed", ({ path }) => {
       if (childrenCacheRef.current[path] === undefined) return;
       readDir(path)
-        .then((entries) =>
+        .then((result) =>
           setChildrenCache((prev) => {
-            const next = { ...prev, [path]: entries };
+            const value: CachedDir = { entries: result.entries, hasMore: result.has_more, total: result.total };
+            const next = { ...prev, [path]: value };
             childrenCacheRef.current = next;
             return next;
           })

--- a/src/hooks/useFolderTree.ts
+++ b/src/hooks/useFolderTree.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { DirEntry } from "@/lib/tauri-commands";
+import type { CachedDir } from "@/hooks/useFolderChildren";
 import type { GhostEntry } from "@/store";
 
 export type TreeNode = {
@@ -18,13 +18,13 @@ export interface FolderTreeResult {
 
 export function buildFolderTree(
   root: string | null,
-  childrenCache: Record<string, DirEntry[]>,
+  childrenCache: Record<string, CachedDir>,
   expandedFolders: Record<string, boolean>,
   filter: string,
   ghostEntries: GhostEntry[]
 ): FolderTreeResult {
   function hasMatch(folderPath: string): boolean {
-    const entries = childrenCache[folderPath] ?? [];
+    const entries = childrenCache[folderPath]?.entries ?? [];
     return entries.some(
       (e) =>
         (!e.is_dir && e.name.toLowerCase().includes(filter.toLowerCase())) ||
@@ -33,7 +33,7 @@ export function buildFolderTree(
   }
 
   function buildFlatList(parentPath: string, depth: number): TreeNode[] {
-    const entries = childrenCache[parentPath] ?? [];
+    const entries = childrenCache[parentPath]?.entries ?? [];
     const result: TreeNode[] = [];
     for (const entry of entries) {
       if (filter) {
@@ -133,7 +133,7 @@ export function buildFolderTree(
 
 export function useFolderTree(
   root: string | null,
-  childrenCache: Record<string, DirEntry[]>,
+  childrenCache: Record<string, CachedDir>,
   expandedFolders: Record<string, boolean>,
   filter: string,
   ghostEntries: GhostEntry[]

--- a/src/lib/__tests__/folder-tree.test.ts
+++ b/src/lib/__tests__/folder-tree.test.ts
@@ -6,6 +6,12 @@ import {
   computeWatchedDirs,
 } from "../folder-tree";
 import type { DirEntry } from "@/lib/tauri-commands";
+import type { CachedDir } from "@/hooks/useFolderChildren";
+
+/** Wrap DirEntry[] in the CachedDir shape used by childrenCache. */
+function wrap(entries: DirEntry[]): CachedDir {
+  return { entries, hasMore: false, total: entries.length };
+}
 
 describe("pathStartsWithRootCrossPlatform", () => {
   it("matches identical paths", () => {
@@ -44,16 +50,16 @@ describe("getAncestors", () => {
 
 describe("buildGroupedFilterResult", () => {
   const ROOT = "/r";
-  const cache: Record<string, DirEntry[]> = {
-    "/r": [
+  const cache: Record<string, CachedDir> = {
+    "/r": wrap([
       { name: "alpha.md", path: "/r/alpha.md", is_dir: false },
       { name: "sub", path: "/r/sub", is_dir: true },
       { name: "skip.txt", path: "/r/skip.txt", is_dir: false },
-    ],
-    "/r/sub": [
+    ]),
+    "/r/sub": wrap([
       { name: "beta.md", path: "/r/sub/beta.md", is_dir: false },
       { name: "gamma.md", path: "/r/sub/gamma.md", is_dir: false },
-    ],
+    ]),
   };
 
   it("groups by immediate parent and sorts by relative path", () => {
@@ -80,12 +86,12 @@ describe("buildGroupedFilterResult", () => {
   });
 
   it("respects the entryCap budget", () => {
-    const big: Record<string, DirEntry[]> = {
-      "/r": Array.from({ length: 50 }, (_, i) => ({
+    const big: Record<string, CachedDir> = {
+      "/r": wrap(Array.from({ length: 50 }, (_, i) => ({
         name: `f${i}.md`,
         path: `/r/f${i}.md`,
         is_dir: false,
-      })),
+      }))),
     };
     const groups = buildGroupedFilterResult("/r", big, ".md", { entryCap: 5 });
     expect(groups[0].files.length).toBeLessThanOrEqual(5);

--- a/src/lib/folder-tree.ts
+++ b/src/lib/folder-tree.ts
@@ -1,4 +1,4 @@
-import type { DirEntry } from "@/lib/tauri-commands";
+import type { CachedDir } from "@/hooks/useFolderChildren";
 
 /**
  * Cross-platform path prefix check. Returns true when `filePath` lies inside
@@ -60,7 +60,7 @@ const DEFAULT_ENTRY_CAP = 10000;
  */
 export function buildGroupedFilterResult(
   root: string | null,
-  childrenCache: Record<string, DirEntry[]>,
+  childrenCache: Record<string, CachedDir>,
   filter: string,
   opts?: { depthCap?: number; entryCap?: number }
 ): FilterGroup[] {
@@ -73,7 +73,7 @@ export function buildGroupedFilterResult(
 
   const walk = (dir: string, depth: number): boolean => {
     if (depth > depthCap) return true;
-    const entries = childrenCache[dir];
+    const entries = childrenCache[dir]?.entries;
     if (!entries) return false;
     for (const e of entries) {
       if (visited++ >= entryCap) return true;

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -86,8 +86,14 @@ export const revealInFolder = (path: string): Promise<void> =>
 export const resolveHtmlAssets = (html: string, htmlDir: string): Promise<string> =>
   invoke<string>("resolve_html_assets", { html, htmlDir });
 
-export const readDir = (path: string): Promise<DirEntry[]> =>
-  invoke<DirEntry[]>("read_dir", { path });
+export interface ReadDirResult {
+  entries: DirEntry[];
+  total: number;
+  has_more: boolean;
+}
+
+export const readDir = (path: string, limit?: number): Promise<ReadDirResult> =>
+  invoke<ReadDirResult>("read_dir", { path, limit: limit ?? null });
 
 export const getLaunchArgs = (): Promise<LaunchArgs> =>
   invoke<LaunchArgs>("get_launch_args");

--- a/src/styles/folder-tree.css
+++ b/src/styles/folder-tree.css
@@ -271,3 +271,15 @@
   font-size: 13px;
   line-height: 1;
 }
+
+/* ── "Show all N items…" truncation row ─────────────────────────────────── */
+.tree-row.load-more {
+  color: var(--link-color, #0078d4);
+  cursor: pointer;
+  font-style: italic;
+  padding: 2px 0;
+  font-size: 12px;
+}
+.tree-row.load-more:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary

Caps directory listing results at 250 entries by default to prevent IPC serialization and DOM rendering stutter for large directories.

## Changes

- Rust read_dir: Returns ReadDirResult with optional limit param (default 250)
- Frontend useFolderChildren: Cache stores CachedDir; loadChildren accepts optional limit
- FolderTree: Shows 'Show all N items' row for truncated directories
- Mocks: Both Vitest mock and Playwright fixture updated with transparent array wrapping

## Design decisions

- Cap + truncate, not offset/limit pagination - directory contents change between calls
- 250 default - most real directories have fewer entries
- User can load all - clicking 'Show all' re-fetches with limit=total

## Testing

- All 318 Rust lib tests pass
- All 66 Rust integration tests pass
- All 1535 Vitest frontend tests pass
- New tests: useFolderChildren stores hasMore/total, bypasses cache on explicit limit