### PR TITLE
fix: multi-window expert review  remaining bugs and test gaps

### DIFF
--- a/e2e/native/06-mrsf-config-reload.spec.ts
+++ b/e2e/native/06-mrsf-config-reload.spec.ts
@@ -33,48 +33,58 @@ test.describe("Native .mrsf.yaml config reload (full-stack watcher)", () => {
         "sidecar_root: .reviews\n",
       );
 
-      // Poll for .mrsf.yaml config to be picked up by the watcher by
-      // attempting add_comment and checking the result location. This
-      // replaces the previous fixed-sleep approach.
+      // Phase 1: Poll `get_sidecar_config` until the watcher picks up
+      // .mrsf.yaml. This is deterministic (IPC query to the config cache)
+      // and avoids relying on filesystem side-effects that are
+      // timing-sensitive on slow CI runners.
+      const MAX_CONFIG_POLLS = 60; // 60 × 500ms = 30s budget
+      let configDetected = false;
+      for (let i = 0; i < MAX_CONFIG_POLLS; i++) {
+        await nativePage.waitForTimeout(500);
+        const result = await nativePage.evaluate((root: string) => {
+          // @ts-ignore — Tauri internals
+          return window.__TAURI_INTERNALS__.invoke("get_sidecar_config", { root });
+        }, tmpDir);
+        if (result && (result as { enabled: boolean }).enabled) {
+          configDetected = true;
+          break;
+        }
+      }
+      expect(
+        configDetected,
+        "get_sidecar_config should report enabled=true after watcher reloads .mrsf.yaml",
+      ).toBe(true);
+
+      // Phase 2: Config is confirmed loaded — verify add_comment writes
+      // the sidecar into .reviews/.
       const reviewsDir = path.join(tmpDir, ".reviews");
       const sidecarPath = path.join(reviewsDir, "readme.md.review.yaml");
       const colocated = path.join(tmpDir, "readme.md.review.yaml");
 
-      let found = false;
-      for (let attempt = 0; attempt < 20; attempt++) {
-        // Clean up any prior attempt artifacts
-        if (fs.existsSync(colocated)) fs.unlinkSync(colocated);
-        if (fs.existsSync(sidecarPath)) fs.unlinkSync(sidecarPath);
+      // Clean up any artifacts from Phase 1 probes (get_sidecar_config
+      // doesn't write, but be safe).
+      if (fs.existsSync(colocated)) fs.unlinkSync(colocated);
+      if (fs.existsSync(sidecarPath)) fs.unlinkSync(sidecarPath);
 
-        await nativePage.waitForTimeout(500);
+      await nativePage.evaluate((fp: string) => {
+        // @ts-ignore — Tauri internals
+        return window.__TAURI_INTERNALS__.invoke("add_comment", {
+          filePath: fp,
+          author: "e2e-test",
+          text: "Comment under sidecar_root",
+          anchor: null,
+          commentType: null,
+          severity: null,
+          document: null,
+        });
+      }, docFile);
 
-        // Try adding a comment — the sidecar should land in .reviews/
-        await nativePage.evaluate((fp: string) => {
-          // @ts-ignore — Tauri internals
-          return window.__TAURI_INTERNALS__.invoke("add_comment", {
-            filePath: fp,
-            author: "e2e-test",
-            text: "Comment under sidecar_root",
-            anchor: null,
-            commentType: null,
-            severity: null,
-            document: null,
-          });
-        }, docFile);
-
-        // Give the write a moment to flush
-        await nativePage.waitForTimeout(200);
-
-        if (fs.existsSync(sidecarPath)) {
-          found = true;
-          break;
-        }
-      }
+      // Give the write a moment to flush
+      await nativePage.waitForTimeout(500);
 
       // Verify: sidecar landed in .reviews/ directory
-      expect(found, `sidecar should exist at ${sidecarPath} within 10s`).toBe(true);
+      expect(fs.existsSync(sidecarPath), `sidecar should exist at ${sidecarPath}`).toBe(true);
       expect(fs.existsSync(reviewsDir)).toBe(true);
-      expect(fs.existsSync(sidecarPath)).toBe(true);
 
       // Verify co-located sidecar was NOT created
       expect(

--- a/src-tauri/src/commands/file_viewer_prefs.rs
+++ b/src-tauri/src/commands/file_viewer_prefs.rs
@@ -127,7 +127,7 @@ pub fn set_pref_at(
 
 #[tauri::command]
 pub fn get_file_viewer_pref(app: AppHandle, path: String) -> Option<FileViewerPref> {
-    let canonical = match std::fs::canonicalize(&path) {
+    let canonical = match crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&path)) {
         Ok(c) => c,
         Err(_) => return None,
     };
@@ -145,7 +145,8 @@ pub fn set_file_viewer_pref(
     path: String,
     allow_images: bool,
 ) -> Result<(), String> {
-    let canonical = std::fs::canonicalize(&path).map_err(|e| e.to_string())?;
+    let canonical = crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&path))
+        .map_err(|e| e.to_string())?;
     let key = hash_path(&canonical);
     let mut prefs = load_prefs(&app);
     prefs.entries.insert(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -352,8 +352,13 @@ pub fn run() {
                         let label = reg.next_label();
                         let display = folder_display_name(&path);
                         match create_app_window(&app_handle, &label, &format!("mdownreview — {display}")) {
-                            Ok(_) => {
+                            Ok(new_win) => {
                                 reg.register(label.clone(), registry::WindowKind::Folder(path.clone()));
+                                reg.push_args(&label, LaunchArgs {
+                                    folders: vec![path.to_string_lossy().into_owned()],
+                                    files: vec![],
+                                });
+                                let _ = new_win.emit("args-received", ());
                                 log::info!("[window] setup: created {label} for {}", path.display());
                             }
                             Err(e) => log::error!("[window] setup: window for {} failed: {e}", path.display()),

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -132,7 +132,11 @@ impl WindowRegistry {
     }
 
     /// Update the kind of an existing window entry.
-    pub fn update_kind(&self, label: &str, kind: WindowKind) {
+    ///
+    /// NOTE: This does NOT enforce one-folder-one-window. Use
+    /// `try_claim_folder` for folder claims. This is only safe for
+    /// downgrading to `FileOnly` (e.g. `unregister_window_folder`).
+    pub(crate) fn update_kind(&self, label: &str, kind: WindowKind) {
         let mut entries = self.entries.lock().expect("registry lock poisoned");
         if let Some(entry) = entries.iter_mut().find(|e| e.label == label) {
             entry.kind = kind;
@@ -143,6 +147,7 @@ impl WindowRegistry {
     ///
     /// - If the folder is already owned by `label` → update in place, return `Ok`.
     /// - If the folder is owned by a different window → return `Err(existing_label)`.
+    /// - If `label` is not registered → return `Err("window not registered")`.
     /// - Otherwise → update `label`'s kind to `Folder(path)`, return `Ok`.
     pub fn try_claim_folder(&self, label: &str, path: PathBuf) -> Result<(), String> {
         let mut entries = self.entries.lock().expect("registry lock poisoned");
@@ -154,11 +159,13 @@ impl WindowRegistry {
                 }
             }
         }
-        // Safe to claim — update this window's kind
+        // Find and update this window's kind
         if let Some(entry) = entries.iter_mut().find(|e| e.label == label) {
             entry.kind = WindowKind::Folder(path);
+            Ok(())
+        } else {
+            Err("window not registered".to_string())
         }
-        Ok(())
     }
 
     /// Remove a window by label.
@@ -688,5 +695,16 @@ mod tests {
             RouteDecision::FocusExisting(label) => assert_eq!(label, "main"),
             other => panic!("expected FocusExisting, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn try_claim_folder_rejects_unregistered_label() {
+        let reg = WindowRegistry::new();
+        // Label "ghost" was never registered
+        let result = reg.try_claim_folder("ghost", PathBuf::from("/projects/a"));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "window not registered");
+        // Folder should NOT be claimed
+        assert_eq!(reg.find_by_folder(Path::new("/projects/a")), None);
     }
 }

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -111,7 +111,7 @@ pub async fn install_update(app: AppHandle) -> Result<(), String> {
                     content_length,
                     chunk_length,
                 };
-                let _ = app_handle.emit_to("main", "update-progress", payload);
+                let _ = Emitter::emit(&app_handle, "update-progress", payload);
             },
             move || {
                 let payload = UpdateProgressEvent {
@@ -119,7 +119,7 @@ pub async fn install_update(app: AppHandle) -> Result<(), String> {
                     content_length: None,
                     chunk_length: 0,
                 };
-                let _ = app_finish.emit_to("main", "update-progress", payload);
+                let _ = Emitter::emit(&app_finish, "update-progress", payload);
             },
         )
         .await

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { basename } from "@/lib/path-utils";
 import { IconFile, IconFolder, IconComment } from "@/components/Icons";
 import "@/styles/app.css";
 import "@/styles/print.css";
+import { unregisterWindowFolder } from "@/lib/tauri-commands";
 
 export default function App() {
   const {
@@ -72,6 +73,13 @@ export default function App() {
   const dragRef= useRef<{ startX: number; startWidth: number } | null>(null);
 
   const { handleOpenFile, handleOpenFolder } = useDialogActions();
+
+  // Shared close-folder handler: resets store root AND unregisters from
+  // the Rust WindowRegistry so the folder can be re-opened elsewhere.
+  const handleCloseFolder = useCallback(() => {
+    useStore.getState().closeFolder();
+    unregisterWindowFolder().catch(() => {});
+  }, []);
 
   // F1 — Ctrl/Cmd+Shift+M: trigger the existing selection-toolbar add-
   // comment path. We dispatch a real bubbling `mouseup` from the end of
@@ -197,7 +205,7 @@ export default function App() {
           {root !== null && (
             <>
               <ErrorBoundary>
-                <FolderTree onFileOpen={openFile} onCloseFolder={() => useStore.getState().closeFolder()} />
+                <FolderTree onFileOpen={openFile} onCloseFolder={handleCloseFolder} />
               </ErrorBoundary>
               <div className="drag-handle" onMouseDown={onDragStart} />
             </>

--- a/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
+++ b/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
@@ -51,6 +51,48 @@ describe("useCrossWindowPrefsSync", () => {
     expect(useStore.getState().commentsPaneVisible).toBe(true);
   });
 
+  it("does not sync showSidecarFiles (per-window preference)", () => {
+    useStore.setState({ showSidecarFiles: false });
+    renderHook(() => useCrossWindowPrefsSync());
+
+    act(() => {
+      fireStorageEvent(
+        "mdownreview-ui",
+        payload({ showSidecarFiles: true }),
+      );
+    });
+
+    expect(useStore.getState().showSidecarFiles).toBe(false);
+  });
+
+  it("syncs readingWidth across windows", () => {
+    useStore.setState({ readingWidth: 720 });
+    renderHook(() => useCrossWindowPrefsSync());
+
+    act(() => {
+      fireStorageEvent(
+        "mdownreview-ui",
+        payload({ readingWidth: 1200 }),
+      );
+    });
+
+    expect(useStore.getState().readingWidth).toBe(1200);
+  });
+
+  it("syncs zoomByFiletype across windows", () => {
+    useStore.setState({ zoomByFiletype: {} });
+    renderHook(() => useCrossWindowPrefsSync());
+
+    act(() => {
+      fireStorageEvent(
+        "mdownreview-ui",
+        payload({ zoomByFiletype: { ".md": 1.5 } }),
+      );
+    });
+
+    expect(useStore.getState().zoomByFiletype).toEqual({ ".md": 1.5 });
+  });
+
   it("updates global prefs when a storage event fires with the persist key", () => {
     renderHook(() => useCrossWindowPrefsSync());
 

--- a/src/hooks/__tests__/useFolderChildren.test.ts
+++ b/src/hooks/__tests__/useFolderChildren.test.ts
@@ -216,4 +216,44 @@ describe("useFolderChildren folder-changed listener", () => {
 
     expect(unlisten).toHaveBeenCalled();
   });
+
+  it("discards stale folder-changed readDir results after root change", async () => {
+    // Simulate: rootA is loaded, folder-changed fires for rootA, then root
+    // switches to rootB before the readDir resolves. The stale result for
+    // rootA must be discarded.
+    const entriesA = [{ name: "a.md", path: "/rootA/a.md", is_dir: false }];
+    const staleRefresh = [{ name: "stale.md", path: "/rootA/stale.md", is_dir: false }];
+    const entriesB = [{ name: "b.md", path: "/rootB/b.md", is_dir: false }];
+
+    let resolveStale!: (v: ReadDirResult) => void;
+    const stalePromise = new Promise<ReadDirResult>((r) => { resolveStale = r; });
+
+    vi.mocked(commands.readDir)
+      .mockResolvedValueOnce(wrapEntries(entriesA))  // initial rootA load
+      .mockReturnValueOnce(stalePromise as never)     // folder-changed readDir (slow)
+      .mockResolvedValueOnce(wrapEntries(entriesB));  // rootB load
+
+    // Mount with rootA — loads & caches entriesA
+    const { result, rerender } = renderHook(
+      ({ root }) => useFolderChildren(root),
+      { initialProps: { root: "/rootA" as string | null } },
+    );
+    await act(async () => {});
+    expect(result.current.childrenCache["/rootA"]?.entries).toEqual(entriesA);
+
+    // Fire folder-changed for rootA — starts the slow readDir
+    const cb = getFolderChangedCallback();
+    await act(async () => { cb({ path: "/rootA" }); });
+
+    // Switch root to rootB — clears cache, sets cancelled flag
+    rerender({ root: "/rootB" });
+    await act(async () => {});
+    expect(result.current.childrenCache["/rootB"]?.entries).toEqual(entriesB);
+
+    // Now the stale readDir resolves — must be discarded
+    await act(async () => { resolveStale(wrapEntries(staleRefresh)); });
+
+    // rootA's stale result should NOT appear in the cache
+    expect(result.current.childrenCache["/rootA"]).toBeUndefined();
+  });
 });

--- a/src/hooks/__tests__/useMenuListeners.test.ts
+++ b/src/hooks/__tests__/useMenuListeners.test.ts
@@ -13,6 +13,11 @@ vi.mock("@/lib/tauri-events", () => ({
   }),
 }));
 
+const mockUnregisterWindowFolder = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/tauri-commands", () => ({
+  unregisterWindowFolder: (...args: unknown[]) => mockUnregisterWindowFolder(...args),
+}));
+
 vi.mock("@/logger", () => ({
   error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn(),
 }));
@@ -94,6 +99,15 @@ describe("useMenuListeners", () => {
     renderHook(() => useMenuListeners(callbacks));
     listeners.get("menu-check-updates")?.();
     expect(callbacks.checkForUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("menu-close-folder calls closeFolder and unregisterWindowFolder", () => {
+    const closeFolder = vi.fn();
+    useStore.setState({ closeFolder });
+    renderHook(() => useMenuListeners(callbacks));
+    listeners.get("menu-close-folder")?.();
+    expect(closeFolder).toHaveBeenCalledOnce();
+    expect(mockUnregisterWindowFolder).toHaveBeenCalledOnce();
   });
 
   it("dispatches openSettings on menu-help-settings event", () => {

--- a/src/hooks/useDialogActions.ts
+++ b/src/hooks/useDialogActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { showOpenDialog, registerWindowFolder } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
 import { useStore } from "@/store";
 
 export function useDialogActions() {
@@ -34,8 +35,11 @@ export function useDialogActions() {
         await setRoot(selected);
         addRecentItem(selected, "folder");
       }
-    } catch {
-      // User cancelled, dialog error, or folder already open in another window
+    } catch (err) {
+      // Distinguish registry rejection from user cancellation
+      if (err && typeof err === "string" && err.includes("already open")) {
+        warn(`[useDialogActions] folder already open in another window`);
+      }
     }
   }, [setRoot, addRecentItem]);
 

--- a/src/hooks/useFileWatcher.ts
+++ b/src/hooks/useFileWatcher.ts
@@ -78,20 +78,25 @@ export function useFileWatcher() {
     };
   }, [debouncedScan]);
 
-  // Scan for ghost entries when workspace root changes
+  // Scan for ghost entries when workspace root changes.
+  // A `cancelled` flag guards against stale responses after rapid root
+  // switches (issue #250).
   useEffect(() => {
     if (!root) {
       setGhostEntries([]);
       return;
     }
+    let cancelled = false;
     scanReviewFiles(root)
-      .then((pairs) =>
+      .then((pairs) => {
+        if (cancelled) return;
         setGhostEntries(
           pairs.map(([sidecarPath, sourcePath]) => ({ sidecarPath, sourcePath }))
-        )
-      )
+        );
+      })
       .catch((err) =>
         warn(`[useFileWatcher] failed to scan review files: ${err}`)
       );
+    return () => { cancelled = true; };
   }, [root, setGhostEntries]);
 }

--- a/src/hooks/useFolderChildren.ts
+++ b/src/hooks/useFolderChildren.ts
@@ -53,27 +53,32 @@ export function useFolderChildren(root: string | null) {
   // Refresh cached entries when Rust reports a folder change. We only refresh
   // dirs we already have in the cache — unknown dirs would be loaded lazily
   // on expand. Reads the cache via ref so the listener doesn't re-subscribe
-  // on every cache mutation.
+  // on every cache mutation. A `cancelled` ref guards against stale async
+  // responses after root changes (issue #250).
+  const cancelledRef = useRef(false);
   useEffect(() => {
+    cancelledRef.current = false;
     const unlisten = listenEvent("folder-changed", ({ path }) => {
       if (childrenCacheRef.current[path] === undefined) return;
       readDir(path, undefined, showSidecarFilesRef.current || undefined)
-        .then((result) =>
+        .then((result) => {
+          if (cancelledRef.current) return;
           setChildrenCache((prev) => {
             const value: CachedDir = { entries: result.entries, hasMore: result.has_more, total: result.total };
             const next = { ...prev, [path]: value };
             childrenCacheRef.current = next;
             return next;
-          })
-        )
+          });
+        })
         .catch((err) =>
           warn(`[useFolderChildren] folder-changed refresh failed: ${err}`)
         );
     });
     return () => {
+      cancelledRef.current = true;
       unlisten.then((fn) => fn()).catch(() => {});
     };
-  }, []);
+  }, [root]);
 
   return { childrenCache, loadChildren };
 }

--- a/src/hooks/useFolderChildren.ts
+++ b/src/hooks/useFolderChildren.ts
@@ -53,16 +53,16 @@ export function useFolderChildren(root: string | null) {
   // Refresh cached entries when Rust reports a folder change. We only refresh
   // dirs we already have in the cache — unknown dirs would be loaded lazily
   // on expand. Reads the cache via ref so the listener doesn't re-subscribe
-  // on every cache mutation. A `cancelled` ref guards against stale async
+  // on every cache mutation. A generation counter guards against stale async
   // responses after root changes (issue #250).
-  const cancelledRef = useRef(false);
+  const generationRef = useRef(0);
   useEffect(() => {
-    cancelledRef.current = false;
+    const gen = ++generationRef.current;
     const unlisten = listenEvent("folder-changed", ({ path }) => {
       if (childrenCacheRef.current[path] === undefined) return;
       readDir(path, undefined, showSidecarFilesRef.current || undefined)
         .then((result) => {
-          if (cancelledRef.current) return;
+          if (generationRef.current !== gen) return;
           setChildrenCache((prev) => {
             const value: CachedDir = { entries: result.entries, hasMore: result.has_more, total: result.total };
             const next = { ...prev, [path]: value };
@@ -75,7 +75,6 @@ export function useFolderChildren(root: string | null) {
         );
     });
     return () => {
-      cancelledRef.current = true;
       unlisten.then((fn) => fn()).catch(() => {});
     };
   }, [root]);

--- a/src/store/launchArgs.ts
+++ b/src/store/launchArgs.ts
@@ -22,15 +22,21 @@ export async function openFilesFromArgs(
   folders: string[],
   store: ReturnType<typeof useStore.getState>,
 ): Promise<void> {
-  // Last folder wins (spec requirement)
+  // Last folder wins (spec requirement).
+  // Confirm registration with the Rust registry (the Rust setup/router
+  // already claimed the folder — this re-confirms and updates the title).
+  // If it fails (e.g., folder already open), log but still set root since
+  // the Rust side already routed this folder to this window.
   if (folders.length > 0) {
     const lastFolder = folders[folders.length - 1];
     const canonicalFolder = await canonicalizeOrFallback(lastFolder);
     await store.setRoot(canonicalFolder);
     store.addRecentItem(canonicalFolder, "folder");
-    registerWindowFolder(canonicalFolder).catch((err) =>
-      warn(`[launchArgs] register_window_folder failed: ${err}`)
-    );
+    try {
+      await registerWindowFolder(canonicalFolder);
+    } catch (err) {
+      warn(`[launchArgs] register_window_folder failed: ${err}`);
+    }
   }
   const alreadyOpen = new Set(store.tabs.map((t) => t.path));
   // Deduplicate incoming files


### PR DESCRIPTION
## Fix: multi-window expert review  remaining bugs and test gaps

Closes #250

Based on `feature/issue-248-multiwindow-state-isolation` (PR #249).

## Bug fixes (11 items from expert review)

### Critical/High
1. **FolderTree close button**  now calls `unregisterWindowFolder` via shared `handleCloseFolder` (was stale registry)
2. **`setup()` extra windows**  now get `push_args` + `args-received` signal (were opening blank)
3. **Update progress events**  now broadcast to all windows via `Emitter::emit` (was `emit_to("main")` only)

### Medium
4. **`useFolderChildren`**  generation counter guards stale `readDir` results on root switch
5. **`useFileWatcher`**  `cancelled` flag guards stale ghost scan on root switch
6. **`try_claim_folder`**  returns `Err("window not registered")` for unknown labels (was silent `Ok`)
7. **`openFilesFromArgs`**  now `await`s `registerWindowFolder` (was fire-and-forget)
8. **`useDialogActions`**  logs warning on folder-already-open rejection (was silent catch)

### Low
9. **`file_viewer_prefs.rs`**  IPC commands use `canonicalize_no_verbatim` (was `std::fs::canonicalize`)
10. **`update_kind`**  restricted to `pub(crate)` with safety doc
11. **`comments-changed`**  confirmed intentionally app-wide (frontend filters by `file_path`)

## Tests added
- `showSidecarFiles` NOT synced cross-window
- `readingWidth` and `zoomByFiletype` ARE synced cross-window
- `try_claim_folder_rejects_unregistered_label` (Rust)
- `menu-close-folder` asserts `closeFolder` + `unregisterWindowFolder`
- Stale `readDir` cancellation via generation counter

## Expert re-review results
- **Architect**: All 8 issues FIXED 
- **React/Tauri**: All 7 issues FIXED 
- **Test**: 5/7 gaps ADDRESSED, 2 remaining added 