### PR TITLE
fix(folder-tree): show-sidecars toggle no longer blanks the pane

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -114,15 +114,20 @@ pub fn read_dir_inner(
             e.to_string()
         })?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        if !show && is_sidecar_file(&name) {
+        // Sidecar file filter — gate on is_file so a directory whose name
+        // ends in `.review.yaml` (legal on every FS) is never mistaken
+        // for a sidecar file.
+        if !show && !meta.is_dir() && is_sidecar_file(&name) {
             continue;
         }
-        // Hide the sidecar_root directory when it overlaps the workspace tree
-        if !show {
-            if let Some(ref hide) = hide_dir_name {
-                if name == *hide && meta.is_dir() {
-                    continue;
-                }
+        // AC10: hide the sidecar_root directory whenever a redirect is
+        // configured. The "Show sidecar files in folder pane" toggle
+        // surfaces sibling .review.{yaml,json} files in their natural
+        // location — it must NOT also expose the internal sidecar storage
+        // tree. Keep these contracts decoupled.
+        if let Some(ref hide) = hide_dir_name {
+            if name == *hide && meta.is_dir() {
+                continue;
             }
         }
 

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -452,6 +452,93 @@ fn read_dir_hides_sidecar_root_dir() {
     );
 }
 
+/// `read_dir` with `show_sidecars=true` surfaces `.review.yaml` /
+/// `.review.json` files in their natural location so users can inspect
+/// the raw metadata when desired.
+#[test]
+fn read_dir_shows_review_sidecars_when_show_true() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("readme.md"), "hello").unwrap();
+    std::fs::write(
+        dir.path().join("readme.md.review.yaml"),
+        "mrsf_version: '1.0'\ndocument: readme.md\ncomments: []\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("main.rs.review.json"),
+        r#"{"mrsf_version":"1.0","document":"main.rs","comments":[]}"#,
+    )
+    .unwrap();
+
+    let state = SidecarConfigState::new();
+    let result =
+        read_dir_inner(dir.path().to_str().unwrap().to_string(), None, Some(true), &state)
+            .unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+
+    assert!(names.contains(&"readme.md"));
+    assert!(
+        names.contains(&"readme.md.review.yaml"),
+        "YAML sidecars must be visible when show_sidecars=true"
+    );
+    assert!(
+        names.contains(&"main.rs.review.json"),
+        "JSON sidecars must be visible when show_sidecars=true"
+    );
+}
+
+/// AC10 contract is independent of the user-facing show-sidecars toggle:
+/// the internal `sidecar_root` directory must remain hidden even when
+/// the user opts to surface co-located sidecar files.
+#[test]
+fn read_dir_hides_sidecar_root_dir_even_when_show_true() {
+    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
+
+    let dir = tempfile::tempdir().unwrap();
+    let ws = dir.path();
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    std::fs::write(ws.join("readme.md"), "hello").unwrap();
+    std::fs::create_dir(ws.join(".reviews")).unwrap();
+
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_ws, Some(std::path::PathBuf::from(".reviews")));
+
+    let result =
+        read_dir_inner(ws.to_str().unwrap().to_string(), None, Some(true), &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        !names.contains(&".reviews"),
+        "AC10: sidecar_root dir must remain hidden even when show_sidecars=true"
+    );
+    assert!(names.contains(&"readme.md"));
+}
+
+/// A directory whose name happens to end in `.review.yaml` (legal on
+/// every FS) must NOT be filtered out by the sidecar file rule, which
+/// only applies to files.
+#[test]
+fn read_dir_does_not_hide_directory_with_sidecar_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("notes.review.yaml")).unwrap();
+    std::fs::create_dir(dir.path().join("data.review.json")).unwrap();
+    std::fs::write(dir.path().join("readme.md"), "hello").unwrap();
+
+    let state = SidecarConfigState::new();
+    let result = read_dir_inner(dir.path().to_str().unwrap().to_string(), None, None, &state)
+        .unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+
+    assert!(
+        names.contains(&"notes.review.yaml"),
+        "directories ending in .review.yaml must not be filtered as sidecar files"
+    );
+    assert!(
+        names.contains(&"data.review.json"),
+        "directories ending in .review.json must not be filtered as sidecar files"
+    );
+    assert!(names.contains(&"readme.md"));
+}
+
 // ── FileChangeEvent serialization ─────────────────────────────────────────
 
 #[test]

--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -232,11 +232,17 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   ) => {
     const isActive = activeTabPath === path;
     const expanded = opts.isDir ? expandedFolders[path] : undefined;
+    const isSidecar =
+      !opts.isDir && (name.endsWith(".review.yaml") || name.endsWith(".review.json"));
     return (
       <div
         key={path}
         data-path={path}
-        className={`tree-entry${isActive ? " active" : ""}${opts.isGhost ? " tree-entry--ghost" : ""}`}
+        className={
+          `tree-entry${isActive ? " active" : ""}` +
+          `${opts.isGhost ? " tree-entry--ghost" : ""}` +
+          `${isSidecar ? " tree-entry--sidecar" : ""}`
+        }
         tabIndex={0}
         role={opts.isDir ? "treeitem" : "option"}
         aria-selected={isActive}

--- a/src/hooks/__tests__/useFolderChildren.test.ts
+++ b/src/hooks/__tests__/useFolderChildren.test.ts
@@ -17,8 +17,13 @@ vi.mock("@/logger", () => ({
   trace: vi.fn(),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
+  // Reset Zustand store fields the hook reads — tests share the global
+  // store so leaked expandedFolders / showSidecarFiles would skew the
+  // per-test readDir call counts.
+  const { useStore } = await import("@/store");
+  useStore.setState({ expandedFolders: {}, showSidecarFiles: false });
 });
 
 /** Wrap DirEntry[] in the ReadDirResult shape returned by the Rust command. */
@@ -108,6 +113,61 @@ describe("useFolderChildren", () => {
       entries = await result.current.loadChildren("/other");
     });
     expect(entries).toEqual([]);
+  });
+
+  it("reloads root + expanded folders when showSidecarFiles toggles", async () => {
+    // Reproduces the "blank pane after toggle" + "default mismatch on
+    // persist rehydrate" bugs: when showSidecarFiles flips, the cache
+    // must be cleared AND every visible folder must be re-fetched with
+    // the new filter. Previously the load short-circuited on the stale
+    // cached entries and the tree rendered empty.
+    const { useStore } = await import("@/store");
+    useStore.setState({ expandedFolders: { "/root/sub": true } });
+
+    const rootHidden = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
+    const subHidden = [{ name: "x.md", path: "/root/sub/x.md", is_dir: false }];
+    const rootShown = [
+      { name: "a.md", path: "/root/a.md", is_dir: false },
+      { name: "a.md.review.yaml", path: "/root/a.md.review.yaml", is_dir: false },
+    ];
+    const subShown = [
+      { name: "x.md", path: "/root/sub/x.md", is_dir: false },
+      { name: "x.md.review.yaml", path: "/root/sub/x.md.review.yaml", is_dir: false },
+    ];
+    vi.mocked(commands.readDir)
+      .mockResolvedValueOnce(wrapEntries(rootHidden)) // initial root (hidden)
+      .mockResolvedValueOnce(wrapEntries(subHidden))  // expanded sub (hidden)
+      .mockResolvedValueOnce(wrapEntries(rootShown))  // root reload after toggle
+      .mockResolvedValueOnce(wrapEntries(subShown));  // sub reload after toggle
+
+    useStore.setState({ showSidecarFiles: false });
+    const { result } = renderHook(() => useFolderChildren("/root"));
+    await act(async () => {});
+
+    // Trigger the expanded-sub fetch the same way the FolderTree would
+    await act(async () => {
+      await result.current.loadChildren("/root/sub");
+    });
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(rootHidden);
+    expect(result.current.childrenCache["/root/sub"]?.entries).toEqual(subHidden);
+
+    // Flip the toggle — the hook must wipe the cache AND re-fetch root +
+    // every currently-expanded folder with show_sidecars=true.
+    await act(async () => {
+      useStore.setState({ showSidecarFiles: true });
+    });
+
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(rootShown);
+    expect(result.current.childrenCache["/root/sub"]?.entries).toEqual(subShown);
+
+    // Verify the IPC was called with the new filter for both folders.
+    const calls = vi.mocked(commands.readDir).mock.calls;
+    const reloadCalls = calls.slice(2);
+    const reloadedPaths = reloadCalls.map((c) => c[0]).sort();
+    expect(reloadedPaths).toEqual(["/root", "/root/sub"]);
+    for (const c of reloadCalls) {
+      expect(c[2]).toBe(true); // show_sidecars
+    }
   });
 
   it("does not load when root is null", async () => {

--- a/src/hooks/useFolderChildren.ts
+++ b/src/hooks/useFolderChildren.ts
@@ -43,12 +43,30 @@ export function useFolderChildren(root: string | null) {
     [showSidecarFiles]
   );
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on prop change
-  useEffect(() => { setChildrenCache({}); }, [root, showSidecarFiles]);
-
+  // Reset cache and reload visible folders when root or the show-sidecars
+  // filter changes. The ref is updated synchronously so that loadChildren
+  // calls within this same effect (and any concurrent listener) see the
+  // cleared state and re-fetch with the new filter — without this, the
+  // load below would short-circuit on the stale cached entries and the
+  // tree would render empty until the next manual reload (issue: blank
+  // folder pane after toggling "Show sidecar files").
   useEffect(() => {
-    if (root) loadChildren(root);
-  }, [root, loadChildren]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on filter change
+    setChildrenCache({});
+    childrenCacheRef.current = {};
+    if (!root) return;
+    // Reload root + every currently-expanded folder so the user's view is
+    // preserved across the toggle. Snapshot via getState to avoid
+    // re-subscribing on every expand/collapse.
+    const expanded = useStore.getState().expandedFolders;
+    const paths = new Set<string>([root]);
+    for (const [p, isExpanded] of Object.entries(expanded)) {
+      if (isExpanded) paths.add(p);
+    }
+    for (const p of paths) {
+      void loadChildren(p);
+    }
+  }, [root, showSidecarFiles, loadChildren]);
 
   // Refresh cached entries when Rust reports a folder change. We only refresh
   // dirs we already have in the cache — unknown dirs would be loaded lazily

--- a/src/styles/folder-tree.css
+++ b/src/styles/folder-tree.css
@@ -124,6 +124,15 @@
   opacity: 0.4;
 }
 
+/* Sidecar entry (.review.yaml/.review.json sibling visible via the
+   "Show sidecar files in folder pane" setting). Dimmed + italic to
+   signal it is metadata, not a primary source file. */
+.tree-entry--sidecar .tree-name,
+.tree-entry--sidecar .tree-icon {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 /* Comment count badge */
 .tree-comment-badge {
   font-size: 10px;


### PR DESCRIPTION
Stacked on #260. Fixes three must-fix bugs in the 'Show sidecar files in folder pane' feature.

## Bugs fixed

### 1. Folder pane goes blank after flipping the toggle
`useFolderChildren` split cache reset and reload across two effects. `setChildrenCache({})` is async, so the load effect ran with the still-stale ref, short-circuited on the cached entries, and never re-fetched. Combined into one effect that clears the ref synchronously and reloads root + every currently-expanded folder so the user's view is preserved.

### 2. Default mismatch: toggle persisted ON, folder pane still shows sidecars hidden
Same root cause as #1  when the persist middleware rehydrated `showSidecarFiles=true` on app start, the cache-clear effect fired but the load short-circuited on the stale entries from the initial `false` render. Fixed by the same patch.

### 3. AC10 contract weakened: toggling sidecars on exposed the entire `.reviews/` internal storage tree
`fs::read_dir` gated the AC10 `sidecar_root` directory hide on `!show_sidecars`. The two contracts ('reveal sibling `.review.{yaml,json}` files' vs 'never expose internal sidecar storage') must stay decoupled. Now `sidecar_root` is always hidden when configured.

### 4. Directory named `foo.review.yaml/` was silently filtered
The sidecar-file filter only checked the name suffix. Added `!meta.is_dir()` gate.

### Bonus: dialog text claimed '(dimmed/italic)' rendering that didn't exist
Added the `.tree-entry--sidecar` CSS rule and threaded an `isSidecar` flag through `renderRow` so the dialog text is truthful.

## Tests
-  Vitest: `useFolderChildren` reloads root + expanded folders when `showSidecarFiles` toggles, with the new filter passed to `readDir`.
-  Rust: `read_dir` surfaces `.review.yaml`/`.review.json` when `show=true`.
-  Rust: `read_dir` keeps `sidecar_root` hidden even when `show=true` (AC10).
-  Rust: `read_dir` does not filter directories whose name ends in `.review.yaml`/`.review.json`.
- All 109 Rust integration tests + 12 useFolderChildren tests pass.