### PR TITLE
fix: multi-window state contamination and duplicate folder bypass

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,10 +139,24 @@ fn register_window_folder(
     let canonical = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&folder))
         .map_err(|e| format!("invalid folder: {}", e))?;
     let display = folder_display_name(&canonical);
-    registry.update_kind(window.label(), registry::WindowKind::Folder(canonical));
-    let _ = window.set_title(&format!("mdownreview — {display}"));
-    log::info!("[window] {} registered folder: {display}", window.label());
-    Ok(())
+    match registry.try_claim_folder(window.label(), canonical.clone()) {
+        Ok(()) => {
+            let _ = window.set_title(&format!("mdownreview — {display}"));
+            log::info!("[window] {} registered folder: {display}", window.label());
+            Ok(())
+        }
+        Err(existing_label) => {
+            // Focus the window that already owns this folder
+            if let Some(existing_win) = window.app_handle().get_webview_window(&existing_label) {
+                focus_window(&existing_win);
+            }
+            log::info!(
+                "[window] {} tried to claim folder {display} already owned by {existing_label}",
+                window.label()
+            );
+            Err(format!("folder already open in window '{existing_label}'"))
+        }
+    }
 }
 
 #[tauri::command]
@@ -168,7 +182,7 @@ fn route_args_through_registry(
         return;
     };
     for folder in &args.folders {
-        let canonical = std::fs::canonicalize(folder)
+        let canonical = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(folder))
             .unwrap_or_else(|_| std::path::PathBuf::from(folder));
         match reg.route_folder(&canonical) {
             registry::RouteDecision::FocusExisting(label) => {
@@ -198,7 +212,7 @@ fn route_args_through_registry(
         }
     }
     for file in &args.files {
-        let canonical = std::fs::canonicalize(file)
+        let canonical = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(file))
             .unwrap_or_else(|_| std::path::PathBuf::from(file));
         match reg.route_file(&canonical) {
             registry::RouteDecision::AddToWindow { label, files } => {
@@ -309,29 +323,43 @@ pub fn run() {
             let cwd = std::env::current_dir().unwrap_or_default();
             let launch_args = parse_launch_args(&raw_args, &cwd);
 
-            // Register the default "main" window in the registry
+            // Register the default "main" window in the registry.
+            // Use canonicalize_no_verbatim consistently (not std::fs::canonicalize)
+            // to avoid \\?\ mismatches on Windows (issue #248).
             let reg = app.state::<registry::WindowRegistry>();
-            if let Some(first_folder) = launch_args.folders.first() {
-                let canonical = std::fs::canonicalize(first_folder)
-                    .unwrap_or_else(|_| std::path::PathBuf::from(first_folder));
-                reg.register("main".to_string(), registry::WindowKind::Folder(canonical));
+            let first_canonical = launch_args.folders.first().and_then(|f| {
+                crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(f)).ok()
+            });
+            if let Some(ref canonical) = first_canonical {
+                reg.register("main".to_string(), registry::WindowKind::Folder(canonical.clone()));
             } else {
                 reg.register("main".to_string(), registry::WindowKind::FileOnly);
             }
 
-            // Create additional windows for extra folders (beyond the first)
+            // Create additional windows for extra folders (beyond the first),
+            // deduplicating via route_folder() to enforce one-folder-one-window.
             let app_handle = app.handle().clone();
             for folder in launch_args.folders.iter().skip(1) {
-                let canonical = std::fs::canonicalize(folder)
-                    .unwrap_or_else(|_| std::path::PathBuf::from(folder));
-                let label = reg.next_label();
-                let display = folder_display_name(&canonical);
-                match create_app_window(&app_handle, &label, &format!("mdownreview — {display}")) {
-                    Ok(_) => {
-                        reg.register(label.clone(), registry::WindowKind::Folder(canonical.clone()));
-                        log::info!("[window] setup: created {label} for {}", canonical.display());
+                let canonical = match crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(folder)) {
+                    Ok(c) => c,
+                    Err(_) => std::path::PathBuf::from(folder),
+                };
+                match reg.route_folder(&canonical) {
+                    registry::RouteDecision::FocusExisting(label) => {
+                        log::info!("[window] setup: folder {} already open in {label}, skipping", canonical.display());
                     }
-                    Err(e) => log::error!("[window] setup: window for {} failed: {e}", canonical.display()),
+                    registry::RouteDecision::CreateFolder { path } => {
+                        let label = reg.next_label();
+                        let display = folder_display_name(&path);
+                        match create_app_window(&app_handle, &label, &format!("mdownreview — {display}")) {
+                            Ok(_) => {
+                                reg.register(label.clone(), registry::WindowKind::Folder(path.clone()));
+                                log::info!("[window] setup: created {label} for {}", path.display());
+                            }
+                            Err(e) => log::error!("[window] setup: window for {} failed: {e}", path.display()),
+                        }
+                    }
+                    _ => {}
                 }
             }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -139,6 +139,28 @@ impl WindowRegistry {
         }
     }
 
+    /// Atomically claim a folder for a window, enforcing one-folder-one-window.
+    ///
+    /// - If the folder is already owned by `label` → update in place, return `Ok`.
+    /// - If the folder is owned by a different window → return `Err(existing_label)`.
+    /// - Otherwise → update `label`'s kind to `Folder(path)`, return `Ok`.
+    pub fn try_claim_folder(&self, label: &str, path: PathBuf) -> Result<(), String> {
+        let mut entries = self.entries.lock().expect("registry lock poisoned");
+        // Check if another window already owns this folder
+        for entry in entries.iter() {
+            if let WindowKind::Folder(p) = &entry.kind {
+                if paths_equal(p, &path) && entry.label != label {
+                    return Err(entry.label.clone());
+                }
+            }
+        }
+        // Safe to claim — update this window's kind
+        if let Some(entry) = entries.iter_mut().find(|e| e.label == label) {
+            entry.kind = WindowKind::Folder(path);
+        }
+        Ok(())
+    }
+
     /// Remove a window by label.
     pub fn unregister(&self, label: &str) {
         let mut entries = self.entries.lock().expect("registry lock poisoned");
@@ -598,5 +620,73 @@ mod tests {
         let r2 = reg.drain_args("w2");
         assert_eq!(r1.files, vec!["/a.md".to_string()]);
         assert_eq!(r2.files, vec!["/b.md".to_string()]);
+    }
+
+    // ── try_claim_folder tests (issue #248) ────────────────────────────────
+
+    #[test]
+    fn try_claim_folder_succeeds_when_unclaimed() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".into(), WindowKind::FileOnly);
+        assert!(reg.try_claim_folder("w1", PathBuf::from("/projects/a")).is_ok());
+        assert_eq!(reg.find_by_folder(Path::new("/projects/a")), Some("w1".into()));
+    }
+
+    #[test]
+    fn try_claim_folder_allows_same_window_reclaim() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".into(), WindowKind::Folder(PathBuf::from("/projects/a")));
+        // Same window re-claiming same folder should succeed
+        assert!(reg.try_claim_folder("w1", PathBuf::from("/projects/a")).is_ok());
+    }
+
+    #[test]
+    fn try_claim_folder_allows_same_window_switch() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".into(), WindowKind::Folder(PathBuf::from("/projects/a")));
+        // Same window switching to a different folder should succeed
+        assert!(reg.try_claim_folder("w1", PathBuf::from("/projects/b")).is_ok());
+        assert_eq!(reg.find_by_folder(Path::new("/projects/b")), Some("w1".into()));
+        // Old folder should no longer be claimed
+        assert_eq!(reg.find_by_folder(Path::new("/projects/a")), None);
+    }
+
+    #[test]
+    fn try_claim_folder_rejects_duplicate() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".into(), WindowKind::Folder(PathBuf::from("/projects/a")));
+        reg.register("w2".into(), WindowKind::FileOnly);
+        // w2 trying to claim w1's folder should fail
+        let result = reg.try_claim_folder("w2", PathBuf::from("/projects/a"));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "w1");
+        // w1 should still own the folder
+        assert_eq!(reg.find_by_folder(Path::new("/projects/a")), Some("w1".into()));
+    }
+
+    #[test]
+    fn try_claim_folder_case_insensitive_on_windows() {
+        let reg = WindowRegistry::new();
+        reg.register("w1".into(), WindowKind::Folder(PathBuf::from("C:\\Projects\\App")));
+        reg.register("w2".into(), WindowKind::FileOnly);
+        if cfg!(windows) {
+            // Different case should still be detected as duplicate
+            let result = reg.try_claim_folder("w2", PathBuf::from("c:\\projects\\app"));
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn setup_dedup_via_route_folder() {
+        // Simulates the setup() path: registering "main" then routing extras
+        let reg = WindowRegistry::new();
+        let folder = PathBuf::from("/projects/a");
+        reg.register("main".into(), WindowKind::Folder(folder.clone()));
+
+        // Routing the same folder should return FocusExisting, not CreateFolder
+        match reg.route_folder(&folder) {
+            RouteDecision::FocusExisting(label) => assert_eq!(label, "main"),
+            other => panic!("expected FocusExisting, got {other:?}"),
+        }
     }
 }

--- a/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
+++ b/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
@@ -35,6 +35,22 @@ describe("useCrossWindowPrefsSync", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not sync per-window layout state (folderPaneWidth, commentsPaneVisible)", () => {
+    useStore.setState({ folderPaneWidth: 240, commentsPaneVisible: true });
+    renderHook(() => useCrossWindowPrefsSync());
+
+    act(() => {
+      fireStorageEvent(
+        "mdownreview-ui",
+        payload({ folderPaneWidth: 400, commentsPaneVisible: false }),
+      );
+    });
+
+    // Per-window layout state must NOT be synced (issue #248)
+    expect(useStore.getState().folderPaneWidth).toBe(240);
+    expect(useStore.getState().commentsPaneVisible).toBe(true);
+  });
+
   it("updates global prefs when a storage event fires with the persist key", () => {
     renderHook(() => useCrossWindowPrefsSync());
 

--- a/src/hooks/__tests__/useDialogActions.test.ts
+++ b/src/hooks/__tests__/useDialogActions.test.ts
@@ -69,6 +69,37 @@ describe("useDialogActions", () => {
     expect(registerWindowFolder).toHaveBeenCalledWith("/test/folder");
   });
 
+  it("handleOpenFolder calls registerWindowFolder before setRoot", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(registerWindowFolder).mockImplementation(async () => {
+      callOrder.push("register");
+    });
+    vi.mocked(showOpenDialog).mockResolvedValue("/test/folder");
+    const origSetRoot = useStore.getState().setRoot;
+    const setRootSpy = vi.fn(async (root: string | null) => {
+      callOrder.push("setRoot");
+      await origSetRoot(root);
+    });
+    useStore.setState({ setRoot: setRootSpy });
+
+    const { result } = renderHook(() => useDialogActions());
+    await act(async () => { await result.current.handleOpenFolder(); });
+
+    expect(callOrder).toEqual(["register", "setRoot"]);
+    expect(registerWindowFolder).toHaveBeenCalledWith("/test/folder");
+  });
+
+  it("handleOpenFolder does not set root when registerWindowFolder rejects", async () => {
+    vi.mocked(registerWindowFolder).mockRejectedValue(
+      new Error("folder already open in window 'w1'")
+    );
+    vi.mocked(showOpenDialog).mockResolvedValue("/test/folder");
+    const { result } = renderHook(() => useDialogActions());
+    await act(async () => { await result.current.handleOpenFolder(); });
+    // Root should remain null — registration was rejected
+    expect(useStore.getState().root).toBeNull();
+  });
+
   it("cancelled dialog (null) is no-op", async () => {
     vi.mocked(showOpenDialog).mockResolvedValue(null);
     const { result } = renderHook(() => useDialogActions());

--- a/src/hooks/useCrossWindowPrefsSync.ts
+++ b/src/hooks/useCrossWindowPrefsSync.ts
@@ -23,8 +23,9 @@ export function useCrossWindowPrefsSync(): void {
         const state = parsed?.state;
         if (!state) return;
 
-        // Apply only the keys that `partialize` persists (global prefs).
-        // Per-window state (tabs, expandedFolders, root…) is never touched.
+        // Apply only global prefs — NOT per-window layout state.
+        // folderPaneWidth, commentsPaneVisible, showSidecarFiles are persisted
+        // as defaults for new windows but never synced cross-window (issue #248).
         useStore.setState({
           ...(state.theme !== undefined && { theme: state.theme }),
           ...(state.authorName !== undefined && {
@@ -38,12 +39,6 @@ export function useCrossWindowPrefsSync(): void {
           }),
           ...(state.readingWidth !== undefined && {
             readingWidth: state.readingWidth,
-          }),
-          ...(state.folderPaneWidth !== undefined && {
-            folderPaneWidth: state.folderPaneWidth,
-          }),
-          ...(state.commentsPaneVisible !== undefined && {
-            commentsPaneVisible: state.commentsPaneVisible,
           }),
           ...(state.zoomByFiletype !== undefined && {
             zoomByFiletype: state.zoomByFiletype,

--- a/src/hooks/useDialogActions.ts
+++ b/src/hooks/useDialogActions.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
 import { showOpenDialog, registerWindowFolder } from "@/lib/tauri-commands";
-import { warn } from "@/logger";
 import { useStore } from "@/store";
 
 export function useDialogActions() {
@@ -29,14 +28,14 @@ export function useDialogActions() {
     try {
       const selected = await showOpenDialog({ directory: true, multiple: false });
       if (typeof selected === "string") {
+        // Register with the Rust registry first — if the folder is already
+        // open in another window, this rejects and we must not switch root.
+        await registerWindowFolder(selected);
         await setRoot(selected);
         addRecentItem(selected, "folder");
-        registerWindowFolder(selected).catch((err) =>
-          warn(`[useDialogActions] register_window_folder failed: ${err}`)
-        );
       }
     } catch {
-      // User cancelled or dialog error
+      // User cancelled, dialog error, or folder already open in another window
     }
   }, [setRoot, addRecentItem]);
 


### PR DESCRIPTION
## Fix: multi-window state contamination and duplicate folder bypass

Closes #248

## Changes

### Per-window state isolation (UX contamination fix)
- Removed `folderPaneWidth` and `commentsPaneVisible` from `useCrossWindowPrefsSync`  these are per-window layout state, not global prefs
- They remain in `partialize` as sensible defaults for new windows, but changes no longer propagate to other windows
- `showSidecarFiles` was already missing from sync (now explicitly documented as per-window)

### One-folder-one-window enforcement
- Added `WindowRegistry::try_claim_folder()`  atomic duplicate check under one lock (no TOCTOU)
- `register_window_folder` now rejects + focuses existing window when folder is already open
- `useDialogActions.handleOpenFolder` inverted: `registerWindowFolder` before `setRoot` so UI doesn't mutate on rejection
- `setup()` now uses `route_folder()` to deduplicate startup folder args

### Consistent path normalization
- All registry paths now use `canonicalize_no_verbatim` (not `std::fs::canonicalize`) to avoid `\\?\` prefix mismatches on Windows

## Requirements

- [x] `folderPaneWidth` changes in one window do NOT propagate to other windows
- [x] `commentsPaneVisible` toggle in one window does NOT affect other windows
- [x] `showSidecarFiles` toggle in one window does NOT affect other windows
- [x] `register_window_folder` rejects (or focuses existing) when folder is already open in another window
- [x] `setup()` startup with duplicate folder args deduplicates (uses `route_folder()`)
- [x] Registry unit test: `register_window_folder` rejects duplicate folder
- [x] Registry unit test: `setup` deduplicates folder args
- [x] Remove `folderPaneWidth`, `commentsPaneVisible`, `showSidecarFiles` from `useCrossWindowPrefsSync`
- [x] Keep these fields persisted as new-window defaults but not cross-window synced
- [ ] Browser E2E or native E2E test verifying per-window state isolation

## Tests added
- **Registry (Rust):** 6 new tests for `try_claim_folder`  unclaimed, reclaim, switch, duplicate rejection, case-insensitive, route_folder dedup
- **useCrossWindowPrefsSync:** test that `folderPaneWidth`/`commentsPaneVisible` are NOT synced
- **useDialogActions:** test register-before-setRoot ordering + rejection prevents root change