### PR TITLE
fix: remove zoom from persistence/sync and guard cross-window ping-pong

### DIFF
--- a/.claude/merge-pr-loop/runs/merge-loop-20260428T184754Z/loop.md
+++ b/.claude/merge-pr-loop/runs/merge-loop-20260428T184754Z/loop.md
@@ -1,0 +1,47 @@
+# merge-pr-loop  merge-loop-20260428T184754Z
+
+
+## PR 1  #241
+- Started: 2026-04-28T18:48:00Z   Finished: 2026-04-28T19:10:00Z   Duration: 0:22
+- Branch: feature/issue-240-sidecar-root-ux   PR: https://github.com/dryotta/mdownreview/pull/241
+- Outcome: Merged
+- Release-gate runs: 25071490712 (fail  cache infra), 25071841923 (pass), 25072356831 (pass  post-rebase)
+- Forward-fix attempts: 0/5
+- Final commit: d9d685f (squashed into main as 79ab1a1)
+- Block reason: n/a
+
+## PR 2  #246
+- Started: 2026-04-28T19:40:00Z   Finished: 2026-04-28T19:57:00Z   Duration: 0:17
+- Branch: feature/issue-243-viewer-toolbar-consolidation   PR: https://github.com/dryotta/mdownreview/pull/246
+- Outcome: Merged
+- Release-gate runs: 25073574497 (pass), 25074083434 (pass — post-rebase)
+- Forward-fix attempts: 0/5
+- Final commit: 5fe8251 (squashed into main)
+- Block reason: n/a
+
+## PR 3  #247
+- Started: 2026-04-28T20:07:00Z   Finished: 2026-04-28T20:21:00Z   Duration: 0:14
+- Branch: fix/badge-count-cap   PR: https://github.com/dryotta/mdownreview/pull/247
+- Outcome: Merged
+- Release-gate runs: 25074861849 (pass)
+- Forward-fix attempts: 0/5
+- Final commit: 1c9a81d (squashed into main)
+- Block reason: n/a
+
+## PR 4  #249
+- Started: 2026-04-28T20:23:00Z   Finished: 2026-04-28T20:48:00Z   Duration: 0:25
+- Branch: feature/issue-248-multiwindow-state-isolation   PR: https://github.com/dryotta/mdownreview/pull/249
+- Outcome: Merged
+- Release-gate runs: 25075490875 (pass), 25076139895 (pass  post-rebase)
+- Forward-fix attempts: 0/5
+- Final commit: 253c4f5 (squashed into main)
+- Block reason: n/a
+
+## PR 5  #251
+- Started: 2026-04-28T21:00:00Z   Finished: 2026-04-28T21:40:00Z   Duration: 0:40
+- Branch: feature/issue-250-multiwindow-expert-fixes   PR: https://github.com/dryotta/mdownreview/pull/251
+- Outcome: Merged
+- Release-gate runs: 25077367737 (fail  native E2E), 25078318202 (pass  after forward-fix)
+- Forward-fix attempts: 1/5
+- Final commit: 2114b0d (squashed into main)
+- Block reason: n/a

--- a/src/components/viewers/MermaidView.tsx
+++ b/src/components/viewers/MermaidView.tsx
@@ -125,7 +125,7 @@ export const MermaidView = forwardRef<MermaidViewHandle, Props>(function Mermaid
       const line = mapNodeToSourceLine(n, lines);
       if (line !== null) n.setAttribute("data-source-line", String(line));
     }
-  }, [svg, content, zoom, filePath]);
+  }, [svg, content, filePath]);
 
   const handleExportSvg = useCallback(() => {
     if (!svg) return;

--- a/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
+++ b/src/hooks/__tests__/useCrossWindowPrefsSync.test.ts
@@ -79,7 +79,7 @@ describe("useCrossWindowPrefsSync", () => {
     expect(useStore.getState().readingWidth).toBe(1200);
   });
 
-  it("syncs zoomByFiletype across windows", () => {
+  it("does not sync zoomByFiletype (per-window session-only state)", () => {
     useStore.setState({ zoomByFiletype: {} });
     renderHook(() => useCrossWindowPrefsSync());
 
@@ -90,7 +90,7 @@ describe("useCrossWindowPrefsSync", () => {
       );
     });
 
-    expect(useStore.getState().zoomByFiletype).toEqual({ ".md": 1.5 });
+    expect(useStore.getState().zoomByFiletype).toEqual({});
   });
 
   it("updates global prefs when a storage event fires with the persist key", () => {
@@ -105,6 +105,23 @@ describe("useCrossWindowPrefsSync", () => {
 
     expect(useStore.getState().theme).toBe("dark");
     expect(useStore.getState().authorName).toBe("Alice");
+  });
+
+  it("skips setState when incoming values match current state (ping-pong guard)", () => {
+    useStore.setState({ theme: "dark", authorName: "Alice" });
+    renderHook(() => useCrossWindowPrefsSync());
+    const spy = vi.spyOn(useStore, "setState");
+
+    act(() => {
+      fireStorageEvent(
+        "mdownreview-ui",
+        payload({ theme: "dark", authorName: "Alice" }),
+      );
+    });
+
+    // setState should NOT be called when values haven't changed
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it("ignores storage events for unrelated keys", () => {

--- a/src/hooks/useCrossWindowPrefsSync.ts
+++ b/src/hooks/useCrossWindowPrefsSync.ts
@@ -11,6 +11,13 @@ const PERSIST_KEY = "mdownreview-ui";
  * `localStorage.setItem` is called, so any prefs change made in one
  * window (theme, author, recents …) propagates live to every other
  * open window without IPC.
+ *
+ * **Equality guard:** each incoming field is compared to its current
+ * value before being included in the `setState` patch.  Without this,
+ * every `setState` call triggers the persist middleware to write ALL
+ * partialize'd fields (including per-window ones like `folderPaneWidth`)
+ * back to localStorage, which fires a `storage` event in the *other*
+ * window, creating an infinite ping-pong loop.
  */
 export function useCrossWindowPrefsSync(): void {
   useEffect(() => {
@@ -26,24 +33,33 @@ export function useCrossWindowPrefsSync(): void {
         // Apply only global prefs — NOT per-window layout state.
         // folderPaneWidth, commentsPaneVisible, showSidecarFiles are persisted
         // as defaults for new windows but never synced cross-window (issue #248).
-        useStore.setState({
-          ...(state.theme !== undefined && { theme: state.theme }),
-          ...(state.authorName !== undefined && {
-            authorName: state.authorName,
-          }),
-          ...(state.recentItems !== undefined && {
-            recentItems: state.recentItems,
-          }),
-          ...(state.updateChannel !== undefined && {
-            updateChannel: state.updateChannel,
-          }),
-          ...(state.readingWidth !== undefined && {
-            readingWidth: state.readingWidth,
-          }),
-          ...(state.zoomByFiletype !== undefined && {
-            zoomByFiletype: state.zoomByFiletype,
-          }),
-        });
+        // zoomByFiletype is session-only (not persisted or synced).
+        //
+        // Equality guard: only include fields whose value actually changed to
+        // avoid a persist → storage-event → persist ping-pong between windows.
+        const cur = useStore.getState();
+        const patch: Record<string, unknown> = {};
+
+        if (state.theme !== undefined && state.theme !== cur.theme) {
+          patch.theme = state.theme;
+        }
+        if (state.authorName !== undefined && state.authorName !== cur.authorName) {
+          patch.authorName = state.authorName;
+        }
+        if (state.updateChannel !== undefined && state.updateChannel !== cur.updateChannel) {
+          patch.updateChannel = state.updateChannel;
+        }
+        if (state.readingWidth !== undefined && state.readingWidth !== cur.readingWidth) {
+          patch.readingWidth = state.readingWidth;
+        }
+        if (state.recentItems !== undefined &&
+            JSON.stringify(state.recentItems) !== JSON.stringify(cur.recentItems)) {
+          patch.recentItems = state.recentItems;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          useStore.setState(patch);
+        }
       } catch {
         // Malformed storage value — ignore silently.
       }

--- a/src/store/__tests__/viewerPrefs.test.ts
+++ b/src/store/__tests__/viewerPrefs.test.ts
@@ -6,8 +6,10 @@
  *   1. `setZoom` clamps to [ZOOM_MIN, ZOOM_MAX] and rejects non-finite values.
  *   2. `bumpZoom` is the single mutation chokepoint (in/out/reset) and is
  *      itself clamped.
- *   3. The persistence allowlist (`partialize`) includes `zoomByFiletype`
- *      but NOT `allowedRemoteImageDocs` — trust decisions are session-only.
+ *   3. The persistence allowlist (`partialize`) excludes BOTH
+ *      `allowedRemoteImageDocs` (session-only trust) AND `zoomByFiletype`
+ *      (per-window session-only — persisting/syncing causes storage-event
+ *      ping-pong between windows).
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { useStore } from "@/store";
@@ -122,8 +124,8 @@ describe("viewerPrefs persistence allowlist", () => {
   // Crude but stable: extract the partialize body and string-match keys.
   const partializeBody = storeIndex.match(/partialize:\s*\(state\)\s*=>\s*\(\{([\s\S]*?)\}\)/)?.[1] ?? "";
 
-  it("includes zoomByFiletype (persisted)", () => {
-    expect(partializeBody).toMatch(/zoomByFiletype:\s*state\.zoomByFiletype/);
+  it("excludes zoomByFiletype (session-only — persisting causes ping-pong)", () => {
+    expect(partializeBody).not.toMatch(/zoomByFiletype/);
   });
 
   it("excludes allowedRemoteImageDocs (session-only trust)", () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -205,8 +205,9 @@ export const useStore = create<Store>()(
       // ViewerPrefs (delegated to ./viewerPrefs.ts).
       // - `allowedRemoteImageDocs` is intentionally NOT in `partialize` below:
       //   trust decisions must not silently survive an app restart.
-      // - `zoomByFiletype` IS persisted (small bounded map, one entry per
-      //   filetype key) — see partialize.
+      // - `zoomByFiletype` is intentionally NOT in `partialize`: zoom is
+      //   per-window session-only state (persisting/syncing it causes a
+      //   storage-event ping-pong loop between windows).
       ...createViewerPrefsSlice(set, get),
 
       // TabHistory (delegated to ./tabHistory.ts) — per-window back/forward.
@@ -349,7 +350,6 @@ export const useStore = create<Store>()(
         readingWidth: state.readingWidth,
         recentItems: state.recentItems,
         updateChannel: state.updateChannel,
-        zoomByFiletype: state.zoomByFiletype,
         showSidecarFiles: state.showSidecarFiles,
       }),
     }

--- a/src/store/viewerPrefs.ts
+++ b/src/store/viewerPrefs.ts
@@ -7,10 +7,10 @@
  *      A1). NEVER persisted: trust decisions must not silently survive an
  *      app restart, and the per-path map would bloat the persisted snapshot.
  *
- *   2. `zoomByFiletype` — per-filetype zoom level (#65 D1/D2/D3). PERSISTED
- *      via the `partialize` allowlist in `src/store/index.ts`. Bounded to a
- *      handful of small numeric entries (one per filetype key, ~10 max), so
- *      it does not bloat persistence.
+ *   2. `zoomByFiletype` — per-filetype zoom level (#65 D1/D2/D3). NOT
+ *      persisted: zoom is per-window, session-only state that must not
+ *      survive app restart or sync across windows (causes storage-event
+ *      ping-pong between windows).
  *
  * Composed into the combined store in `src/store/index.ts`. Follows the
  * extraction pattern of `src/store/tabs.ts`.


### PR DESCRIPTION
## Fix: zoom infinite loop and cross-window storage ping-pong

### Problem

Multi-window zoom caused an infinite loop of zoom levels. Two root causes:

1. `zoomByFiletype` was persisted and synced cross-window. Window A zooms, persist writes localStorage, Window B receives storage event, applies via setState, persist writes back (new object reference), Window A receives event — infinite loop.

2. Broader ping-pong in `useCrossWindowPrefsSync`. Even for legitimately synced fields (theme, author, etc.), every setState call triggers the persist middleware to write ALL partialize'd fields — including per-window ones like folderPaneWidth — back to localStorage. When two windows have different per-window values, this creates an infinite storage-event ping-pong.

### Fix

1. **Zoom removed from persistence and cross-window sync.** `zoomByFiletype` removed from partialize allowlist and useCrossWindowPrefsSync. Zoom is per-window, session-only state.

2. **Equality guard added to useCrossWindowPrefsSync.** Each incoming field is compared to its current store value before inclusion in the setState patch. If nothing actually changed, setState is skipped entirely — breaking the ping-pong cycle.

3. **Spurious zoom dep removed from MermaidView layout effect** — the source-line walk doesn't use zoom.

### Tests

- zoomByFiletype excluded from partialize (was: included)
- zoomByFiletype not synced cross-window (new)
- Ping-pong guard: setState skipped when incoming values match current state (new)
- All 29 affected tests pass

### Files changed

| File | Change |
|---|---|
| src/store/index.ts | Remove zoomByFiletype from partialize, update comment |
| src/store/viewerPrefs.ts | Update doc comment (NOT persisted) |
| src/store/__tests__/viewerPrefs.test.ts | Assert zoom excluded from persist |
| src/hooks/useCrossWindowPrefsSync.ts | Remove zoom sync, add equality guards |
| src/hooks/__tests__/useCrossWindowPrefsSync.test.ts | Add zoom exclusion + ping-pong guard tests |
| src/components/viewers/MermaidView.tsx | Remove spurious zoom dep from layout effect |
