### PR TITLE
fix: sync WindowRegistry on open/close folder + New Window menu

### DIFF
--- a/e2e/browser/fixtures/error-tracking.ts
+++ b/e2e/browser/fixtures/error-tracking.ts
@@ -158,6 +158,8 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
               }
               if (cmd === "get_file_viewer_pref") return null;
               if (cmd === "set_file_viewer_pref") return undefined;
+              if (cmd === "register_window_folder") return undefined;
+              if (cmd === "unregister_window_folder") return undefined;
             }
             return result;
           }
@@ -194,6 +196,8 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
           }
           if (cmd === "get_file_viewer_pref") return null;
           if (cmd === "set_file_viewer_pref") return undefined;
+          if (cmd === "register_window_folder") return undefined;
+          if (cmd === "unregister_window_folder") return undefined;
           // ── Two-layer mock parity (issue #135) ─────────────────────────
           // Mirroring the Vitest mock defaults so unit-tests and browser
           // e2e tests observe the same baseline shape. Locked in by

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,33 @@ fn folder_display_name(path: &std::path::Path) -> String {
         .unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
 
+#[tauri::command]
+fn register_window_folder(
+    window: tauri::Window,
+    folder: String,
+    registry: tauri::State<'_, registry::WindowRegistry>,
+) -> Result<(), String> {
+    let canonical = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&folder))
+        .map_err(|e| format!("invalid folder: {}", e))?;
+    let display = folder_display_name(&canonical);
+    registry.update_kind(window.label(), registry::WindowKind::Folder(canonical));
+    let _ = window.set_title(&format!("mdownreview — {display}"));
+    log::info!("[window] {} registered folder: {display}", window.label());
+    Ok(())
+}
+
+#[tauri::command]
+fn unregister_window_folder(
+    window: tauri::Window,
+    registry: tauri::State<'_, registry::WindowRegistry>,
+) -> Result<(), String> {
+    registry.update_kind(window.label(), registry::WindowKind::FileOnly);
+    // TODO: call watcher_state.remove_window once fix/per-window-watcher-state merges
+    let _ = window.set_title("mdownreview");
+    log::info!("[window] {} unregistered folder", window.label());
+    Ok(())
+}
+
 /// Find the focused `WebviewWindow`, falling back to the "main" window.
 fn focused_or_main<M: Manager<tauri::Wry>>(manager: &M) -> Option<tauri::WebviewWindow> {
     manager
@@ -254,6 +281,13 @@ pub fn run() {
             )?;
             let close_folder =
                 MenuItem::with_id(app, "close-folder", "Close Folder", true, None::<&str>)?;
+            let new_window = MenuItem::with_id(
+                app,
+                "new-window",
+                "New Window",
+                true,
+                Some("CmdOrCtrl+Shift+N"),
+            )?;
             let close_tab =
                 MenuItem::with_id(app, "close-tab", "Close Tab", true, Some("CmdOrCtrl+W"))?;
             let close_all_tabs = MenuItem::with_id(
@@ -266,6 +300,7 @@ pub fn run() {
             let file_menu = SubmenuBuilder::new(app, "File")
                 .item(&open_file)
                 .item(&open_folder)
+                .item(&new_window)
                 .item(&close_folder)
                 .separator()
                 .item(&close_tab)
@@ -339,6 +374,24 @@ pub fn run() {
                         for w in app.webview_windows().values() {
                             let _ = w.unminimize();
                             let _ = w.show();
+                        }
+                        return;
+                    }
+                    "new-window" => {
+                        let reg = app.state::<registry::WindowRegistry>();
+                        let label = reg.next_label();
+                        let builder = tauri::WebviewWindowBuilder::new(
+                            app, &label, tauri::WebviewUrl::App("index.html".into()),
+                        )
+                        .title("mdownreview")
+                        .inner_size(1100.0, 750.0)
+                        .min_inner_size(600.0, 400.0);
+                        match builder.build() {
+                            Ok(_) => {
+                                reg.register(label.clone(), registry::WindowKind::FileOnly);
+                                log::info!("[window] new-window: created {label}");
+                            }
+                            Err(e) => log::error!("[window] new-window failed: {e}"),
                         }
                         return;
                     }
@@ -434,6 +487,8 @@ pub fn run() {
                 commands::word_tokens::tokenize_words,
                 update::check_update,
                 update::install_update,
+                register_window_folder,
+                unregister_window_folder,
                 $($extra),*
             ]
         };

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -126,6 +126,14 @@ impl WindowRegistry {
         entries.push(WindowEntry { label, kind });
     }
 
+    /// Update the kind of an existing window entry.
+    pub fn update_kind(&self, label: &str, kind: WindowKind) {
+        let mut entries = self.entries.lock().expect("registry lock poisoned");
+        if let Some(entry) = entries.iter_mut().find(|e| e.label == label) {
+            entry.kind = kind;
+        }
+    }
+
     /// Remove a window by label.
     pub fn unregister(&self, label: &str) {
         let mut entries = self.entries.lock().expect("registry lock poisoned");
@@ -378,6 +386,25 @@ mod tests {
             let child = Path::new("/users/dev/project/src/main.rs");
             assert!(is_ancestor(parent, child));
         }
+    }
+
+    #[test]
+    fn update_kind_changes_existing_entry() {
+        let reg = WindowRegistry::new();
+        reg.register("main".to_string(), WindowKind::FileOnly);
+        assert!(reg.find_file_only().is_some());
+        reg.update_kind("main", WindowKind::Folder(PathBuf::from("/projects/myapp")));
+        assert!(reg.find_file_only().is_none());
+        assert!(reg.find_by_folder(Path::new("/projects/myapp")).is_some());
+    }
+
+    #[test]
+    fn update_kind_noop_for_unknown_label() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".to_string(), WindowKind::FileOnly);
+        reg.update_kind("unknown", WindowKind::Folder(PathBuf::from("/a")));
+        // w1 should remain FileOnly
+        assert!(reg.find_file_only().is_some());
     }
 
     #[test]

--- a/src/__mocks__/@tauri-apps/api/core.ts
+++ b/src/__mocks__/@tauri-apps/api/core.ts
@@ -160,6 +160,8 @@ async function defaultInvoke(
   if (cmd === "get_file_viewer_pref") return null;
   if (cmd === "set_file_viewer_pref") return undefined;
   if (cmd === "read_dir") return { entries: [], total: 0, has_more: false } satisfies ReadDirResult;
+  if (cmd === "register_window_folder") return undefined;
+  if (cmd === "unregister_window_folder") return undefined;
   return undefined;
 }
 

--- a/src/hooks/__tests__/useDialogActions.test.ts
+++ b/src/hooks/__tests__/useDialogActions.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useDialogActions } from "../useDialogActions";
-import { showOpenDialog } from "@/lib/tauri-commands";
+import { showOpenDialog, registerWindowFolder } from "@/lib/tauri-commands";
 import { useStore } from "@/store";
 
 vi.mock("@/lib/tauri-commands", () => ({
   showOpenDialog: vi.fn(),
+  registerWindowFolder: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/logger", () => ({
@@ -59,6 +60,13 @@ describe("useDialogActions", () => {
         expect.objectContaining({ path: "/test/folder", type: "folder" }),
       ])
     );
+  });
+
+  it("handleOpenFolder calls registerWindowFolder", async () => {
+    vi.mocked(showOpenDialog).mockResolvedValue("/test/folder");
+    const { result } = renderHook(() => useDialogActions());
+    await act(async () => { await result.current.handleOpenFolder(); });
+    expect(registerWindowFolder).toHaveBeenCalledWith("/test/folder");
   });
 
   it("cancelled dialog (null) is no-op", async () => {

--- a/src/hooks/useDialogActions.ts
+++ b/src/hooks/useDialogActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
-import { showOpenDialog } from "@/lib/tauri-commands";
+import { showOpenDialog, registerWindowFolder } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
 import { useStore } from "@/store";
 
 export function useDialogActions() {
@@ -30,6 +31,9 @@ export function useDialogActions() {
       if (typeof selected === "string") {
         await setRoot(selected);
         addRecentItem(selected, "folder");
+        registerWindowFolder(selected).catch((err) =>
+          warn(`[useDialogActions] register_window_folder failed: ${err}`)
+        );
       }
     } catch {
       // User cancelled or dialog error

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { listenEvent } from "@/lib/tauri-events";
+import { unregisterWindowFolder } from "@/lib/tauri-commands";
 import { useStore } from "@/store";
 
 interface MenuListenerCallbacks {
@@ -30,7 +31,10 @@ export function useMenuListeners({
     const pending = [
       listenEvent("menu-open-file", () => handleOpenFile()),
       listenEvent("menu-open-folder", () => handleOpenFolder()),
-      listenEvent("menu-close-folder", () => useStore.getState().closeFolder()),
+      listenEvent("menu-close-folder", () => {
+        useStore.getState().closeFolder();
+        unregisterWindowFolder().catch(() => {});
+      }),
       listenEvent("menu-toggle-comments-pane", () => toggleCommentsPane()),
       listenEvent("menu-close-tab", () => {
         const { activeTabPath, closeTab } = useStore.getState();

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -429,3 +429,13 @@ export const getFileViewerPref = (path: string): Promise<FileViewerPref | null> 
 export const setFileViewerPref = (path: string, allowImages: boolean): Promise<void> =>
   invoke<void>("set_file_viewer_pref", { path, allowImages });
 
+// ── Window registry sync ─────────────────────────────────────────────────
+
+/** Update the WindowRegistry to record this window as owning `folder`. */
+export const registerWindowFolder = (folder: string): Promise<void> =>
+  invoke<void>("register_window_folder", { folder });
+
+/** Reset this window's registry entry to FileOnly and clear the title. */
+export const unregisterWindowFolder = (): Promise<void> =>
+  invoke<void>("unregister_window_folder");
+


### PR DESCRIPTION
## Summary

Three related changes to multi-window support:

1. **Registry sync on Open Folder**  new `register_window_folder` IPC command updates the WindowRegistry and window title when the user opens a folder
2. **Registry sync on Close Folder**  new `unregister_window_folder` IPC command transitions back to FileOnly and resets title
3. **New Window (Ctrl+Shift+N)**  File menu item creates an empty FileOnly window

## Changes

- **registry.rs**: New `update_kind()` method + 2 tests
- **lib.rs**: Two new commands + New Window menu item and handler
- **tauri-commands.ts**: Frontend IPC wrappers
- **useDialogActions.ts**: Calls `registerWindowFolder` after `setRoot`
- **useMenuListeners.ts**: Calls `unregisterWindowFolder` on close-folder
- **Both mock layers**: Updated for issue #135 parity

## Testing

- 320 Rust tests pass (`cargo test --lib`)
- 1533 frontend tests pass (1 pre-existing timeout failure in SettingsSurface AC6 unrelated to changes)
- IPC mock parity test passes