### PR TITLE
feat: implement #243  Viewer toolbar consolidation: all viewers get ViewerToolbar, all actions surface through it

### DIFF
--- a/docs/features/viewer-consistency.md
+++ b/docs/features/viewer-consistency.md
@@ -128,16 +128,4 @@ When a new file type or viewer is added:
 
 ## Known gaps (current violations)
 
-Tracked here until fixed. Each is a candidate for a GitHub issue.
-
-1. **Error state (non-ghost) has no ViewerToolbar** — violates universal requirements 1, 2, 4. The `<div className="viewer-error">` renders with no toolbar, no "Comment on file", no FileActionsBar.
-
-2. **DeletedFileViewer has no ViewerToolbar** — violates universal requirements 1, 2. No toolbar, no "Comment on file" button. The sidecar still exists so file-level commenting should work. The "open the comments panel to view" text is passive — needs an actionable button.
-
-3. **TooLargePlaceholder: FileActionsBar in body instead of toolbar** — violates universal requirements 3, 4. "Reveal in folder" button is in the viewer body instead of the toolbar trailing slot.
-
-4. **BinaryPlaceholder: FileActionsBar in body, missing from toolbar** — violates universal requirements 3, 4. `<FileActionsBar>` is rendered inside the body (line 141); the ViewerRouter mounts no `trailing` on the toolbar. "Copy path" and "Show as hex" toggle are also in the body instead of the toolbar.
-
-5. **MermaidView: custom zoom + export buttons in body** — violates universal requirements 3, 7. Local `scale` state instead of `useZoom`. Export PNG/SVG buttons are in a custom toolbar div inside the component instead of the shared ViewerToolbar.
-
-6. **ImageViewer: fit/original-size toggle and ZoomControl in body** — violates universal requirement 3. The "Original size" / "Fit to view" button and `ZoomControl` are rendered in the ImageViewer header, not through the shared ViewerToolbar mounted in ViewerRouter. The ViewerRouter toolbar is `hidden` with no zoom props.
+No known gaps — all viewers comply with the universal requirements as of the toolbar consolidation in PR #246.

--- a/src/components/viewers/BinaryPlaceholder.tsx
+++ b/src/components/viewers/BinaryPlaceholder.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { basename } from "@/lib/path-utils";
 import {
   getBinaryIconCategory,
@@ -6,21 +6,14 @@ import {
   formatBytes,
   type BinaryIconCategory,
 } from "@/lib/file-types";
-import { copyToClipboard } from "@/lib/tauri-commands";
-import { warn } from "@/logger";
-import { FileActionsBar } from "./FileActionsBar";
-import { HexView } from "./HexView";
 
 interface Props {
   path: string;
-  /** File size in bytes; gates the "Show as hex" toggle (≥ 1 MB → disabled). */
+  /** File size in bytes. */
   size?: number;
   /** Last-modified time as epoch milliseconds; row is omitted when null/undefined. */
   mtime?: number | null;
 }
-
-/** Hex view is gated to keep memory + render cost predictable. */
-const HEX_MAX_BYTES = 1024 * 1024;
 
 // ── Inline SVG icon map ───────────────────────────────────────────────────
 // Tiny pictograms keyed by `getBinaryIconCategory`. Each is a 24×24 stroke-
@@ -97,32 +90,15 @@ function FileIcon({ category }: { category: BinaryIconCategory }) {
   );
 }
 
+/**
+ * Pure metadata display for binary files. All actions (hex toggle, copy path,
+ * reveal in folder) surface through the ViewerToolbar mounted by
+ * BinaryViewerShell — the body is content/metadata only.
+ */
 export function BinaryPlaceholder({ path, size, mtime }: Props) {
-  const [showHex, setShowHex] = useState(false);
   const name = basename(path);
   const category = getBinaryIconCategory(path);
   const mime = getMimeHint(path);
-  const sizeOk = size !== undefined && size < HEX_MAX_BYTES;
-
-  const handleCopy = () => {
-    void copyToClipboard(path).catch((e) =>
-      warn(`copyToClipboard failed: ${String(e)}`),
-    );
-  };
-
-  if (showHex) {
-    return (
-      <div className="binary-placeholder binary-placeholder--hex">
-        <div className="binary-placeholder__header">
-          <span className="binary-filename">{name}</span>
-          <button type="button" onClick={() => setShowHex(false)}>
-            ← Back
-          </button>
-        </div>
-        <HexView path={path} />
-      </div>
-    );
-  }
 
   return (
     <div className="binary-placeholder">
@@ -137,24 +113,6 @@ export function BinaryPlaceholder({ path, size, mtime }: Props) {
       {size !== undefined && (
         <p className="binary-size">{formatBytes(size)}</p>
       )}
-      <div className="binary-actions">
-        <FileActionsBar path={path} />
-        <button type="button" onClick={handleCopy}>
-          Copy path
-        </button>
-        <button
-          type="button"
-          onClick={() => setShowHex(true)}
-          disabled={!sizeOk}
-          title={
-            sizeOk
-              ? "Render the first bytes as hex"
-              : "Hex view is disabled for files ≥ 1 MB"
-          }
-        >
-          Show as hex
-        </button>
-      </div>
     </div>
   );
 }

--- a/src/components/viewers/BinaryViewerShell.tsx
+++ b/src/components/viewers/BinaryViewerShell.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { copyToClipboard } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
+import { BinaryPlaceholder } from "./BinaryPlaceholder";
+import { HexView } from "./HexView";
+import { ViewerToolbar } from "./ViewerToolbar";
+import { FileActionsBar } from "./FileActionsBar";
+
+interface Props {
+  path: string;
+  size?: number;
+  mtime?: number | null;
+  onCommentOnFile?: () => void;
+}
+
+/** Hex view is gated to keep memory + render cost predictable. */
+const HEX_MAX_BYTES = 1024 * 1024;
+
+/**
+ * Shell component that owns hex-toggle state and composes the ViewerToolbar
+ * above either BinaryPlaceholder (metadata) or HexView. All binary-viewer
+ * actions (hex toggle, copy path, reveal) surface through the toolbar.
+ */
+export function BinaryViewerShell({ path, size, mtime, onCommentOnFile }: Props) {
+  const [showHex, setShowHex] = useState(false);
+  const sizeOk = size !== undefined && size < HEX_MAX_BYTES;
+
+  const handleCopy = () => {
+    void copyToClipboard(path).catch((e) =>
+      warn(`copyToClipboard failed: ${String(e)}`),
+    );
+  };
+
+  return (
+    <div className="viewer-media-container">
+      <ViewerToolbar
+        activeView="visual"
+        onViewChange={() => {}}
+        hidden
+        onCommentOnFile={onCommentOnFile}
+        trailing={
+          <>
+            <button
+              type="button"
+              className="viewer-toolbar-btn"
+              onClick={() => setShowHex(!showHex)}
+              disabled={!sizeOk}
+              title={
+                sizeOk
+                  ? showHex
+                    ? "Show file metadata"
+                    : "Show as hex"
+                  : "Hex view is disabled for files ≥ 1 MB"
+              }
+              aria-label={showHex ? "Back to metadata" : "Show as hex"}
+            >
+              {showHex ? "← Back" : "Hex"}
+            </button>
+            <button
+              type="button"
+              className="viewer-toolbar-btn"
+              onClick={handleCopy}
+              aria-label="Copy path"
+              title="Copy file path"
+            >
+              Copy path
+            </button>
+            <FileActionsBar path={path} />
+          </>
+        }
+      />
+      {showHex ? (
+        <HexView path={path} />
+      ) : (
+        <BinaryPlaceholder path={path} size={size} mtime={mtime} />
+      )}
+    </div>
+  );
+}

--- a/src/components/viewers/DeletedFileViewer.tsx
+++ b/src/components/viewers/DeletedFileViewer.tsx
@@ -1,19 +1,19 @@
 import { useComments } from "@/lib/vm/use-comments";
-import { useStore } from "@/store";
 import "@/styles/comments.css";
 
 interface Props {
   filePath: string;
 }
 
+/**
+ * Content body for deleted/moved files. Shows metadata about the file's
+ * orphaned comments. All actions (show comments) surface through the
+ * ViewerToolbar mounted by ViewerRouter — the body is metadata only.
+ */
 export function DeletedFileViewer({ filePath }: Props) {
   const { comments } = useComments(filePath);
 
   const fileName = filePath.split(/[/\\]/).pop() ?? filePath;
-
-  const handleShowComments = () => {
-    useStore.getState().toggleCommentsPane();
-  };
 
   return (
     <div className="deleted-file-viewer" style={{ padding: 24, maxWidth: 640, margin: "0 auto" }}>
@@ -32,31 +32,11 @@ export function DeletedFileViewer({ filePath }: Props) {
         </p>
       </div>
 
-      {comments.length === 0 ? (
-        <p style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
-          No comments found in the review sidecar.
-        </p>
-      ) : (
-        <div style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
-          <p style={{ margin: "0 0 8px" }}>
-            {comments.length} comment{comments.length > 1 ? "s" : ""} in the review sidecar.
-          </p>
-          <button
-            type="button"
-            onClick={handleShowComments}
-            style={{
-              padding: "6px 16px",
-              border: "1px solid var(--color-border, #d0d7de)",
-              background: "var(--color-surface, #f6f8fa)",
-              borderRadius: 6,
-              cursor: "pointer",
-              fontSize: 13,
-            }}
-          >
-            Show comments
-          </button>
-        </div>
-      )}
+      <p style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
+        {comments.length === 0
+          ? "No comments found in the review sidecar."
+          : `${comments.length} comment${comments.length > 1 ? "s" : ""} in the review sidecar — use the toolbar to show comments.`}
+      </p>
     </div>
   );
 }

--- a/src/components/viewers/DeletedFileViewer.tsx
+++ b/src/components/viewers/DeletedFileViewer.tsx
@@ -1,4 +1,5 @@
 import { useComments } from "@/lib/vm/use-comments";
+import { useStore } from "@/store";
 import "@/styles/comments.css";
 
 interface Props {
@@ -9,6 +10,10 @@ export function DeletedFileViewer({ filePath }: Props) {
   const { comments } = useComments(filePath);
 
   const fileName = filePath.split(/[/\\]/).pop() ?? filePath;
+
+  const handleShowComments = () => {
+    useStore.getState().toggleCommentsPane();
+  };
 
   return (
     <div className="deleted-file-viewer" style={{ padding: 24, maxWidth: 640, margin: "0 auto" }}>
@@ -27,11 +32,31 @@ export function DeletedFileViewer({ filePath }: Props) {
         </p>
       </div>
 
-      <p style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
-        {comments.length === 0
-          ? "No comments found in the review sidecar."
-          : `${comments.length} comment${comments.length > 1 ? "s" : ""} — open the comments panel to view.`}
-      </p>
+      {comments.length === 0 ? (
+        <p style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
+          No comments found in the review sidecar.
+        </p>
+      ) : (
+        <div style={{ fontSize: 13, color: "var(--color-muted)", marginBottom: 16 }}>
+          <p style={{ margin: "0 0 8px" }}>
+            {comments.length} comment{comments.length > 1 ? "s" : ""} in the review sidecar.
+          </p>
+          <button
+            type="button"
+            onClick={handleShowComments}
+            style={{
+              padding: "6px 16px",
+              border: "1px solid var(--color-border, #d0d7de)",
+              background: "var(--color-surface, #f6f8fa)",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Show comments
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/viewers/EnhancedViewer.tsx
+++ b/src/components/viewers/EnhancedViewer.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy, useState, useRef } from "react";
 import { useStore } from "@/store";
 import { getFileCategory, hasVisualization, getDefaultView, getFiletypeKey } from "@/lib/file-types";
 import { useZoom } from "@/hooks/useZoom";
@@ -10,6 +10,7 @@ import { JsonTreeView } from "./JsonTreeView";
 import { HtmlPreviewView } from "./HtmlPreviewView";
 import { KqlPlanView } from "./KqlPlanView";
 import { SkeletonLoader } from "./SkeletonLoader";
+import type { MermaidViewHandle } from "./MermaidView";
 
 // Lazy-load heavy visualization components
 const CsvTableView = lazy(() =>
@@ -33,6 +34,7 @@ export function EnhancedViewer({ content, path, filePath, fileSize, onCommentOnF
   const canVisualize = hasVisualization(category);
   const defaultView = getDefaultView(category);
   const [wordWrap, setWordWrap] = useState(false);
+  const mermaidRef = useRef<MermaidViewHandle>(null);
 
   const viewMode = useStore((s) => s.viewModeByTab[filePath]) ?? defaultView;
   const setViewMode = useStore((s) => s.setViewMode);
@@ -47,6 +49,8 @@ export function EnhancedViewer({ content, path, filePath, fileSize, onCommentOnF
   const filetypeKey = getFiletypeKey(path, showSource ? "source" : "visual");
   const { zoom, zoomIn, zoomOut, reset } = useZoom(filetypeKey);
 
+  const isMermaidVisual = category === "mermaid" && !showSource;
+
   return (
     <div className="enhanced-viewer">
       {/* L1 — file actions live in the toolbar's `trailing` slot so they
@@ -60,14 +64,40 @@ export function EnhancedViewer({ content, path, filePath, fileSize, onCommentOnF
         onToggleWrap={() => setWordWrap(!wordWrap)}
         zoom={{ zoom, onZoomIn: zoomIn, onZoomOut: zoomOut, onReset: reset }}
         onCommentOnFile={onCommentOnFile}
-        trailing={<FileActionsBar path={filePath} />}
+        trailing={
+          <>
+            {isMermaidVisual && (
+              <>
+                <button
+                  type="button"
+                  className="viewer-toolbar-btn"
+                  onClick={() => mermaidRef.current?.exportPng()}
+                  aria-label="Export PNG"
+                  title="Export diagram as PNG"
+                >
+                  PNG
+                </button>
+                <button
+                  type="button"
+                  className="viewer-toolbar-btn"
+                  onClick={() => mermaidRef.current?.exportSvg()}
+                  aria-label="Export SVG"
+                  title="Export diagram as SVG"
+                >
+                  SVG
+                </button>
+              </>
+            )}
+            <FileActionsBar path={filePath} />
+          </>
+        }
       />
       {showSource ? (
         <SourceView content={content} path={path} filePath={filePath} fileSize={fileSize} wordWrap={wordWrap} zoom={zoom} />
       ) : (
         <div className="enhanced-viewer-content">
           <Suspense fallback={<SkeletonLoader />}>
-            {renderVisualView(category, content, path, filePath, fileSize)}
+            {renderVisualView(category, content, path, filePath, fileSize, zoom, mermaidRef)}
           </Suspense>
         </div>
       )}
@@ -80,7 +110,9 @@ function renderVisualView(
   content: string,
   path: string,
   filePath: string,
-  fileSize?: number
+  fileSize: number | undefined,
+  zoom: number,
+  mermaidRef: React.RefObject<MermaidViewHandle | null>,
 ) {
   switch (category) {
     case "markdown":
@@ -92,7 +124,7 @@ function renderVisualView(
     case "html":
       return <HtmlPreviewView content={content} filePath={filePath} />;
     case "mermaid":
-      return <MermaidView content={content} path={path} />;
+      return <MermaidView ref={mermaidRef} content={content} path={path} zoom={zoom} />;
     case "kql":
       return <KqlPlanView content={content} />;
     default:

--- a/src/components/viewers/ImageViewer.tsx
+++ b/src/components/viewers/ImageViewer.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useImageData } from "@/hooks/useImageData";
 import { extname } from "@/lib/path-utils";
-import { useZoom } from "@/hooks/useZoom";
-import { ZoomControl } from "./ZoomControl";
 import "@/styles/image-viewer.css";
 
 interface Props {
   path: string;
+  /** Zoom level from the shared useZoom hook, driven by ImageViewerShell. */
+  zoom: number;
+  /** When true, the image scales to fit the container; when false, shows at natural size. */
+  fit: boolean;
 }
 
 const MIME_MAP: Record<string, string> = {
@@ -43,8 +45,7 @@ function clampPan(
   };
 }
 
-export function ImageViewer({ path }: Props) {
-  const [fit, setFit] = useState(true);
+export function ImageViewer({ path, zoom, fit }: Props) {
   const [dimensions, setDimensions] = useState<{ w: number; h: number } | null>(null);
   // Drag-to-pan offset, only meaningful when zoom > 1.
   const [pan, setPan] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
@@ -57,7 +58,6 @@ export function ImageViewer({ path }: Props) {
   const filename = path.split(/[\\/]/).pop() || path;
   const mime = MIME_MAP[extname(path)] ?? "image/png";
   const { dataUrl, error } = useImageData(path, mime);
-  const { zoom, zoomIn, zoomOut, reset } = useZoom(".image");
   const canPan = zoom > 1;
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on prop change
@@ -121,22 +121,6 @@ export function ImageViewer({ path }: Props) {
 
   return (
     <div className="image-viewer" style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <div className="image-viewer-header" style={{ display: "flex", alignItems: "center", gap: 12, padding: "8px 12px", borderBottom: "1px solid var(--color-border, #d0d7de)", fontSize: 13 }}>
-        <span style={{ fontWeight: 600 }}>{filename}</span>
-        {dimensions && (
-          <span style={{ color: "var(--color-muted, #656d76)" }}>
-            {dimensions.w} × {dimensions.h}
-          </span>
-        )}
-        <button
-          type="button"
-          onClick={() => setFit(!fit)}
-          style={{ marginLeft: "auto", padding: "2px 8px", border: "1px solid var(--color-border, #d0d7de)", background: "var(--color-surface, #f6f8fa)", borderRadius: 4, cursor: "pointer", fontSize: 12 }}
-        >
-          {fit ? "Original size" : "Fit to view"}
-        </button>
-        <ZoomControl zoom={zoom} onZoomIn={zoomIn} onZoomOut={zoomOut} onReset={reset} />
-      </div>
       <div
         ref={canvasRef}
         className="image-viewer-canvas"

--- a/src/components/viewers/ImageViewerShell.tsx
+++ b/src/components/viewers/ImageViewerShell.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useZoom } from "@/hooks/useZoom";
+import { ViewerToolbar } from "./ViewerToolbar";
+import { FileActionsBar } from "./FileActionsBar";
+import { ImageViewer } from "./ImageViewer";
+
+interface Props {
+  path: string;
+  onCommentOnFile?: () => void;
+}
+
+/**
+ * Shell component that owns zoom and fit state and composes the ViewerToolbar
+ * above ImageViewer. Zoom and fit-toggle surface through the toolbar instead
+ * of the image viewer's body.
+ */
+export function ImageViewerShell({ path, onCommentOnFile }: Props) {
+  const [fit, setFit] = useState(true);
+  const { zoom, zoomIn, zoomOut, reset } = useZoom(".image");
+
+  return (
+    <div className="viewer-media-container">
+      <ViewerToolbar
+        activeView="visual"
+        onViewChange={() => {}}
+        hidden
+        onCommentOnFile={onCommentOnFile}
+        zoom={{ zoom, onZoomIn: zoomIn, onZoomOut: zoomOut, onReset: reset }}
+        trailing={
+          <>
+            <button
+              type="button"
+              className="viewer-toolbar-btn"
+              onClick={() => setFit(!fit)}
+              aria-label={fit ? "Original size" : "Fit to view"}
+              title={fit ? "Show at original size" : "Fit image to view"}
+            >
+              {fit ? "Original size" : "Fit to view"}
+            </button>
+            <FileActionsBar path={path} />
+          </>
+        }
+      />
+      <ImageViewer key={path} path={path} zoom={zoom} fit={fit} />
+    </div>
+  );
+}

--- a/src/components/viewers/MermaidView.tsx
+++ b/src/components/viewers/MermaidView.tsx
@@ -1,10 +1,18 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useId, forwardRef, useImperativeHandle } from "react";
 import "@/styles/mermaid-view.css";
 
 interface Props {
   content: string;
   /** Optional file path. When provided, a file-level comment badge is shown. */
   path?: string;
+  /** Zoom level from the shared useZoom hook, driven by EnhancedViewer. */
+  zoom?: number;
+}
+
+/** Handle exposed to EnhancedViewer for toolbar export buttons. */
+export interface MermaidViewHandle {
+  exportPng: () => void;
+  exportSvg: () => void;
 }
 
 function escapeRegExp(s: string): string {
@@ -49,10 +57,9 @@ function mapNodeToSourceLine(node: SVGGElement, lines: string[]): number | null 
   return null;
 }
 
-export function MermaidView({ content, path }: Props) {
+export const MermaidView = forwardRef<MermaidViewHandle, Props>(function MermaidView({ content, path, zoom = 1 }, ref) {
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string>("");
-  const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
   const reactId = useId();
   const mermaidId = `mermaid-${reactId.replace(/:/g, "")}`;
@@ -118,7 +125,7 @@ export function MermaidView({ content, path }: Props) {
       const line = mapNodeToSourceLine(n, lines);
       if (line !== null) n.setAttribute("data-source-line", String(line));
     }
-  }, [svg, content, scale, filePath]);
+  }, [svg, content, zoom, filePath]);
 
   const handleExportSvg = useCallback(() => {
     if (!svg) return;
@@ -151,27 +158,23 @@ export function MermaidView({ content, path }: Props) {
     img.src = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(svg)));
   }, [svg]);
 
+  useImperativeHandle(ref, () => ({
+    exportPng: handleExportPng,
+    exportSvg: handleExportSvg,
+  }), [handleExportPng, handleExportSvg]);
+
   return (
     <div className="mermaid-view" style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <div className="mermaid-toolbar" style={{ display: "flex", gap: 8, padding: "8px 12px", borderBottom: "1px solid var(--color-border, #d0d7de)", alignItems: "center" }}>
-        <button onClick={() => setScale(s => Math.max(0.25, s - 0.25))} aria-label="Zoom out">−</button>
-        <span style={{ fontSize: 12, minWidth: 48, textAlign: "center" }}>{Math.round(scale * 100)}%</span>
-        <button onClick={() => setScale(s => Math.min(4, s + 0.25))} aria-label="Zoom in">+</button>
-        <button onClick={() => setScale(1)} aria-label="Reset zoom">Reset</button>
-        <div style={{ flex: 1 }} />
-        <button onClick={handleExportPng} aria-label="Export PNG">PNG</button>
-        <button onClick={handleExportSvg} aria-label="Export SVG">SVG</button>
-      </div>
       <div style={{ flex: 1, overflow: "auto", padding: 16 }}>
         {error && <div className="mermaid-error" style={{ color: "var(--color-danger, #cf222e)", padding: 16 }}>{error}</div>}
         {svg && (
           <div
             ref={containerRef}
             title="Mermaid diagram"
-            style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}
+            style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
           />
         )}
       </div>
     </div>
   );
-}
+});

--- a/src/components/viewers/TooLargePlaceholder.tsx
+++ b/src/components/viewers/TooLargePlaceholder.tsx
@@ -1,20 +1,18 @@
 import { basename } from "@/lib/path-utils";
 import { formatBytes } from "@/lib/file-types";
-import { revealInFolder } from "@/lib/tauri-commands";
-import { warn } from "@/logger";
 
 interface Props {
   path: string;
   size?: number;
 }
 
+/**
+ * Pure metadata display for files that exceed the 10 MB read cap.
+ * All actions (reveal in folder) surface through the ViewerToolbar
+ * mounted by ViewerRouter — the body is content/metadata only.
+ */
 export function TooLargePlaceholder({ path, size }: Props) {
   const name = basename(path);
-  const handleReveal = () => {
-    void revealInFolder(path).catch((e) =>
-      warn(`revealInFolder failed: ${String(e)}`),
-    );
-  };
   return (
     <div className="too-large-placeholder">
       <p className="binary-filename">{name}</p>
@@ -22,14 +20,9 @@ export function TooLargePlaceholder({ path, size }: Props) {
         <p className="binary-size">{formatBytes(size)}</p>
       )}
       <p className="too-large-message">
-        File exceeds the 10 MB read cap. Reveal it in your file manager to open
-        it from there.
+        File exceeds the 10 MB read cap. Use the toolbar to reveal it in your
+        file manager.
       </p>
-      <div className="binary-actions">
-        <button type="button" onClick={handleReveal}>
-          Reveal in folder
-        </button>
-      </div>
     </div>
   );
 }

--- a/src/components/viewers/ViewerRouter.tsx
+++ b/src/components/viewers/ViewerRouter.tsx
@@ -3,11 +3,11 @@ import { useStore } from "@/store";
 import { useFileContent } from "@/hooks/useFileContent";
 import { SkeletonLoader } from "./SkeletonLoader";
 import { EnhancedViewer } from "./EnhancedViewer";
-import { ImageViewer } from "./ImageViewer";
+import { ImageViewerShell } from "./ImageViewerShell";
 import { AudioViewer, getAudioMime } from "./AudioViewer";
 import { VideoViewer, getVideoMime } from "./VideoViewer";
 import { PdfViewer } from "./PdfViewer";
-import { BinaryPlaceholder } from "./BinaryPlaceholder";
+import { BinaryViewerShell } from "./BinaryViewerShell";
 import { TooLargePlaceholder } from "./TooLargePlaceholder";
 import { DeletedFileViewer } from "./DeletedFileViewer";
 import { FileActionsBar } from "./FileActionsBar";
@@ -155,18 +155,7 @@ export function ViewerRouter({ path }: Props) {
   // mount a minimal `ViewerToolbar` (toggle hidden, no zoom) above each one
   // to surface the file-anchored "Comment on file" entry point universally.
   if (status === "image") {
-    return (
-      <div className="viewer-media-container">
-        <ViewerToolbar
-          activeView="visual"
-          onViewChange={() => {}}
-          hidden
-          onCommentOnFile={handleCommentOnFile}
-          trailing={<FileActionsBar path={path} />}
-        />
-        <ImageViewer key={path} path={path} />
-      </div>
-    );
+    return <ImageViewerShell key={path} path={path} onCommentOnFile={handleCommentOnFile} />;
   }
 
   if (status === "audio") {
@@ -222,6 +211,7 @@ export function ViewerRouter({ path }: Props) {
           onViewChange={() => {}}
           hidden
           onCommentOnFile={handleCommentOnFile}
+          trailing={<FileActionsBar path={path} />}
         />
         <TooLargePlaceholder key={path} path={path} size={sizeBytes} />
       </div>
@@ -229,6 +219,23 @@ export function ViewerRouter({ path }: Props) {
   }
 
   if (status === "binary") {
+    return <BinaryViewerShell key={path} path={path} size={sizeBytes} mtime={mtimeMs} onCommentOnFile={handleCommentOnFile} />;
+  }
+
+  if (status === "error") {
+    if (isGhost) {
+      return (
+        <div className="viewer-media-container">
+          <ViewerToolbar
+            activeView="visual"
+            onViewChange={() => {}}
+            hidden
+            onCommentOnFile={handleCommentOnFile}
+          />
+          <DeletedFileViewer key={path} filePath={path} />
+        </div>
+      );
+    }
     return (
       <div className="viewer-media-container">
         <ViewerToolbar
@@ -236,19 +243,11 @@ export function ViewerRouter({ path }: Props) {
           onViewChange={() => {}}
           hidden
           onCommentOnFile={handleCommentOnFile}
+          trailing={<FileActionsBar path={path} />}
         />
-        <BinaryPlaceholder key={path} path={path} size={sizeBytes} mtime={mtimeMs} />
-      </div>
-    );
-  }
-
-  if (status === "error") {
-    if (isGhost) {
-      return <DeletedFileViewer key={path} filePath={path} />;
-    }
-    return (
-      <div className="viewer-error">
-        Error loading file: {error}
+        <div className="viewer-error">
+          Error loading file: {error}
+        </div>
       </div>
     );
   }

--- a/src/components/viewers/ViewerRouter.tsx
+++ b/src/components/viewers/ViewerRouter.tsx
@@ -231,6 +231,17 @@ export function ViewerRouter({ path }: Props) {
             onViewChange={() => {}}
             hidden
             onCommentOnFile={handleCommentOnFile}
+            trailing={
+              <button
+                type="button"
+                className="viewer-toolbar-btn"
+                onClick={() => useStore.getState().toggleCommentsPane()}
+                aria-label="Show comments"
+                title="Show comments panel"
+              >
+                Show comments
+              </button>
+            }
           />
           <DeletedFileViewer key={path} filePath={path} />
         </div>

--- a/src/components/viewers/__tests__/BinaryPlaceholder.test.tsx
+++ b/src/components/viewers/__tests__/BinaryPlaceholder.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
 
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
@@ -11,35 +11,9 @@ vi.mock("@/lib/vm/use-comment-actions", () => ({
   useCommentActions: () => ({ addComment: vi.fn().mockResolvedValue(undefined) }),
 }));
 
-vi.mock("../HexView", () => ({
-  HexView: ({ path }: { path: string }) => (
-    <div data-testid="hex-view-mock" data-path={path}>HEX</div>
-  ),
-}));
-
-import { invoke } from "@tauri-apps/api/core";
 import { BinaryPlaceholder } from "../BinaryPlaceholder";
 
-const invokeMock = invoke as ReturnType<typeof vi.fn>;
-
-const writeText = vi.fn().mockResolvedValue(undefined);
-vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText }));
-
-beforeEach(() => {
-  invokeMock.mockClear();
-  invokeMock.mockResolvedValue(undefined);
-  writeText.mockClear();
-});
-
-describe("BinaryPlaceholder — Section E", () => {
-  it("renders the three action buttons", () => {
-    render(<BinaryPlaceholder path="/ws/sample.bin" size={512} />);
-    expect(screen.getByRole("button", { name: /reveal in folder/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /copy path/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /show as hex/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /open in default app/i })).not.toBeInTheDocument();
-  });
-
+describe("BinaryPlaceholder — pure metadata display", () => {
   it("renders the file name, MIME hint and human-readable size", () => {
     render(<BinaryPlaceholder path="/ws/song.mp3" size={2 * 1024 * 1024} />);
     expect(screen.getByText("song.mp3")).toBeInTheDocument();
@@ -52,47 +26,9 @@ describe("BinaryPlaceholder — Section E", () => {
     expect(screen.getByTestId("binary-icon-archive")).toBeInTheDocument();
   });
 
-  it("disables 'Show as hex' when size ≥ 1 MB", () => {
-    render(<BinaryPlaceholder path="/ws/big.bin" size={1024 * 1024} />);
-    expect(screen.getByRole("button", { name: /show as hex/i })).toBeDisabled();
-  });
-
-  it("disables 'Show as hex' when size is unknown", () => {
-    render(<BinaryPlaceholder path="/ws/unknown.bin" />);
-    expect(screen.getByRole("button", { name: /show as hex/i })).toBeDisabled();
-  });
-
-  it("enables 'Show as hex' when size < 1 MB", () => {
-    render(<BinaryPlaceholder path="/ws/tiny.bin" size={1024} />);
-    expect(screen.getByRole("button", { name: /show as hex/i })).toBeEnabled();
-  });
-
-  it("clicking 'Reveal in folder' invokes reveal_in_folder", () => {
-    render(<BinaryPlaceholder path="/ws/sample.bin" size={100} />);
-    fireEvent.click(screen.getByRole("button", { name: /reveal in folder/i }));
-    expect(invokeMock).toHaveBeenCalledWith("reveal_in_folder", { path: "/ws/sample.bin" });
-  });
-
-  it("clicking 'Copy path' delegates to the clipboard plugin", async () => {
-    const { findByRole } = render(<BinaryPlaceholder path="/ws/sample.bin" size={100} />);
-    fireEvent.click(await findByRole("button", { name: /copy path/i }));
-    // Two microtasks: dynamic import resolution + writeText invocation.
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith("/ws/sample.bin");
-    });
-  });
-
-  it("clicking 'Show as hex' switches to HexView", () => {
-    render(<BinaryPlaceholder path="/ws/sample.bin" size={100} />);
-    fireEvent.click(screen.getByRole("button", { name: /show as hex/i }));
-    expect(screen.getByTestId("hex-view-mock")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /reveal in folder/i })).not.toBeInTheDocument();
-  });
-
-  it("does not render inline comment UI (panel-only)", () => {
-    render(<BinaryPlaceholder path="/ws/sample.bin" size={100} />);
-    expect(screen.queryByRole("button", { name: /comment on this file/i })).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/comment on this file/i)).not.toBeInTheDocument();
+  it("does not render any action buttons — actions surface through BinaryViewerShell toolbar", () => {
+    render(<BinaryPlaceholder path="/ws/sample.bin" size={512} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("renders mtime row when mtime prop is present", () => {

--- a/src/components/viewers/__tests__/BinaryViewerShell.test.tsx
+++ b/src/components/viewers/__tests__/BinaryViewerShell.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@tauri-apps/api/core");
+vi.mock("@/logger");
+
+vi.mock("@/lib/vm/use-comments", () => ({
+  useComments: () => ({ threads: [], comments: [], loading: false, reload: () => {} }),
+}));
+vi.mock("@/lib/vm/use-comment-actions", () => ({
+  useCommentActions: () => ({ addComment: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock("@/hooks/useFileBadges", () => ({
+  useFileBadges: () => ({}),
+}));
+
+vi.mock("../HexView", () => ({
+  HexView: ({ path }: { path: string }) => (
+    <div data-testid="hex-view-mock" data-path={path}>HEX</div>
+  ),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { BinaryViewerShell } from "../BinaryViewerShell";
+
+const invokeMock = invoke as ReturnType<typeof vi.fn>;
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText }));
+
+beforeEach(() => {
+  invokeMock.mockClear();
+  invokeMock.mockResolvedValue(undefined);
+  writeText.mockClear();
+});
+
+describe("BinaryViewerShell", () => {
+  it("renders a ViewerToolbar with hex toggle, copy path, and FileActionsBar", () => {
+    render(<BinaryViewerShell path="/ws/sample.bin" size={512} />);
+    expect(screen.getByRole("toolbar")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show as hex/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy path/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reveal in folder/i })).toBeInTheDocument();
+  });
+
+  it("renders Comment on file button when onCommentOnFile is provided", () => {
+    const onCof = vi.fn();
+    render(<BinaryViewerShell path="/ws/sample.bin" size={512} onCommentOnFile={onCof} />);
+    const btn = screen.getByRole("button", { name: /comment on file/i });
+    fireEvent.click(btn);
+    expect(onCof).toHaveBeenCalledOnce();
+  });
+
+  it("clicking hex toggle switches to HexView", () => {
+    render(<BinaryViewerShell path="/ws/sample.bin" size={100} />);
+    fireEvent.click(screen.getByRole("button", { name: /show as hex/i }));
+    expect(screen.getByTestId("hex-view-mock")).toBeInTheDocument();
+  });
+
+  it("clicking hex toggle again switches back to metadata", () => {
+    render(<BinaryViewerShell path="/ws/sample.bin" size={100} />);
+    fireEvent.click(screen.getByRole("button", { name: /show as hex/i }));
+    expect(screen.getByTestId("hex-view-mock")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /back to metadata/i }));
+    expect(screen.queryByTestId("hex-view-mock")).not.toBeInTheDocument();
+    expect(screen.getByText("sample.bin")).toBeInTheDocument();
+  });
+
+  it("disables hex toggle when size ≥ 1 MB", () => {
+    render(<BinaryViewerShell path="/ws/big.bin" size={1024 * 1024} />);
+    expect(screen.getByRole("button", { name: /show as hex/i })).toBeDisabled();
+  });
+
+  it("disables hex toggle when size is unknown", () => {
+    render(<BinaryViewerShell path="/ws/unknown.bin" />);
+    expect(screen.getByRole("button", { name: /show as hex/i })).toBeDisabled();
+  });
+
+  it("clicking copy path delegates to the clipboard plugin", async () => {
+    render(<BinaryViewerShell path="/ws/sample.bin" size={100} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy path/i }));
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("/ws/sample.bin");
+    });
+  });
+
+  it("clicking reveal in folder invokes reveal_in_folder", () => {
+    render(<BinaryViewerShell path="/ws/sample.bin" size={100} />);
+    fireEvent.click(screen.getByRole("button", { name: /reveal in folder/i }));
+    expect(invokeMock).toHaveBeenCalledWith("reveal_in_folder", { path: "/ws/sample.bin" });
+  });
+});

--- a/src/components/viewers/__tests__/DeletedFileViewer.test.tsx
+++ b/src/components/viewers/__tests__/DeletedFileViewer.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { DeletedFileViewer } from "../DeletedFileViewer";
 import { useComments } from "@/lib/vm/use-comments";
+import { useStore } from "@/store";
 import type { MatchedComment, CommentThread as CommentThreadType } from "@/lib/tauri-commands";
 
 vi.mock("@tauri-apps/api/core");
@@ -116,5 +117,31 @@ describe("DeletedFileViewer", () => {
 
     render(<DeletedFileViewer filePath={FILE_PATH} />);
     expect(screen.getByText(/1 comment/)).toBeInTheDocument();
+  });
+
+  it("renders a 'Show comments' button when comments exist", () => {
+    const threads = [makeThread(makeComment("1", "Review comment"))];
+    const allComments = threads.flatMap(t => [t.root, ...t.replies]);
+    mockUseComments.mockReturnValue({ threads, comments: allComments, loading: false, reload: vi.fn() });
+
+    render(<DeletedFileViewer filePath={FILE_PATH} />);
+    expect(screen.getByRole("button", { name: /show comments/i })).toBeInTheDocument();
+  });
+
+  it("does not render 'Show comments' when there are no comments", () => {
+    render(<DeletedFileViewer filePath={FILE_PATH} />);
+    expect(screen.queryByRole("button", { name: /show comments/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Show comments' toggles the comments pane", () => {
+    const threads = [makeThread(makeComment("1", "Review comment"))];
+    const allComments = threads.flatMap(t => [t.root, ...t.replies]);
+    mockUseComments.mockReturnValue({ threads, comments: allComments, loading: false, reload: vi.fn() });
+    const spy = vi.spyOn(useStore.getState(), "toggleCommentsPane");
+
+    render(<DeletedFileViewer filePath={FILE_PATH} />);
+    fireEvent.click(screen.getByRole("button", { name: /show comments/i }));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/src/components/viewers/__tests__/DeletedFileViewer.test.tsx
+++ b/src/components/viewers/__tests__/DeletedFileViewer.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { DeletedFileViewer } from "../DeletedFileViewer";
 import { useComments } from "@/lib/vm/use-comments";
-import { useStore } from "@/store";
 import type { MatchedComment, CommentThread as CommentThreadType } from "@/lib/tauri-commands";
 
 vi.mock("@tauri-apps/api/core");
@@ -119,29 +118,12 @@ describe("DeletedFileViewer", () => {
     expect(screen.getByText(/1 comment/)).toBeInTheDocument();
   });
 
-  it("renders a 'Show comments' button when comments exist", () => {
+  it("does not render any action buttons — actions surface through ViewerRouter toolbar", () => {
     const threads = [makeThread(makeComment("1", "Review comment"))];
     const allComments = threads.flatMap(t => [t.root, ...t.replies]);
     mockUseComments.mockReturnValue({ threads, comments: allComments, loading: false, reload: vi.fn() });
 
     render(<DeletedFileViewer filePath={FILE_PATH} />);
-    expect(screen.getByRole("button", { name: /show comments/i })).toBeInTheDocument();
-  });
-
-  it("does not render 'Show comments' when there are no comments", () => {
-    render(<DeletedFileViewer filePath={FILE_PATH} />);
-    expect(screen.queryByRole("button", { name: /show comments/i })).not.toBeInTheDocument();
-  });
-
-  it("clicking 'Show comments' toggles the comments pane", () => {
-    const threads = [makeThread(makeComment("1", "Review comment"))];
-    const allComments = threads.flatMap(t => [t.root, ...t.replies]);
-    mockUseComments.mockReturnValue({ threads, comments: allComments, loading: false, reload: vi.fn() });
-    const spy = vi.spyOn(useStore.getState(), "toggleCommentsPane");
-
-    render(<DeletedFileViewer filePath={FILE_PATH} />);
-    fireEvent.click(screen.getByRole("button", { name: /show comments/i }));
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/src/components/viewers/__tests__/ImageViewer.test.tsx
+++ b/src/components/viewers/__tests__/ImageViewer.test.tsx
@@ -43,7 +43,7 @@ beforeEach(() => {
 
 describe("ImageViewer (existing behaviour)", () => {
   it("renders image with data URL after loading", async () => {
-    render(<ImageViewer path="/photos/test.png" />);
+    render(<ImageViewer path="/photos/test.png" zoom={1} fit={true} />);
     await waitFor(() => {
       const img = screen.getByRole("img");
       expect(img.getAttribute("src")).toContain("data:image/png;base64,");
@@ -51,24 +51,16 @@ describe("ImageViewer (existing behaviour)", () => {
     expect(readBinaryFile).toHaveBeenCalledWith("/photos/test.png");
   });
 
-  it("shows filename in header", async () => {
-    render(<ImageViewer path="/photos/test.png" />);
-    expect(screen.getByText("test.png")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByRole("img")).toBeInTheDocument();
-    });
-  });
-
   it("shows loading state initially", async () => {
     vi.mocked(readBinaryFile).mockReturnValue(new Promise(() => {}));
-    render(<ImageViewer path="/photos/test.png" />);
+    render(<ImageViewer path="/photos/test.png" zoom={1} fit={true} />);
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
     cleanup();
   });
 
   it("shows error for failed load", async () => {
     vi.mocked(readBinaryFile).mockRejectedValue(new Error("file_too_large"));
-    render(<ImageViewer path="/photos/huge.png" />);
+    render(<ImageViewer path="/photos/huge.png" zoom={1} fit={true} />);
     await waitFor(() => {
       expect(screen.getByText(/error/i)).toBeInTheDocument();
     });
@@ -76,13 +68,9 @@ describe("ImageViewer (existing behaviour)", () => {
 });
 
 describe("ImageViewer (R1)pointer capture, no window listeners", () => {
-  beforeEach(() => {
-    useStore.setState({ zoomByFiletype: { ".png": 2.0, ".image": 2.0 } });
-  });
-
   it("does NOT register window mouse/pointer move/up listeners on drag start", async () => {
     const winAdd = vi.spyOn(window, "addEventListener");
-    const { container } = render(<ImageViewer path="/photos/test.png" />);
+    const { container } = render(<ImageViewer path="/photos/test.png" zoom={2} fit={true} />);
     await waitFor(() => expect(screen.getByRole("img")).toBeInTheDocument());
     const canvas = container.querySelector(".image-viewer-canvas") as HTMLDivElement;
     canvas.setPointerCapture = vi.fn();
@@ -98,7 +86,7 @@ describe("ImageViewer (R1)pointer capture, no window listeners", () => {
   });
 
   it("calls setPointerCapture on pointerdown when zoomed > 1", async () => {
-    const { container } = render(<ImageViewer path="/photos/test.png" />);
+    const { container } = render(<ImageViewer path="/photos/test.png" zoom={2} fit={true} />);
     await waitFor(() => expect(screen.getByRole("img")).toBeInTheDocument());
     const canvas = container.querySelector(".image-viewer-canvas") as HTMLDivElement;
     const captureSpy = vi.fn();
@@ -111,7 +99,7 @@ describe("ImageViewer (R1)pointer capture, no window listeners", () => {
   });
 
   it("does not throw if unmounted mid-drag (no dangling window listeners)", async () => {
-    const { container, unmount } = render(<ImageViewer path="/photos/test.png" />);
+    const { container, unmount } = render(<ImageViewer path="/photos/test.png" zoom={2} fit={true} />);
     await waitFor(() => expect(screen.getByRole("img")).toBeInTheDocument());
     const canvas = container.querySelector(".image-viewer-canvas") as HTMLDivElement;
     canvas.setPointerCapture = vi.fn();

--- a/src/components/viewers/__tests__/ImageViewerShell.test.tsx
+++ b/src/components/viewers/__tests__/ImageViewerShell.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@tauri-apps/api/core");
+vi.mock("@/logger");
+
+vi.mock("@/hooks/useFileBadges", () => ({
+  useFileBadges: () => ({}),
+}));
+
+vi.mock("../ImageViewer", () => ({
+  ImageViewer: ({ path, zoom, fit }: { path: string; zoom: number; fit: boolean }) => (
+    <div data-testid="image-viewer" data-path={path} data-zoom={zoom} data-fit={String(fit)}>
+      ImageViewer
+    </div>
+  ),
+}));
+
+vi.mock("@/store", () => {
+  const state: Record<string, unknown> = {
+    toggleCommentsPane: vi.fn(),
+    zoomByFiletype: {} as Record<string, number>,
+    bumpZoom: () => {},
+    setZoom: () => {},
+  };
+  const useStore = (selector: (s: typeof state) => unknown) => selector(state);
+  (useStore as unknown as { getState: () => typeof state }).getState = () => state;
+  (useStore as unknown as { setState: (partial: Record<string, unknown>) => void }).setState = (partial: Record<string, unknown>) => {
+    Object.assign(state, partial);
+  };
+  return { useStore };
+});
+
+import { ImageViewerShell } from "../ImageViewerShell";
+import { useStore } from "@/store";
+
+beforeEach(() => {
+  useStore.setState({ zoomByFiletype: { ".image": 1.0 } });
+});
+
+describe("ImageViewerShell", () => {
+  it("renders a ViewerToolbar with zoom controls, fit toggle, and FileActionsBar", () => {
+    render(<ImageViewerShell path="/photos/test.png" />);
+    expect(screen.getByRole("toolbar")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /zoom in/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /zoom out/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /original size/i })).toBeInTheDocument();
+  });
+
+  it("renders Comment on file button when onCommentOnFile is provided", () => {
+    const onCof = vi.fn();
+    render(<ImageViewerShell path="/photos/test.png" onCommentOnFile={onCof} />);
+    const btn = screen.getByRole("button", { name: /comment on file/i });
+    fireEvent.click(btn);
+    expect(onCof).toHaveBeenCalledOnce();
+  });
+
+  it("toggles fit/original when button is clicked", () => {
+    render(<ImageViewerShell path="/photos/test.png" />);
+    const btn = screen.getByRole("button", { name: /original size/i });
+    fireEvent.click(btn);
+    expect(screen.getByRole("button", { name: /fit to view/i })).toBeInTheDocument();
+  });
+
+  it("passes zoom and fit props to ImageViewer", () => {
+    render(<ImageViewerShell path="/photos/test.png" />);
+    const viewer = screen.getByTestId("image-viewer");
+    expect(viewer.dataset.zoom).toBe("1");
+    expect(viewer.dataset.fit).toBe("true");
+  });
+
+  it("passes updated fit=false after toggle", () => {
+    render(<ImageViewerShell path="/photos/test.png" />);
+    fireEvent.click(screen.getByRole("button", { name: /original size/i }));
+    expect(screen.getByTestId("image-viewer").dataset.fit).toBe("false");
+  });
+});

--- a/src/components/viewers/__tests__/MermaidView.test.tsx
+++ b/src/components/viewers/__tests__/MermaidView.test.tsx
@@ -47,9 +47,19 @@ describe("MermaidView", () => {
     });
   });
 
-  it("provides export buttons", () => {
+  it("does not render custom toolbar — zoom and export surface through EnhancedViewer toolbar", () => {
     render(<MermaidView content="graph TD; A-->B;" />);
-    expect(screen.getByRole("button", { name: /png/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /svg/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /zoom out/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /zoom in/i })).not.toBeInTheDocument();
+    expect(document.querySelector(".mermaid-toolbar")).not.toBeInTheDocument();
+  });
+
+  it("accepts zoom prop and applies it to the diagram container", async () => {
+    const { container } = render(<MermaidView content="graph TD; A-->B;" zoom={1.5} />);
+    await waitFor(() => {
+      expect(screen.getByTitle("Mermaid diagram")).toBeInTheDocument();
+    });
+    const diagramDiv = container.querySelector("[title='Mermaid diagram']") as HTMLElement;
+    expect(diagramDiv.style.transform).toContain("scale(1.5)");
   });
 });

--- a/src/components/viewers/__tests__/TooLargePlaceholder.test.tsx
+++ b/src/components/viewers/__tests__/TooLargePlaceholder.test.tsx
@@ -1,20 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
 
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/logger");
 
-import { invoke } from "@tauri-apps/api/core";
 import { TooLargePlaceholder } from "../TooLargePlaceholder";
 
-const invokeMock = invoke as ReturnType<typeof vi.fn>;
-
-beforeEach(() => {
-  invokeMock.mockReset();
-  invokeMock.mockResolvedValue(undefined);
-});
-
-describe("TooLargePlaceholder — Section E", () => {
+describe("TooLargePlaceholder — pure metadata display", () => {
   it("renders the file name, the size, and the 10 MB cap message", () => {
     render(<TooLargePlaceholder path="/ws/huge.csv" size={42 * 1024 * 1024} />);
     expect(screen.getByText("huge.csv")).toBeInTheDocument();
@@ -22,19 +14,9 @@ describe("TooLargePlaceholder — Section E", () => {
     expect(screen.getByText(/exceeds the 10 MB read cap/i)).toBeInTheDocument();
   });
 
-  it("renders only the reveal-in-folder CTA (no hex toggle, no open-in-default)", () => {
+  it("renders no action buttons — actions surface through ViewerRouter toolbar", () => {
     render(<TooLargePlaceholder path="/ws/huge.csv" size={42 * 1024 * 1024} />);
-    const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(1);
-    expect(buttons[0]).toHaveAccessibleName(/reveal in folder/i);
-    expect(screen.queryByRole("button", { name: /show as hex/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /open in default app/i })).not.toBeInTheDocument();
-  });
-
-  it("clicking the CTA invokes reveal_in_folder", () => {
-    render(<TooLargePlaceholder path="/ws/huge.csv" size={42 * 1024 * 1024} />);
-    fireEvent.click(screen.getByRole("button", { name: /reveal in folder/i }));
-    expect(invokeMock).toHaveBeenCalledWith("reveal_in_folder", { path: "/ws/huge.csv" });
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("renders without a size when none is provided", () => {

--- a/src/components/viewers/__tests__/ViewerRouter.test.tsx
+++ b/src/components/viewers/__tests__/ViewerRouter.test.tsx
@@ -30,9 +30,14 @@ vi.mock("../EnhancedViewer", () => ({
   ),
 }));
 
-vi.mock("../ImageViewer", () => ({
-  ImageViewer: ({ path }: { path: string }) => (
-    <div data-testid="image-viewer" data-path={path}>ImageViewer</div>
+vi.mock("../ImageViewerShell", () => ({
+  ImageViewerShell: ({ path, onCommentOnFile }: { path: string; onCommentOnFile?: () => void }) => (
+    <div data-testid="image-viewer-shell" data-path={path} data-has-comment-on-file={onCommentOnFile ? "true" : "false"}>
+      ImageViewerShell
+      {onCommentOnFile && (
+        <button data-testid="image-shell-comment-btn" onClick={onCommentOnFile}>cof</button>
+      )}
+    </div>
   ),
 }));
 
@@ -56,9 +61,14 @@ vi.mock("../PdfViewer", () => ({
   ),
 }));
 
-vi.mock("../BinaryPlaceholder", () => ({
-  BinaryPlaceholder: ({ path, size }: { path: string; size?: number }) => (
-    <div data-testid="binary-placeholder" data-path={path} data-size={size}>BinaryPlaceholder</div>
+vi.mock("../BinaryViewerShell", () => ({
+  BinaryViewerShell: ({ path, size, onCommentOnFile }: { path: string; size?: number; onCommentOnFile?: () => void }) => (
+    <div data-testid="binary-viewer-shell" data-path={path} data-size={size} data-has-comment-on-file={onCommentOnFile ? "true" : "false"}>
+      BinaryViewerShell
+      {onCommentOnFile && (
+        <button data-testid="binary-shell-comment-btn" onClick={onCommentOnFile}>cof</button>
+      )}
+    </div>
   ),
 }));
 
@@ -113,11 +123,11 @@ describe("ViewerRouter routing", () => {
     expect(screen.getByTestId("enhanced-viewer")).toBeInTheDocument();
   });
 
-  it("image status routes to ImageViewer", () => {
+  it("image status routes to ImageViewerShell", () => {
     mockUseFileContent.mockReturnValue({ status: "image" });
     useStore.setState({ tabs: [{ path: "/photos/test.png", scrollTop: 0 }] });
     render(<ViewerRouter path="/photos/test.png" />);
-    expect(screen.getByTestId("image-viewer")).toBeInTheDocument();
+    expect(screen.getByTestId("image-viewer-shell")).toBeInTheDocument();
   });
 
   it("audio status routes to AudioViewer (#65 F1)", () => {
@@ -151,27 +161,27 @@ describe("ViewerRouter routing", () => {
     expect(screen.getByTestId("skeleton-loader")).toBeInTheDocument();
   });
 
-  it("binary status shows BinaryPlaceholder", () => {
+  it("binary status shows BinaryViewerShell", () => {
     mockUseFileContent.mockReturnValue({ status: "binary" });
     useStore.setState({ tabs: [{ path: "/docs/file.bin", scrollTop: 0 }] });
     render(<ViewerRouter path="/docs/file.bin" />);
-    expect(screen.getByTestId("binary-placeholder")).toBeInTheDocument();
+    expect(screen.getByTestId("binary-viewer-shell")).toBeInTheDocument();
   });
 
-  it("too_large status shows TooLargePlaceholder (not BinaryPlaceholder)", () => {
+  it("too_large status shows TooLargePlaceholder (not BinaryViewerShell)", () => {
     mockUseFileContent.mockReturnValue({ status: "too_large", sizeBytes: 11 * 1024 * 1024 });
     useStore.setState({ tabs: [{ path: "/data/huge.csv", scrollTop: 0 }] });
     render(<ViewerRouter path="/data/huge.csv" />);
     expect(screen.getByTestId("too-large-placeholder")).toBeInTheDocument();
-    expect(screen.queryByTestId("binary-placeholder")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("binary-viewer-shell")).not.toBeInTheDocument();
     expect(screen.getByTestId("too-large-placeholder").dataset.size).toBe(String(11 * 1024 * 1024));
   });
 
-  it("binary status forwards sizeBytes to BinaryPlaceholder", () => {
+  it("binary status forwards sizeBytes to BinaryViewerShell", () => {
     mockUseFileContent.mockReturnValue({ status: "binary", sizeBytes: 1234 });
     useStore.setState({ tabs: [{ path: "/docs/file.bin", scrollTop: 0 }] });
     render(<ViewerRouter path="/docs/file.bin" />);
-    expect(screen.getByTestId("binary-placeholder").dataset.size).toBe("1234");
+    expect(screen.getByTestId("binary-viewer-shell").dataset.size).toBe("1234");
   });
 
   it("error status shows error message", () => {
@@ -218,11 +228,12 @@ describe("ViewerRouter — onCommentOnFile is wired in every viewer branch", () 
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/r.md");
   });
 
-  it("image viewer surfaces a Comment-on-file button", () => {
+  it("image viewer passes onCommentOnFile to ImageViewerShell", () => {
     mockUseFileContent.mockReturnValue({ status: "image" });
     useStore.setState({ tabs: [{ path: "/x.png", scrollTop: 0 }], pendingFileLevelInputFor: null });
     render(<ViewerRouter path="/x.png" />);
-    fireEvent.click(expectCommentOnFileButton());
+    expect(screen.getByTestId("image-viewer-shell").dataset.hasCommentOnFile).toBe("true");
+    fireEvent.click(screen.getByTestId("image-shell-comment-btn"));
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/x.png");
   });
 
@@ -250,11 +261,12 @@ describe("ViewerRouter — onCommentOnFile is wired in every viewer branch", () 
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/d.pdf");
   });
 
-  it("binary placeholder surfaces a Comment-on-file button", () => {
+  it("binary viewer passes onCommentOnFile to BinaryViewerShell", () => {
     mockUseFileContent.mockReturnValue({ status: "binary" });
     useStore.setState({ tabs: [{ path: "/b.bin", scrollTop: 0 }], pendingFileLevelInputFor: null });
     render(<ViewerRouter path="/b.bin" />);
-    fireEvent.click(expectCommentOnFileButton());
+    expect(screen.getByTestId("binary-viewer-shell").dataset.hasCommentOnFile).toBe("true");
+    fireEvent.click(screen.getByTestId("binary-shell-comment-btn"));
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/b.bin");
   });
 
@@ -266,11 +278,12 @@ describe("ViewerRouter — onCommentOnFile is wired in every viewer branch", () 
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/big.csv");
   });
 
-  it("error branch (non-ghost) does NOT render the toolbar (no live file to anchor against)", () => {
+  it("error branch (non-ghost) renders a toolbar with Comment-on-file and FileActionsBar", () => {
     mockUseFileContent.mockReturnValue({ status: "error", error: "boom" });
-    useStore.setState({ tabs: [{ path: "/missing.md", scrollTop: 0 }] });
+    useStore.setState({ tabs: [{ path: "/missing.md", scrollTop: 0 }], pendingFileLevelInputFor: null });
     render(<ViewerRouter path="/missing.md" />);
-    expect(screen.queryByRole("button", { name: /comment on file/i })).toBeNull();
+    fireEvent.click(expectCommentOnFileButton());
+    expect(useStore.getState().pendingFileLevelInputFor).toBe("/missing.md");
   });
 });
 

--- a/src/components/viewers/__tests__/ViewerRouter.test.tsx
+++ b/src/components/viewers/__tests__/ViewerRouter.test.tsx
@@ -202,6 +202,16 @@ describe("ViewerRouter routing", () => {
     expect(screen.getByTestId("deleted-file-viewer")).toBeInTheDocument();
     expect(screen.queryByText(/Error loading file/)).not.toBeInTheDocument();
   });
+
+  it("ghost branch toolbar has 'Show comments' button", () => {
+    mockUseFileContent.mockReturnValue({ status: "error", error: "file not found" });
+    useStore.setState({
+      tabs: [{ path: "/gone.md", scrollTop: 0 }],
+      ghostEntries: [{ sidecarPath: "/gone.md.review.yaml", sourcePath: "/gone.md" }],
+    });
+    render(<ViewerRouter path="/gone.md" />);
+    expect(screen.getByRole("button", { name: /show comments/i })).toBeInTheDocument();
+  });
 });
 
 // ─── Iter 5 Group B: file-anchored entry point is universal ─────────────────


### PR DESCRIPTION
## Viewer toolbar consolidation

Implements #243  all viewers get ViewerToolbar, all actions surface through the toolbar.

### Approach
- Extract `ImageViewerShell` and `BinaryViewerShell` for Tier 3/4 viewers
- MermaidView: forwardRef + useImperativeHandle for export, shared useZoom
- Add ViewerToolbar to error and deleted states
- Move all action buttons from viewer body to toolbar trailing slot
- Clean up TooLargePlaceholder body actions

## Progress

- [x] Every viewer (all tiers including error and deleted states) renders a `ViewerToolbar`
- [x] Every `ViewerToolbar` has `onCommentOnFile` wired
- [x] `FileActionsBar` is in the toolbar `trailing` slot for all viewers where the file exists on disk
- [x] No viewer renders action buttons in its body  body is content/metadata only
- [x] MermaidView uses shared `useZoom`, not local `scale` state; Ctrl+=//0 works
- [x] MermaidView export buttons render in EnhancedViewer's toolbar, not a custom div
- [x] ImageViewer zoom and fit toggle render in the toolbar, not an internal header
- [x] BinaryPlaceholder hex toggle and copy-path render in the toolbar, not the body
- [x] TooLargePlaceholder has no action buttons in its body
- [x] All existing tests pass; new tests cover the toolbar presence for each fixed viewer
- [x] `docs/features/viewer-consistency.md` "Known gaps" section is cleared

Closes #243