### PR TITLE
fix: add JS fallback for Ctrl+Shift+N new-window shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,22 @@ fn create_app_window(
         .build()
 }
 
+/// IPC-callable new-window command — fallback for platforms where the native
+/// menu accelerator (Ctrl+Shift+N) is swallowed by the webview runtime.
+#[tauri::command]
+fn create_new_window(
+    app: tauri::AppHandle,
+    registry: tauri::State<'_, registry::WindowRegistry>,
+) -> Result<(), String> {
+    let new_label = registry.next_label();
+    create_app_window(&app, &new_label, "mdownreview")
+        .map(|_| {
+            registry.register(new_label.clone(), registry::WindowKind::FileOnly);
+            log::info!("[window] create_new_window: created {new_label}");
+        })
+        .map_err(|e| format!("failed to create window: {e}"))
+}
+
 #[tauri::command]
 fn register_window_folder(
     window: tauri::Window,
@@ -514,6 +530,7 @@ pub fn run() {
                 update::install_update,
                 register_window_folder,
                 unregister_window_folder,
+                create_new_window,
                 $($extra),*
             ]
         };

--- a/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -92,6 +92,16 @@ describe("useGlobalShortcuts", () => {
     expect(callbacks.toggleCommentsPane).toHaveBeenCalledOnce();
   });
 
+  it("Ctrl+Shift+N calls createNewWindow and prevents default", async () => {
+    const cmds = await import("@/lib/tauri-commands");
+    const spy = vi.spyOn(cmds, "createNewWindow").mockResolvedValue(undefined);
+    renderHook(() => useGlobalShortcuts(callbacks));
+    const ev = fire({ key: "N", shift: true });
+    expect(ev.defaultPrevented).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
   it("Ctrl+W closes the active tab", () => {
     renderHook(() => useGlobalShortcuts(callbacks));
     fire({ key: "w" });

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useStore } from "@/store";
 import { getFiletypeKey, getFileCategory, getDefaultView } from "@/lib/file-types";
+import { createNewWindow } from "@/lib/tauri-commands";
 
 interface ShortcutCallbacks {
   handleOpenFile: () => void;
@@ -137,6 +138,13 @@ export function useGlobalShortcuts({
       if (e.shiftKey && e.key === "C") {
         e.preventDefault();
         toggleCommentsPane();
+        return;
+      }
+      // Ctrl/Cmd+Shift+N — new window. JS fallback because WebView2 on
+      // Windows swallows this accelerator before the native menu sees it.
+      if (e.shiftKey && e.key === "N") {
+        e.preventDefault();
+        createNewWindow();
         return;
       }
       // F1 — Ctrl/Cmd+Shift+M starts a comment on the current selection.

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -465,3 +465,7 @@ export const registerWindowFolder = (folder: string): Promise<void> =>
 export const unregisterWindowFolder = (): Promise<void> =>
   invoke<void>("unregister_window_folder");
 
+/** Create a new empty window (JS fallback for Ctrl+Shift+N). */
+export const createNewWindow = (): Promise<void> =>
+  invoke<void>("create_new_window");
+


### PR DESCRIPTION
## Problem

Ctrl+Shift+N (New Window) did not work on Windows. WebView2 (Chromium) swallows the keystroke before Tauri native menu accelerator sees it.

Other Ctrl+Shift shortcuts (O, C, W, M) worked because they had JavaScript fallback handlers in useGlobalShortcuts.ts. Ctrl+Shift+N relied solely on the native menu accelerator.

## Fix

1. Rust: New create_new_window IPC command that creates a window via the existing create_app_window helper + registers it in the WindowRegistry
2. TS wrapper: createNewWindow() typed invoke wrapper in tauri-commands.ts
3. JS shortcut: Ctrl+Shift+N handler in useGlobalShortcuts.ts that calls createNewWindow() with preventDefault()
4. Test: Verifies the shortcut fires and prevents default

## Testing

- 35/35 useGlobalShortcuts tests pass (including new test)
- Frontend build clean (tsc + vite)
- Rust build clean
- Manual test: Ctrl+Shift+N opens a new window