### PR TITLE
fix: readDir show_sidecars parameter never reached Rust

### DIFF
--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -93,7 +93,7 @@ export interface ReadDirResult {
 }
 
 export const readDir = (path: string, limit?: number, showSidecars?: boolean): Promise<ReadDirResult> =>
-  invoke<ReadDirResult>("read_dir", { path, limit: limit ?? null, showSidecars: showSidecars ?? null });
+  invoke<ReadDirResult>("read_dir", { path, limit: limit ?? null, show_sidecars: showSidecars ?? null });
 
 export const getLaunchArgs = (): Promise<LaunchArgs> =>
   invoke<LaunchArgs>("get_launch_args");


### PR DESCRIPTION
The frontend sent showSidecars (camelCase) but the Rust read_dir command expects show_sidecars (snake_case). Without rename_all on the command, the parameter was silently ignored - the Show sidecar files toggle in the config dialog never had any effect. One-line fix in tauri-commands.ts.