### PR TITLE
fix(sidecar): full-stack fixes for the Show-Sidecars feature

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -217,13 +217,31 @@ fn cmd_read(
 ) -> Result<(), String> {
     let cwd_path = cwd();
     let root = root_dir(folder.as_deref());
+    // Load `.mrsf.yaml` once for the workspace so single-file resolution
+    // (`resolve_sidecar_with_config`) and folder scanning agree on the
+    // sidecar redirect. Silent fallback on parse errors — a malformed
+    // `.mrsf.yaml` shouldn't make `mdownreview-cli read` exit non-zero
+    // for users on workspaces they didn't author.
+    let sidecar_root = paths::try_load_mrsf_config(&root);
 
     // Single-file mode: resolve and load exactly one sidecar; surface errors
     // (missing, outside-root, etc.) instead of silently skipping.
     if let Some(file_arg) = file.as_ref() {
-        let sidecar_path = paths::resolve_sidecar(file_arg, folder.as_deref(), &cwd_path)?;
-        let source_path = paths::source_for_sidecar(&sidecar_path)
-            .ok_or_else(|| format!("error: cannot derive source path from {:?}", sidecar_path))?;
+        let sidecar_path = paths::resolve_sidecar_with_config(
+            file_arg,
+            folder.as_deref(),
+            &cwd_path,
+            sidecar_root.as_deref(),
+        )?;
+        // Use the redirect-aware helper so a sidecar under `.reviews/`
+        // reports its real source location, not the non-existent path
+        // inside the redirect folder.
+        let source_path = paths::source_for_sidecar_with_config(
+            &sidecar_path,
+            &canonicalize_no_verbatim(&root).unwrap_or_else(|_| root.clone()),
+            sidecar_root.as_deref(),
+        )
+        .ok_or_else(|| format!("error: cannot derive source path from {:?}", sidecar_path))?;
         let raw = load_raw_sidecar(&sidecar_path)?;
         let filtered = filter_raw_comments(&raw, include_resolved);
         let entry = build_entry(&sidecar_path, &source_path, &root, &filtered);
@@ -237,17 +255,20 @@ fn cmd_read(
         return Ok(());
     }
 
-    // Folder scan mode.
+    // Folder scan mode — share the GUI's primitive so the two surfaces
+    // produce identical pairs and both honour `.mrsf.yaml`.
     let root_str = root.to_string_lossy().to_string();
-    let files = scanner::find_review_files(&root_str, 10_000);
+    let files = scanner::scan_workspace(&root_str, 10_000);
     let mut entries: Vec<(serde_json::Value, Vec<serde_json::Value>)> = Vec::new();
 
-    for (sidecar_str, _src_str) in &files {
+    for (sidecar_str, source_str) in &files {
         let sidecar_path = PathBuf::from(sidecar_str);
-        let source_path = match paths::source_for_sidecar(&sidecar_path) {
-            Some(p) => p,
-            None => continue,
-        };
+        // Trust the source path emitted by `scan_workspace`: when a
+        // `.mrsf.yaml` redirect is active it already maps `.reviews/`
+        // sidecars back to the real source location. Re-deriving via
+        // `paths::source_for_sidecar` would silently re-introduce the
+        // ghost-misclassification bug for redirected workspaces.
+        let source_path = PathBuf::from(source_str);
         let raw = match load_raw_sidecar(&sidecar_path) {
             Ok(r) => r,
             Err(e) => {
@@ -320,12 +341,30 @@ fn cmd_respond(
     }
 
     let cwd_path = cwd();
-    let sidecar_path = paths::resolve_sidecar(file, folder.as_deref(), &cwd_path)?;
-    let source_path = paths::source_for_sidecar(&sidecar_path)
-        .ok_or_else(|| format!("error: cannot derive source path from {:?}", sidecar_path))?;
-    let source_str = source_path
+    let root = root_dir(folder.as_deref());
+    let sidecar_root = paths::try_load_mrsf_config(&root);
+    let sidecar_path = paths::resolve_sidecar_with_config(
+        file,
+        folder.as_deref(),
+        &cwd_path,
+        sidecar_root.as_deref(),
+    )?;
+    // Drive `patch_comment_at` directly with the resolved YAML/JSON
+    // paths so writes follow the `.mrsf.yaml` redirect — `patch_comment`
+    // would synthesize co-located paths from the source file and miss
+    // sidecars stored under `.reviews/`.
+    let sidecar_str = sidecar_path
         .to_str()
-        .ok_or_else(|| "error: non-utf8 source path".to_string())?;
+        .ok_or_else(|| "error: non-utf8 sidecar path".to_string())?;
+    let (yaml_path, json_path) = if let Some(stem) = sidecar_str.strip_suffix(".review.yaml") {
+        (sidecar_str.to_string(), format!("{stem}.review.json"))
+    } else if let Some(stem) = sidecar_str.strip_suffix(".review.json") {
+        (format!("{stem}.review.yaml"), sidecar_str.to_string())
+    } else {
+        return Err(format!(
+            "error: resolved sidecar does not have a .review.{{yaml,json}} suffix: {sidecar_str}"
+        ));
+    };
 
     let mut mutations: Vec<CommentMutation> = Vec::new();
     if let Some(text) = response {
@@ -339,7 +378,8 @@ fn cmd_respond(
         mutations.push(CommentMutation::SetResolved(true));
     }
 
-    sidecar::patch_comment(source_str, comment_id, &mutations).map_err(|e| e.to_string())?;
+    sidecar::patch_comment_at(&yaml_path, &json_path, comment_id, &mutations)
+        .map_err(|e| e.to_string())?;
 
     let summary = match (response.is_some(), resolve) {
         (true, true) => format!("responded and resolved {}", comment_id),

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -120,14 +120,16 @@ pub fn read_dir_inner(
         if !show && !meta.is_dir() && is_sidecar_file(&name) {
             continue;
         }
-        // AC10: hide the sidecar_root directory whenever a redirect is
-        // configured. The "Show sidecar files in folder pane" toggle
-        // surfaces sibling .review.{yaml,json} files in their natural
-        // location — it must NOT also expose the internal sidecar storage
-        // tree. Keep these contracts decoupled.
-        if let Some(ref hide) = hide_dir_name {
-            if name == *hide && meta.is_dir() {
-                continue;
+        // The "Show sidecar files in folder pane" toggle controls every
+        // sidecar artifact uniformly: when OFF (default) we hide both
+        // the inline `.review.{yaml,json}` files AND the `sidecar_root`
+        // directory configured by `.mrsf.yaml`. When ON, both surface so
+        // users can browse `.reviews/` and inspect the raw metadata.
+        if !show {
+            if let Some(ref hide) = hide_dir_name {
+                if name == *hide && meta.is_dir() {
+                    continue;
+                }
             }
         }
 

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -114,15 +114,20 @@ pub fn read_dir_inner(
             e.to_string()
         })?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        if !show && is_sidecar_file(&name) {
+        // Sidecar file filter — gate on is_file so a directory whose name
+        // ends in `.review.yaml` (legal on every FS) is never mistaken
+        // for a sidecar file.
+        if !show && !meta.is_dir() && is_sidecar_file(&name) {
             continue;
         }
-        // Hide the sidecar_root directory when it overlaps the workspace tree
-        if !show {
-            if let Some(ref hide) = hide_dir_name {
-                if name == *hide && meta.is_dir() {
-                    continue;
-                }
+        // AC10: hide the sidecar_root directory whenever a redirect is
+        // configured. The "Show sidecar files in folder pane" toggle
+        // surfaces sibling .review.{yaml,json} files in their natural
+        // location — it must NOT also expose the internal sidecar storage
+        // tree. Keep these contracts decoupled.
+        if let Some(ref hide) = hide_dir_name {
+            if name == *hide && meta.is_dir() {
+                continue;
             }
         }
 

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -94,28 +94,14 @@ pub fn get_log_path(app: tauri::AppHandle) -> Result<String, String> {
 
 /// Scan a directory tree for MRSF sidecar files (delegates to core::scanner).
 ///
-/// Honours the workspace's `sidecar_root` redirect (if a `.mrsf.yaml`
-/// has been registered for `root` via `SidecarConfigState`) so sidecars
-/// stored under e.g. `.reviews/` are mapped back to their real source
-/// location instead of being incorrectly flagged as ghosts.
+/// Honours the workspace's `.mrsf.yaml` redirect so sidecars stored
+/// under e.g. `.reviews/` are mapped back to their real source location
+/// instead of being incorrectly flagged as ghosts. Both the GUI IPC
+/// and the CLI go through [`crate::core::scanner::scan_workspace`] for
+/// identical `(sidecar, source)` output.
 #[tauri::command]
-pub fn scan_review_files(
-    root: String,
-    config_state: tauri::State<'_, crate::watcher::SidecarConfigState>,
-) -> Result<Vec<(String, String)>, String> {
-    Ok(scan_review_files_inner(root, &config_state))
-}
-
-/// Inner implementation, decoupled from `tauri::State` so unit/integration
-/// tests can construct a plain `SidecarConfigState` and call this directly.
-pub fn scan_review_files_inner(
-    root: String,
-    config_state: &crate::watcher::SidecarConfigState,
-) -> Vec<(String, String)> {
-    let sidecar_root = config_state
-        .resolve_for_file(std::path::Path::new(&root))
-        .and_then(|(_, sr)| sr);
-    crate::core::scanner::find_review_files_with_config(&root, 10_000, sidecar_root.as_deref())
+pub fn scan_review_files(root: String) -> Result<Vec<(String, String)>, String> {
+    Ok(crate::core::scanner::scan_workspace(&root, 10_000))
 }
 
 /// Test-only command: open a folder and all its non-sidecar files via args-received.

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -93,9 +93,29 @@ pub fn get_log_path(app: tauri::AppHandle) -> Result<String, String> {
 }
 
 /// Scan a directory tree for MRSF sidecar files (delegates to core::scanner).
+///
+/// Honours the workspace's `sidecar_root` redirect (if a `.mrsf.yaml`
+/// has been registered for `root` via `SidecarConfigState`) so sidecars
+/// stored under e.g. `.reviews/` are mapped back to their real source
+/// location instead of being incorrectly flagged as ghosts.
 #[tauri::command]
-pub fn scan_review_files(root: String) -> Result<Vec<(String, String)>, String> {
-    Ok(crate::core::scanner::find_review_files(&root, 10_000))
+pub fn scan_review_files(
+    root: String,
+    config_state: tauri::State<'_, crate::watcher::SidecarConfigState>,
+) -> Result<Vec<(String, String)>, String> {
+    Ok(scan_review_files_inner(root, &config_state))
+}
+
+/// Inner implementation, decoupled from `tauri::State` so unit/integration
+/// tests can construct a plain `SidecarConfigState` and call this directly.
+pub fn scan_review_files_inner(
+    root: String,
+    config_state: &crate::watcher::SidecarConfigState,
+) -> Vec<(String, String)> {
+    let sidecar_root = config_state
+        .resolve_for_file(std::path::Path::new(&root))
+        .and_then(|(_, sr)| sr);
+    crate::core::scanner::find_review_files_with_config(&root, 10_000, sidecar_root.as_deref())
 }
 
 /// Test-only command: open a folder and all its non-sidecar files via args-received.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use html::{compute_fold_regions, resolve_html_assets, FoldRegion};
 pub use launch::set_root_via_test;
 pub use launch::{
     get_launch_args, get_log_path, parse_launch_args,
-    scan_review_files, scan_review_files_inner,
+    scan_review_files,
 };
 pub use remote_asset::fetch_remote_asset;
 pub use search::{

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use html::{compute_fold_regions, resolve_html_assets, FoldRegion};
 pub use launch::set_root_via_test;
 pub use launch::{
     get_launch_args, get_log_path, parse_launch_args,
-    scan_review_files,
+    scan_review_files, scan_review_files_inner,
 };
 pub use remote_asset::fetch_remote_asset;
 pub use search::{

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -75,6 +75,32 @@ pub fn source_for_sidecar(p: &Path) -> Option<PathBuf> {
     None
 }
 
+/// `.mrsf.yaml`-aware variant of [`source_for_sidecar`]. If the sidecar
+/// lives under `<workspace_root>/<sidecar_root>/`, the returned source
+/// path is remapped to `<workspace_root>/<rel>` so callers see the real
+/// file location instead of the non-existent path inside the redirect
+/// folder. Falls through to the suffix-strip behaviour for co-located
+/// sidecars or when no redirect is configured.
+///
+/// Shared by [`crate::core::scanner::find_review_files_with_config`]
+/// (folder-scan source mapping) and the CLI's single-file
+/// `mdownreview-cli read --file …` path so both surfaces report the
+/// same source location for a redirected sidecar.
+pub fn source_for_sidecar_with_config(
+    sidecar_path: &Path,
+    workspace_root: &Path,
+    sidecar_root: Option<&Path>,
+) -> Option<PathBuf> {
+    let trimmed = source_for_sidecar(sidecar_path)?;
+    if let Some(sr) = sidecar_root {
+        let abs_sidecar_root = workspace_root.join(sr);
+        if let Ok(rel) = trimmed.strip_prefix(&abs_sidecar_root) {
+            return Some(workspace_root.join(rel));
+        }
+    }
+    Some(trimmed)
+}
+
 /// Resolve a sidecar path from CLI input,canonicalize it, and verify it
 /// stays inside `folder` if one was supplied.
 ///
@@ -88,6 +114,25 @@ pub fn source_for_sidecar(p: &Path) -> Option<PathBuf> {
 /// is provided, the canonical result must start with the canonical folder
 /// — symlinks pointing outside the folder are rejected.
 pub fn resolve_sidecar(input: &str, folder: Option<&str>, cwd: &Path) -> Result<PathBuf, String> {
+    resolve_sidecar_with_config(input, folder, cwd, None)
+}
+
+/// Like [`resolve_sidecar`] but also probes the workspace's
+/// `sidecar_root` redirect (e.g. `.reviews/`) when no co-located sidecar
+/// exists for `input`. Pass `Some(&sr)` after loading `.mrsf.yaml` for
+/// the workspace; pass `None` (or call [`resolve_sidecar`]) to keep the
+/// legacy co-located-only behaviour.
+///
+/// Co-located sidecars take priority — a workspace mid-migration may
+/// have both a stale co-located file and a freshly-redirected one, and
+/// the CLI should match what the GUI shows (co-located wins until
+/// migrated).
+pub fn resolve_sidecar_with_config(
+    input: &str,
+    folder: Option<&str>,
+    cwd: &Path,
+    sidecar_root: Option<&Path>,
+) -> Result<PathBuf, String> {
     let resolved = resolve_path(input, folder, cwd);
 
     let candidate = if input.ends_with(".review.yaml") || input.ends_with(".review.json") {
@@ -96,13 +141,15 @@ pub fn resolve_sidecar(input: &str, folder: Option<&str>, cwd: &Path) -> Result<
         let mut yaml = resolved.clone().into_os_string();
         yaml.push(".review.yaml");
         let yaml = PathBuf::from(yaml);
-        let mut json = resolved.into_os_string();
+        let mut json = resolved.clone().into_os_string();
         json.push(".review.json");
         let json = PathBuf::from(json);
         if yaml.exists() {
             yaml
         } else if json.exists() {
             json
+        } else if let Some(redirected) = probe_redirected_sidecar(&resolved, folder, cwd, sidecar_root) {
+            redirected
         } else {
             return Err(not_found_error(input, folder));
         }
@@ -136,6 +183,39 @@ pub fn resolve_sidecar(input: &str, folder: Option<&str>, cwd: &Path) -> Result<
     Ok(canonical)
 }
 
+/// Probe `<workspace>/<sidecar_root>/<rel_from_workspace>.review.{yaml,json}`
+/// for an existing sidecar. Returns the first match (yaml preferred).
+/// Used as a fallback by [`resolve_sidecar_with_config`] when no
+/// co-located sidecar exists.
+fn probe_redirected_sidecar(
+    resolved_input: &Path,
+    folder: Option<&str>,
+    cwd: &Path,
+    sidecar_root: Option<&Path>,
+) -> Option<PathBuf> {
+    let sr = sidecar_root?;
+    let workspace_raw = folder.map(Path::new).unwrap_or(cwd);
+    let workspace = canonicalize_no_verbatim(workspace_raw).ok()?;
+    let canonical_input =
+        canonicalize_no_verbatim(resolved_input).unwrap_or_else(|_| resolved_input.to_path_buf());
+    let rel = canonical_input.strip_prefix(&workspace).ok()?;
+    let base = workspace.join(sr).join(rel);
+
+    let mut yaml = base.clone().into_os_string();
+    yaml.push(".review.yaml");
+    let yaml = PathBuf::from(yaml);
+    if yaml.exists() {
+        return Some(yaml);
+    }
+    let mut json = base.into_os_string();
+    json.push(".review.json");
+    let json = PathBuf::from(json);
+    if json.exists() {
+        return Some(json);
+    }
+    None
+}
+
 fn not_found_error(input: &str, folder: Option<&str>) -> String {
     format!(
         "error: sidecar not found for '{}' under folder '{}'",
@@ -157,6 +237,18 @@ fn outside_root_error(input: &str, folder: &str) -> String {
 // ---------------------------------------------------------------------------
 
 pub use crate::core::sidecar::config::load_mrsf_config;
+
+/// Best-effort `.mrsf.yaml` lookup for a workspace root. Canonicalizes
+/// `root` and loads the redirect (if any). Errors and missing files are
+/// silently treated as "no redirect configured" — useful for callers that
+/// can't (or don't need to) surface load errors, such as the CLI's
+/// folder scan and `core::scanner::scan_workspace`. Loud callers
+/// (e.g. the `update_tree_watched_dirs` IPC) canonicalize and call
+/// [`load_mrsf_config`] directly so they can log failures.
+pub fn try_load_mrsf_config(root: &Path) -> Option<PathBuf> {
+    let canonical = canonicalize_no_verbatim(root).ok()?;
+    load_mrsf_config(&canonical).ok().flatten()
+}
 
 // ---------------------------------------------------------------------------
 // Sidecar-root path resolution

--- a/src-tauri/src/core/paths_tests.rs
+++ b/src-tauri/src/core/paths_tests.rs
@@ -178,6 +178,224 @@ fn resolve_sidecar_rejects_symlink_escape_windows() {
     );
 }
 
+// ---- source_for_sidecar_with_config (.mrsf.yaml-aware reverse map)
+//
+// Shared between the scanner's folder-scan path and the CLI's
+// single-file path. Both modes (co-located and redirected) and the
+// conversion in each must produce the same source path so the GUI
+// folder pane, the CLI `read --file …`, and the CLI `read --folder …`
+// all report identical source locations for the same sidecar.
+
+#[test]
+fn source_with_config_no_redirect_strips_suffix() {
+    // Co-located mode: behaviour matches `source_for_sidecar`.
+    let workspace = PathBuf::from("/ws");
+    let sidecar = Path::new("/ws/foo.md.review.yaml");
+    let r = source_for_sidecar_with_config(sidecar, &workspace, None);
+    assert_eq!(r, Some(PathBuf::from("/ws/foo.md")));
+}
+
+#[test]
+fn source_with_config_redirected_remaps_to_real_location() {
+    // Redirected mode: sidecar under `<ws>/.reviews/` must resolve to
+    // `<ws>/foo.md`, not `<ws>/.reviews/foo.md` — the conversion the
+    // ghost-detection fix relies on.
+    let workspace = PathBuf::from("/ws");
+    let sidecar = Path::new("/ws/.reviews/foo.md.review.yaml");
+    let sr = PathBuf::from(".reviews");
+    let r = source_for_sidecar_with_config(sidecar, &workspace, Some(&sr));
+    assert_eq!(r, Some(PathBuf::from("/ws/foo.md")));
+}
+
+#[test]
+fn source_with_config_redirected_preserves_subdir_structure() {
+    // The redirect mirrors the source layout — sidecars under
+    // `.reviews/docs/guide.md.review.yaml` map to `<ws>/docs/guide.md`.
+    let workspace = PathBuf::from("/ws");
+    let sidecar = Path::new("/ws/.reviews/docs/guide.md.review.yaml");
+    let sr = PathBuf::from(".reviews");
+    let r = source_for_sidecar_with_config(sidecar, &workspace, Some(&sr));
+    assert_eq!(r, Some(PathBuf::from("/ws/docs/guide.md")));
+}
+
+#[test]
+fn source_with_config_passes_through_colocated_when_redirect_active() {
+    // Mid-migration: a stale co-located sidecar lives at the workspace
+    // root while a redirect is configured. The strip_prefix probe fails,
+    // so the function falls through to the suffix-strip default.
+    let workspace = PathBuf::from("/ws");
+    let sidecar = Path::new("/ws/legacy.md.review.yaml");
+    let sr = PathBuf::from(".reviews");
+    let r = source_for_sidecar_with_config(sidecar, &workspace, Some(&sr));
+    assert_eq!(r, Some(PathBuf::from("/ws/legacy.md")));
+}
+
+#[test]
+fn source_with_config_returns_none_for_non_sidecar_path() {
+    // Inputs that don't carry a sidecar suffix are not recoverable —
+    // the function preserves [`source_for_sidecar`]'s contract.
+    let workspace = PathBuf::from("/ws");
+    let sidecar = Path::new("/ws/foo.md");
+    let sr = PathBuf::from(".reviews");
+    assert_eq!(
+        source_for_sidecar_with_config(sidecar, &workspace, Some(&sr)),
+        None
+    );
+    assert_eq!(
+        source_for_sidecar_with_config(sidecar, &workspace, None),
+        None
+    );
+}
+
+// ---- resolve_sidecar_with_config (.mrsf.yaml redirect) ------------
+//
+// Single-file CLI/GUI sidecar resolution must work in both modes —
+// co-located (legacy / no .mrsf.yaml) and redirected (sidecars under
+// `<root>/<sidecar_root>/`). These tests cover both, plus the
+// migration overlap (both files exist) and the "input is a literal
+// sidecar path" short-circuit.
+
+#[test]
+fn resolve_with_config_no_redirect_matches_resolve_sidecar() {
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    fs::write(folder.join("doc.md.review.yaml"), "y").unwrap();
+    let folder_s = folder.to_string_lossy().to_string();
+
+    let baseline = resolve_sidecar("doc.md", Some(&folder_s), folder).unwrap();
+    let with_cfg =
+        resolve_sidecar_with_config("doc.md", Some(&folder_s), folder, None).unwrap();
+    assert_eq!(baseline, with_cfg, "passing None must match resolve_sidecar");
+}
+
+#[test]
+fn resolve_with_config_finds_yaml_under_redirect_directory() {
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    fs::write(folder.join("doc.md"), "# doc").unwrap();
+    fs::create_dir(folder.join(".reviews")).unwrap();
+    let yaml = folder.join(".reviews").join("doc.md.review.yaml");
+    fs::write(&yaml, "y").unwrap();
+    let folder_s = folder.to_string_lossy().to_string();
+    let sr = PathBuf::from(".reviews");
+    let r =
+        resolve_sidecar_with_config("doc.md", Some(&folder_s), folder, Some(&sr)).unwrap();
+    assert_eq!(r, canonicalize_no_verbatim(&yaml).unwrap());
+}
+
+#[test]
+fn resolve_with_config_finds_json_under_redirect_directory() {
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    fs::write(folder.join("doc.md"), "# doc").unwrap();
+    fs::create_dir(folder.join(".reviews")).unwrap();
+    let json = folder.join(".reviews").join("doc.md.review.json");
+    fs::write(&json, "{}").unwrap();
+    let folder_s = folder.to_string_lossy().to_string();
+    let sr = PathBuf::from(".reviews");
+    let r =
+        resolve_sidecar_with_config("doc.md", Some(&folder_s), folder, Some(&sr)).unwrap();
+    assert_eq!(r, canonicalize_no_verbatim(&json).unwrap());
+}
+
+#[test]
+fn resolve_with_config_prefers_colocated_when_both_exist() {
+    // Mid-migration: a stale co-located sidecar lives next to the file
+    // AND a fresh one under .reviews/. The CLI/GUI must agree on the
+    // co-located one — it's what the file-watcher and folder pane
+    // surface, so writes targeting the "wrong" file would produce
+    // ghost edits invisible to the user.
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    fs::write(folder.join("doc.md"), "# doc").unwrap();
+    let colocated = folder.join("doc.md.review.yaml");
+    fs::write(&colocated, "y").unwrap();
+    fs::create_dir(folder.join(".reviews")).unwrap();
+    fs::write(folder.join(".reviews").join("doc.md.review.yaml"), "y").unwrap();
+    let folder_s = folder.to_string_lossy().to_string();
+    let sr = PathBuf::from(".reviews");
+    let r =
+        resolve_sidecar_with_config("doc.md", Some(&folder_s), folder, Some(&sr)).unwrap();
+    assert_eq!(r, canonicalize_no_verbatim(&colocated).unwrap());
+}
+
+#[test]
+fn resolve_with_config_literal_sidecar_input_bypasses_redirect_probe() {
+    // When the user passes a literal `.review.{yaml,json}` filename, we
+    // use it as-is regardless of redirect — same contract as
+    // resolve_sidecar (write-friendly path for sidecars that don't
+    // exist yet).
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    let folder_s = folder.to_string_lossy().to_string();
+    let sr = PathBuf::from(".reviews");
+    let r = resolve_sidecar_with_config(
+        "new.md.review.yaml",
+        Some(&folder_s),
+        folder,
+        Some(&sr),
+    )
+    .unwrap();
+    let expected = canonicalize_no_verbatim(folder).unwrap().join("new.md.review.yaml");
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn resolve_with_config_missing_in_both_locations_errors() {
+    let dir = tempdir().unwrap();
+    let folder = dir.path();
+    fs::create_dir(folder.join(".reviews")).unwrap();
+    let folder_s = folder.to_string_lossy().to_string();
+    let sr = PathBuf::from(".reviews");
+    let err =
+        resolve_sidecar_with_config("nope.md", Some(&folder_s), folder, Some(&sr)).unwrap_err();
+    assert!(err.contains("nope.md"), "missing input in error: {err}");
+    assert!(err.contains("not found"), "unexpected error: {err}");
+}
+
+// ---- try_load_mrsf_config ----------------------------------------
+
+#[test]
+fn try_load_mrsf_config_returns_none_without_file() {
+    let dir = tempdir().unwrap();
+    assert_eq!(try_load_mrsf_config(dir.path()), None);
+}
+
+#[test]
+fn try_load_mrsf_config_returns_sidecar_root_when_configured() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "sidecar_root: .reviews\n").unwrap();
+    let r = try_load_mrsf_config(dir.path());
+    assert_eq!(r, Some(PathBuf::from(".reviews")));
+}
+
+#[test]
+fn try_load_mrsf_config_silently_returns_none_on_malformed_yaml() {
+    // Malformed config must not propagate an error — CLI/scanner
+    // callers depend on the silent fallback so a single broken
+    // workspace doesn't kill the binary.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), ":::not yaml:::\n").unwrap();
+    assert_eq!(try_load_mrsf_config(dir.path()), None);
+}
+
+#[test]
+fn try_load_mrsf_config_returns_none_on_empty_or_missing_key() {
+    // An empty `.mrsf.yaml` (or one with no sidecar_root key) parses
+    // successfully but signals "no redirect configured". The helper's
+    // contract is None in both that case and the error case.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".mrsf.yaml"), "other_key: value\n").unwrap();
+    assert_eq!(try_load_mrsf_config(dir.path()), None);
+}
+
+#[test]
+fn try_load_mrsf_config_returns_none_for_nonexistent_root() {
+    // Root path that doesn't exist — canonicalize fails, returns None.
+    let bogus = PathBuf::from("/this/path/should/not/exist/zzz");
+    assert_eq!(try_load_mrsf_config(&bogus), None);
+}
+
 // ---- canonicalize_no_verbatim ------------------------------------
 
 #[test]

--- a/src-tauri/src/core/scanner.rs
+++ b/src-tauri/src/core/scanner.rs
@@ -160,28 +160,49 @@ pub fn find_review_files_with_config(
     results
 }
 
+/// Scan a workspace for sidecar files, automatically loading the
+/// workspace's `.mrsf.yaml` configuration to honour any `sidecar_root`
+/// redirect.
+///
+/// Single shared primitive used by the GUI IPC (`scan_review_files`)
+/// and the CLI's folder-scan mode so the two surfaces produce identical
+/// `(sidecar, source)` pairs for the same workspace. Loud callers that
+/// need to log `.mrsf.yaml` parse failures should canonicalize the root
+/// themselves and pair [`crate::core::paths::load_mrsf_config`] with
+/// [`find_review_files_with_config`].
+pub fn scan_workspace(root: &str, cap: usize) -> Vec<(String, String)> {
+    let sidecar_root = crate::core::paths::try_load_mrsf_config(Path::new(root));
+    find_review_files_with_config(root, cap, sidecar_root.as_deref())
+}
+
 /// Derive the source-file path for a sidecar.
 ///
-/// The default rule is "trim the `.review.{yaml,json}` suffix" — which
-/// works for co-located sidecars (`foo.md.review.yaml` → `foo.md`).
-/// When a `sidecar_root` redirect is configured, sidecars stored under
-/// `<workspace>/<sidecar_root>/<rel>.review.{yaml,json}` are mapped to
-/// `<workspace>/<rel>` so the source resolves to the real file location
-/// rather than the non-existent path inside the redirect folder.
+/// Thin wrapper over [`crate::core::paths::source_for_sidecar_with_config`]
+/// returning a [`String`] for the scanner's `(sidecar, source)` output
+/// shape. The conversion logic (suffix-strip + optional redirect
+/// remap) lives in `paths` so the CLI's single-file mode and the
+/// scanner agree on it.
 fn derive_source_path(
     workspace_root: &Path,
     sidecar_path: &str,
     suffix: &str,
     sidecar_root: Option<&Path>,
 ) -> String {
-    let trimmed = sidecar_path.trim_end_matches(suffix);
-    if let Some(sr) = sidecar_root {
-        let abs_sidecar_root = workspace_root.join(sr);
-        if let Ok(rel) = Path::new(trimmed).strip_prefix(&abs_sidecar_root) {
-            return workspace_root.join(rel).to_string_lossy().to_string();
-        }
+    // Fast path matches the historical scanner behaviour byte-for-byte
+    // when no redirect is configured: trim the suffix off the original
+    // string. This keeps the "sidecar shares form with read_dir" path
+    // invariant on Windows (issue #89) — the shared helper takes a
+    // `&Path` and would round-trip through `to_string_lossy`.
+    if sidecar_root.is_none() {
+        return sidecar_path.trim_end_matches(suffix).to_string();
     }
-    trimmed.to_string()
+    crate::core::paths::source_for_sidecar_with_config(
+        Path::new(sidecar_path),
+        workspace_root,
+        sidecar_root,
+    )
+    .map(|p| p.to_string_lossy().into_owned())
+    .unwrap_or_else(|| sidecar_path.trim_end_matches(suffix).to_string())
 }
 
 /// Load a sidecar given the sidecar file path directly (not the source file path).
@@ -371,6 +392,130 @@ comments:
 
         assert_eq!(results.len(), 2);
         for (_sidecar, source) in &results {
+            assert!(
+                std::path::Path::new(source).exists(),
+                "every source must exist on disk: {source}"
+            );
+        }
+    }
+
+    // ---- scan_workspace (.mrsf.yaml-aware shared primitive) ----------
+    //
+    // Used by both the GUI IPC and the CLI's folder-scan mode. These
+    // tests cover both layouts (co-located, redirected) and the
+    // sidecar→source conversion the scanner performs from disk-loaded
+    // `.mrsf.yaml`.
+
+    #[test]
+    fn scan_workspace_colocated_mode_no_mrsf_yaml() {
+        // No `.mrsf.yaml` → sidecars are co-located, source paths are
+        // produced by trimming the suffix. Behaviour identical to
+        // `find_review_files`.
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+        std::fs::write(canonical_root.join("a.md"), "# A").unwrap();
+        std::fs::write(canonical_root.join("b.md"), "# B").unwrap();
+        write_yaml_sidecar(&canonical_root, "a.md");
+        write_yaml_sidecar(&canonical_root, "b.md");
+
+        let results = scan_workspace(canonical_root.to_str().unwrap(), 10_000);
+
+        assert_eq!(results.len(), 2);
+        for (sidecar, source) in &results {
+            assert!(
+                sidecar.ends_with(".review.yaml"),
+                "sidecar must keep its suffix: {sidecar}"
+            );
+            assert!(
+                std::path::Path::new(source).exists(),
+                "co-located source must exist: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn scan_workspace_redirected_mode_loads_mrsf_yaml() {
+        // `.mrsf.yaml` declares `sidecar_root: .reviews`. Sidecars live
+        // under .reviews/ but their source paths must point back at the
+        // real files at the workspace root — exercises the conversion
+        // performed via `try_load_mrsf_config` + `find_review_files_with_config`
+        // inside `scan_workspace`.
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+        std::fs::write(
+            canonical_root.join(".mrsf.yaml"),
+            "sidecar_root: .reviews\n",
+        )
+        .unwrap();
+        std::fs::write(canonical_root.join("readme.md"), "# A").unwrap();
+        let reviews = canonical_root.join(".reviews");
+        std::fs::create_dir(&reviews).unwrap();
+        write_yaml_sidecar(&reviews, "readme.md");
+
+        let results = scan_workspace(canonical_root.to_str().unwrap(), 10_000);
+
+        assert_eq!(results.len(), 1);
+        let (sidecar, source) = &results[0];
+        assert!(
+            sidecar.contains(".reviews"),
+            "sidecar lives under .reviews: {sidecar}"
+        );
+        assert!(
+            !source.contains(".reviews"),
+            "source must be remapped out of .reviews: {source}"
+        );
+        assert!(
+            std::path::Path::new(source).exists(),
+            "remapped source must point at a real file: {source}"
+        );
+    }
+
+    #[test]
+    fn scan_workspace_falls_back_to_colocated_on_malformed_mrsf_yaml() {
+        // A workspace with a broken `.mrsf.yaml` must NOT panic or
+        // return empty — falls back silently to the co-located scan.
+        // CLI users on workspaces they didn't author depend on this.
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+        std::fs::write(canonical_root.join(".mrsf.yaml"), ":::not yaml:::\n").unwrap();
+        std::fs::write(canonical_root.join("doc.md"), "# doc").unwrap();
+        write_yaml_sidecar(&canonical_root, "doc.md");
+
+        let results = scan_workspace(canonical_root.to_str().unwrap(), 10_000);
+        assert_eq!(results.len(), 1, "expected one co-located sidecar");
+        assert!(
+            std::path::Path::new(&results[0].1).exists(),
+            "co-located source must still resolve: {}",
+            results[0].1
+        );
+    }
+
+    #[test]
+    fn scan_workspace_mixed_layout_under_redirect() {
+        // Workspace with both layouts present: `.mrsf.yaml` is
+        // configured AND a stale co-located sidecar exists alongside a
+        // newly-redirected one. Both should appear, both source paths
+        // must point at real files. Mirrors the
+        // `redirect_only_rewrites_sidecars_under_sidecar_root` case but
+        // exercises the full `scan_workspace` entry point (config
+        // loading included).
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+        std::fs::write(
+            canonical_root.join(".mrsf.yaml"),
+            "sidecar_root: .reviews\n",
+        )
+        .unwrap();
+        std::fs::write(canonical_root.join("co.md"), "# co").unwrap();
+        std::fs::write(canonical_root.join("redir.md"), "# redir").unwrap();
+        write_yaml_sidecar(&canonical_root, "co.md");
+        let reviews = canonical_root.join(".reviews");
+        std::fs::create_dir(&reviews).unwrap();
+        write_yaml_sidecar(&reviews, "redir.md");
+
+        let results = scan_workspace(canonical_root.to_str().unwrap(), 10_000);
+        assert_eq!(results.len(), 2);
+        for (_, source) in &results {
             assert!(
                 std::path::Path::new(source).exists(),
                 "every source must exist on disk: {source}"

--- a/src-tauri/src/core/scanner.rs
+++ b/src-tauri/src/core/scanner.rs
@@ -81,7 +81,32 @@ pub fn delete_resolved_sidecars(
 /// silently leaked the user-supplied form, so a workspace opened via a
 /// dialog (`C:\…`) and a workspace opened via an OS handler (`\\?\C:\…`)
 /// produced cross-form strings the renderer could not reconcile).
+///
+/// See [`find_review_files_with_config`] for the variant that respects a
+/// workspace's `sidecar_root` redirect (so sidecars stored under
+/// `<root>/<sidecar_root>/` are mapped back to their actual source file
+/// location). Without a config, sidecars under a redirect would all be
+/// flagged as ghosts because their derived source path
+/// (`<sidecar_root>/<rel>`) doesn't exist on disk — the real source
+/// lives at `<root>/<rel>`.
 pub fn find_review_files(root: &str, cap: usize) -> Vec<(String, String)> {
+    find_review_files_with_config(root, cap, None)
+}
+
+/// Walk `root` for sidecar files, optionally honouring a `sidecar_root`
+/// redirect so the returned `(sidecar, source)` pairs point at the real
+/// source path under `<root>` instead of a non-existent path under
+/// `<root>/<sidecar_root>`.
+///
+/// `sidecar_root` is the relative path read from `.mrsf.yaml` (e.g.
+/// `.reviews`). Pass `None` when no redirect is configured — behaviour
+/// then matches the simple form (trim `.review.{yaml,json}` from the
+/// sidecar path).
+pub fn find_review_files_with_config(
+    root: &str,
+    cap: usize,
+    sidecar_root: Option<&Path>,
+) -> Vec<(String, String)> {
     let mut results = Vec::new();
     let mut seen_sources = std::collections::HashSet::new();
 
@@ -102,7 +127,8 @@ pub fn find_review_files(root: &str, cap: usize) -> Vec<(String, String)> {
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             if name.ends_with(".review.yaml") {
                 let sidecar = path.to_string_lossy().to_string();
-                let source = sidecar.trim_end_matches(".review.yaml").to_string();
+                let source =
+                    derive_source_path(&root_owned, &sidecar, ".review.yaml", sidecar_root);
                 seen_sources.insert(source.clone());
                 results.push((sidecar, source));
                 if results.len() >= cap {
@@ -118,7 +144,8 @@ pub fn find_review_files(root: &str, cap: usize) -> Vec<(String, String)> {
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             if name.ends_with(".review.json") {
                 let sidecar = path.to_string_lossy().to_string();
-                let source = sidecar.trim_end_matches(".review.json").to_string();
+                let source =
+                    derive_source_path(&root_owned, &sidecar, ".review.json", sidecar_root);
                 if !seen_sources.contains(&source) {
                     seen_sources.insert(source.clone());
                     results.push((sidecar, source));
@@ -131,6 +158,30 @@ pub fn find_review_files(root: &str, cap: usize) -> Vec<(String, String)> {
     }
 
     results
+}
+
+/// Derive the source-file path for a sidecar.
+///
+/// The default rule is "trim the `.review.{yaml,json}` suffix" — which
+/// works for co-located sidecars (`foo.md.review.yaml` → `foo.md`).
+/// When a `sidecar_root` redirect is configured, sidecars stored under
+/// `<workspace>/<sidecar_root>/<rel>.review.{yaml,json}` are mapped to
+/// `<workspace>/<rel>` so the source resolves to the real file location
+/// rather than the non-existent path inside the redirect folder.
+fn derive_source_path(
+    workspace_root: &Path,
+    sidecar_path: &str,
+    suffix: &str,
+    sidecar_root: Option<&Path>,
+) -> String {
+    let trimmed = sidecar_path.trim_end_matches(suffix);
+    if let Some(sr) = sidecar_root {
+        let abs_sidecar_root = workspace_root.join(sr);
+        if let Ok(rel) = Path::new(trimmed).strip_prefix(&abs_sidecar_root) {
+            return workspace_root.join(rel).to_string_lossy().to_string();
+        }
+    }
+    trimmed.to_string()
 }
 
 /// Load a sidecar given the sidecar file path directly (not the source file path).
@@ -246,6 +297,85 @@ comments:
         let tmp = TempDir::new().unwrap();
         let results = find_review_files(tmp.path().to_str().unwrap(), 10000);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn redirect_maps_sidecar_to_real_source_path() {
+        // Sidecars stored under <root>/<sidecar_root>/ must resolve to
+        // the actual source location <root>/<rel> — not the non-existent
+        // <root>/<sidecar_root>/<rel> that a naive suffix-trim would
+        // produce. Exercises the .reviews/ ghost-misclassification fix.
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+
+        // Real source files at the workspace root + a subdirectory
+        std::fs::write(canonical_root.join("readme.md"), "# A").unwrap();
+        let docs = canonical_root.join("docs");
+        std::fs::create_dir(&docs).unwrap();
+        std::fs::write(docs.join("guide.md"), "# B").unwrap();
+
+        // Sidecars redirected under .reviews/ mirroring the source layout
+        let reviews = canonical_root.join(".reviews");
+        std::fs::create_dir(&reviews).unwrap();
+        write_yaml_sidecar(&reviews, "readme.md");
+        let reviews_docs = reviews.join("docs");
+        std::fs::create_dir(&reviews_docs).unwrap();
+        write_yaml_sidecar(&reviews_docs, "guide.md");
+
+        let sidecar_root = std::path::PathBuf::from(".reviews");
+        let results = find_review_files_with_config(
+            canonical_root.to_str().unwrap(),
+            10_000,
+            Some(&sidecar_root),
+        );
+
+        assert_eq!(results.len(), 2);
+
+        // Each (sidecar, source) pair: sidecar lives under .reviews,
+        // source lives at the workspace root (existing on disk).
+        for (sidecar, source) in &results {
+            assert!(
+                sidecar.contains(".reviews"),
+                "sidecar should live under .reviews: {sidecar}"
+            );
+            assert!(!source.contains(".reviews"), "source must NOT contain .reviews: {source}");
+            assert!(
+                std::path::Path::new(source).exists(),
+                "source must point at the real file on disk: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn redirect_only_rewrites_sidecars_under_sidecar_root() {
+        // Mixed workspace: one sidecar under .reviews/, another co-located
+        // at the workspace root. Only the redirected sidecar should be
+        // rewritten — the co-located one keeps the suffix-trim behaviour.
+        let tmp = TempDir::new().unwrap();
+        let canonical_root = canonicalize_no_verbatim(tmp.path()).unwrap();
+
+        std::fs::write(canonical_root.join("co.md"), "# co").unwrap();
+        std::fs::write(canonical_root.join("redir.md"), "# redir").unwrap();
+        write_yaml_sidecar(&canonical_root, "co.md"); // co-located
+
+        let reviews = canonical_root.join(".reviews");
+        std::fs::create_dir(&reviews).unwrap();
+        write_yaml_sidecar(&reviews, "redir.md"); // under .reviews/
+
+        let sidecar_root = std::path::PathBuf::from(".reviews");
+        let results = find_review_files_with_config(
+            canonical_root.to_str().unwrap(),
+            10_000,
+            Some(&sidecar_root),
+        );
+
+        assert_eq!(results.len(), 2);
+        for (_sidecar, source) in &results {
+            assert!(
+                std::path::Path::new(source).exists(),
+                "every source must exist on disk: {source}"
+            );
+        }
     }
 
     // ---- delete_resolved_sidecars tests ----

--- a/src-tauri/tests/cli_integration.rs
+++ b/src-tauri/tests/cli_integration.rs
@@ -487,3 +487,121 @@ fn cleanup_include_unresolved_deletes_all() {
     assert!(stdout.contains("1 file(s) deleted"));
     assert!(!sidecar.exists());
 }
+
+// ── .mrsf.yaml redirect (sidecar_root) ─────────────────────────────────────
+
+/// Stage a workspace where sidecars live under `.reviews/` per a
+/// `.mrsf.yaml` redirect — exercises the CLI/GUI shared `.mrsf.yaml`
+/// support: the source file is at `<root>/<name>.md` and the sidecar
+/// is at `<root>/.reviews/<name>.md.review.yaml`.
+fn stage_redirected_mixed() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".mrsf.yaml"),
+        "sidecar_root: .reviews\n",
+    )
+    .unwrap();
+    std::fs::create_dir(tmp.path().join(".reviews")).unwrap();
+    let src = fixtures_dir().join("mixed.md.review.yaml");
+    let sidecar = tmp.path().join(".reviews").join("mixed.md.review.yaml");
+    std::fs::copy(&src, &sidecar).unwrap();
+    std::fs::write(tmp.path().join("mixed.md"), "# Test").unwrap();
+    (tmp, sidecar)
+}
+
+#[test]
+fn read_folder_mode_honours_mrsf_yaml_redirect() {
+    let (tmp, _sidecar) = stage_redirected_mixed();
+    let (stdout, _stderr, code) = run_cli(&[
+        "read",
+        "--folder",
+        tmp.path().to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("CLI output is JSON");
+    let arr = v.as_array().expect("top-level array");
+    assert_eq!(arr.len(), 1, "expected one entry, got: {stdout}");
+    let entry = &arr[0];
+    // The source-file path the CLI reports must be the REAL location
+    // (`mixed.md` at the workspace root), not the non-existent
+    // `.reviews/mixed.md` produced by a naive suffix-trim.
+    let source_rel = entry["sourceFile"]["relative"]
+        .as_str()
+        .expect("sourceFile.relative");
+    assert_eq!(source_rel, "mixed.md", "got: {source_rel}");
+    let review_rel = entry["reviewFile"]["relative"]
+        .as_str()
+        .expect("reviewFile.relative");
+    assert!(
+        review_rel.contains(".reviews"),
+        "review file must live under .reviews/, got: {review_rel}"
+    );
+}
+
+#[test]
+fn read_single_file_resolves_redirected_sidecar_from_source_path() {
+    // User passes the SOURCE filename — CLI must probe `.reviews/` per
+    // the `.mrsf.yaml` redirect to find the sidecar there.
+    let (tmp, _sidecar) = stage_redirected_mixed();
+    let (stdout, stderr, code) = run_cli(&[
+        "read",
+        "--folder",
+        tmp.path().to_str().unwrap(),
+        "--file",
+        "mixed.md",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("CLI output is JSON");
+    assert_eq!(v["sourceFile"]["relative"].as_str(), Some("mixed.md"));
+    assert!(v["reviewFile"]["relative"]
+        .as_str()
+        .unwrap_or("")
+        .contains(".reviews"));
+}
+
+#[test]
+fn respond_writes_to_redirected_sidecar() {
+    // Writing a response must mutate the sidecar at `.reviews/...`,
+    // not synthesize a fresh co-located one. Read-modify-write through
+    // the CLI must touch only the existing redirected file.
+    let (tmp, sidecar) = stage_redirected_mixed();
+    let original = std::fs::read_to_string(&sidecar).unwrap();
+    // Pull a comment id out of the staged fixture without depending on
+    // a YAML parser crate — the fixture format is stable and lists ids
+    // as `- id: "<value>"`.
+    let comment_id = original
+        .lines()
+        .find_map(|l| {
+            l.trim_start()
+                .strip_prefix("- id:")
+                .map(|rest| rest.trim().trim_matches('"').to_string())
+        })
+        .expect("fixture has at least one id");
+
+    let (_stdout, stderr, code) = run_cli(&[
+        "respond",
+        "--folder",
+        tmp.path().to_str().unwrap(),
+        "mixed.md",
+        &comment_id,
+        "--response",
+        "addressed by CLI test",
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+
+    // No co-located sibling should have been created.
+    let colocated = tmp.path().join("mixed.md.review.yaml");
+    assert!(
+        !colocated.exists(),
+        "respond must NOT create a co-located sidecar when redirect is active"
+    );
+
+    // The redirected sidecar must contain the new response.
+    let updated = std::fs::read_to_string(&sidecar).unwrap();
+    assert!(
+        updated.contains("addressed by CLI test"),
+        "redirected sidecar was not updated: {updated}"
+    );
+}

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -487,11 +487,12 @@ fn read_dir_shows_review_sidecars_when_show_true() {
     );
 }
 
-/// AC10 contract is independent of the user-facing show-sidecars toggle:
-/// the internal `sidecar_root` directory must remain hidden even when
-/// the user opts to surface co-located sidecar files.
+/// The "Show sidecar files in folder pane" toggle is a single switch
+/// over every sidecar artifact: when ON, both inline `.review.{yaml,json}`
+/// files AND the configured `sidecar_root` directory are surfaced so the
+/// user can browse the raw metadata they just opted into.
 #[test]
-fn read_dir_hides_sidecar_root_dir_even_when_show_true() {
+fn read_dir_shows_sidecar_root_dir_when_show_true() {
     use mdown_review_lib::core::paths::canonicalize_no_verbatim;
 
     let dir = tempfile::tempdir().unwrap();
@@ -503,12 +504,22 @@ fn read_dir_hides_sidecar_root_dir_even_when_show_true() {
     let state = SidecarConfigState::new();
     state.set_config(canonical_ws, Some(std::path::PathBuf::from(".reviews")));
 
+    // show=false (default): .reviews must be hidden.
+    let result =
+        read_dir_inner(ws.to_str().unwrap().to_string(), None, Some(false), &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        !names.contains(&".reviews"),
+        "show=false: sidecar_root must be hidden"
+    );
+
+    // show=true: .reviews must be visible so users can browse the redirect target.
     let result =
         read_dir_inner(ws.to_str().unwrap().to_string(), None, Some(true), &state).unwrap();
     let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
     assert!(
-        !names.contains(&".reviews"),
-        "AC10: sidecar_root dir must remain hidden even when show_sidecars=true"
+        names.contains(&".reviews"),
+        "show=true: sidecar_root must be visible — toggle controls all sidecar artifacts"
     );
     assert!(names.contains(&"readme.md"));
 }

--- a/src-tauri/tests/commands_integration.rs
+++ b/src-tauri/tests/commands_integration.rs
@@ -452,6 +452,93 @@ fn read_dir_hides_sidecar_root_dir() {
     );
 }
 
+/// `read_dir` with `show_sidecars=true` surfaces `.review.yaml` /
+/// `.review.json` files in their natural location so users can inspect
+/// the raw metadata when desired.
+#[test]
+fn read_dir_shows_review_sidecars_when_show_true() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("readme.md"), "hello").unwrap();
+    std::fs::write(
+        dir.path().join("readme.md.review.yaml"),
+        "mrsf_version: '1.0'\ndocument: readme.md\ncomments: []\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("main.rs.review.json"),
+        r#"{"mrsf_version":"1.0","document":"main.rs","comments":[]}"#,
+    )
+    .unwrap();
+
+    let state = SidecarConfigState::new();
+    let result =
+        read_dir_inner(dir.path().to_str().unwrap().to_string(), None, Some(true), &state)
+            .unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+
+    assert!(names.contains(&"readme.md"));
+    assert!(
+        names.contains(&"readme.md.review.yaml"),
+        "YAML sidecars must be visible when show_sidecars=true"
+    );
+    assert!(
+        names.contains(&"main.rs.review.json"),
+        "JSON sidecars must be visible when show_sidecars=true"
+    );
+}
+
+/// AC10 contract is independent of the user-facing show-sidecars toggle:
+/// the internal `sidecar_root` directory must remain hidden even when
+/// the user opts to surface co-located sidecar files.
+#[test]
+fn read_dir_hides_sidecar_root_dir_even_when_show_true() {
+    use mdown_review_lib::core::paths::canonicalize_no_verbatim;
+
+    let dir = tempfile::tempdir().unwrap();
+    let ws = dir.path();
+    let canonical_ws = canonicalize_no_verbatim(ws).unwrap();
+    std::fs::write(ws.join("readme.md"), "hello").unwrap();
+    std::fs::create_dir(ws.join(".reviews")).unwrap();
+
+    let state = SidecarConfigState::new();
+    state.set_config(canonical_ws, Some(std::path::PathBuf::from(".reviews")));
+
+    let result =
+        read_dir_inner(ws.to_str().unwrap().to_string(), None, Some(true), &state).unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        !names.contains(&".reviews"),
+        "AC10: sidecar_root dir must remain hidden even when show_sidecars=true"
+    );
+    assert!(names.contains(&"readme.md"));
+}
+
+/// A directory whose name happens to end in `.review.yaml` (legal on
+/// every FS) must NOT be filtered out by the sidecar file rule, which
+/// only applies to files.
+#[test]
+fn read_dir_does_not_hide_directory_with_sidecar_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("notes.review.yaml")).unwrap();
+    std::fs::create_dir(dir.path().join("data.review.json")).unwrap();
+    std::fs::write(dir.path().join("readme.md"), "hello").unwrap();
+
+    let state = SidecarConfigState::new();
+    let result = read_dir_inner(dir.path().to_str().unwrap().to_string(), None, None, &state)
+        .unwrap();
+    let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+
+    assert!(
+        names.contains(&"notes.review.yaml"),
+        "directories ending in .review.yaml must not be filtered as sidecar files"
+    );
+    assert!(
+        names.contains(&"data.review.json"),
+        "directories ending in .review.json must not be filtered as sidecar files"
+    );
+    assert!(names.contains(&"readme.md"));
+}
+
 // ── FileChangeEvent serialization ─────────────────────────────────────────
 
 #[test]

--- a/src-tauri/tests/path_form_test.rs
+++ b/src-tauri/tests/path_form_test.rs
@@ -10,7 +10,7 @@
 
 #![cfg(windows)]
 
-use mdown_review_lib::commands::{parse_launch_args, read_dir_inner, scan_review_files_inner};
+use mdown_review_lib::commands::{parse_launch_args, read_dir_inner, scan_review_files};
 use mdown_review_lib::watcher::{SidecarConfigState, WatcherState};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -77,10 +77,8 @@ fn read_dir_emits_no_verbatim_prefix() {
 #[test]
 fn scan_review_files_emits_no_verbatim_prefix() {
     let ws = build_workspace();
-    let pairs = scan_review_files_inner(
-        ws.path().to_string_lossy().into_owned(),
-        &SidecarConfigState::new(),
-    );
+    let pairs = scan_review_files(ws.path().to_string_lossy().into_owned())
+        .expect("scan_review_files");
     assert!(!pairs.is_empty(), "expected at least one sidecar pair");
     for (sidecar, source) in &pairs {
         assert_no_verbatim("scan_review_files.sidecar", sidecar);
@@ -183,10 +181,8 @@ fn scan_review_files_shares_form_with_read_dir() {
     let ws = build_workspace();
     let entries =
         read_dir_inner(ws.path().to_string_lossy().into_owned(), None, None, &SidecarConfigState::new()).expect("read_dir").entries;
-    let pairs = scan_review_files_inner(
-        ws.path().to_string_lossy().into_owned(),
-        &SidecarConfigState::new(),
-    );
+    let pairs = scan_review_files(ws.path().to_string_lossy().into_owned())
+        .expect("scan_review_files");
 
     // Pick the source path emitted for doc.md by the scanner and assert
     // read_dir would emit the byte-identical string for the same file.

--- a/src-tauri/tests/path_form_test.rs
+++ b/src-tauri/tests/path_form_test.rs
@@ -10,7 +10,7 @@
 
 #![cfg(windows)]
 
-use mdown_review_lib::commands::{parse_launch_args, read_dir_inner, scan_review_files};
+use mdown_review_lib::commands::{parse_launch_args, read_dir_inner, scan_review_files_inner};
 use mdown_review_lib::watcher::{SidecarConfigState, WatcherState};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -77,8 +77,10 @@ fn read_dir_emits_no_verbatim_prefix() {
 #[test]
 fn scan_review_files_emits_no_verbatim_prefix() {
     let ws = build_workspace();
-    let pairs =
-        scan_review_files(ws.path().to_string_lossy().into_owned()).expect("scan_review_files");
+    let pairs = scan_review_files_inner(
+        ws.path().to_string_lossy().into_owned(),
+        &SidecarConfigState::new(),
+    );
     assert!(!pairs.is_empty(), "expected at least one sidecar pair");
     for (sidecar, source) in &pairs {
         assert_no_verbatim("scan_review_files.sidecar", sidecar);
@@ -181,8 +183,10 @@ fn scan_review_files_shares_form_with_read_dir() {
     let ws = build_workspace();
     let entries =
         read_dir_inner(ws.path().to_string_lossy().into_owned(), None, None, &SidecarConfigState::new()).expect("read_dir").entries;
-    let pairs =
-        scan_review_files(ws.path().to_string_lossy().into_owned()).expect("scan_review_files");
+    let pairs = scan_review_files_inner(
+        ws.path().to_string_lossy().into_owned(),
+        &SidecarConfigState::new(),
+    );
 
     // Pick the source path emitted for doc.md by the scanner and assert
     // read_dir would emit the byte-identical string for the same file.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { WelcomeView } from "@/components/WelcomeView";
 import { basename } from "@/lib/path-utils";
+import { isSidecarFile } from "@/lib/file-types";
 import { IconFile, IconFolder, IconComment } from "@/components/Icons";
 import "@/styles/app.css";
 import "@/styles/print.css";
@@ -50,6 +51,12 @@ export default function App() {
   const openFile = useStore((s) => s.openFile);
   const { checkForUpdate } = useUpdateActions();
   useUpdateProgress();
+
+  // Sidecars (.review.yaml/.review.json) are app-managed metadata; the UI
+  // hides the comments pane and disables every "add comment" affordance
+  // while a sidecar is the active tab so users cannot create stray
+  // comment threads on a comment-storage file.
+  const activeIsSidecar = activeTabPath !== null && isSidecarFile(activeTabPath);
 
   // Update document.title to reflect the active file and root folder
   useEffect(() => {
@@ -86,9 +93,11 @@ export default function App() {
   // (registered via React event delegation) pops the SelectionToolbar
   // exactly as a mouse interaction would, then auto-click the toolbar's
   // "Comment" button on the next frame to open the CommentInput.
-  // No-op when there is no usable selection.
+  // No-op when there is no usable selection or the active file is a
+  // sidecar (sidecars are app-managed metadata — not commentable).
   const startCommentOnSelection = useCallback(() => {
     if (typeof window === "undefined") return;
+    if (activeTabPath && isSidecarFile(activeTabPath)) return;
     const sel = window.getSelection();
     if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
     const range = sel.getRangeAt(0);
@@ -105,7 +114,7 @@ export default function App() {
       ) as HTMLButtonElement | null;
       btn?.click();
     });
-  }, []);
+  }, [activeTabPath]);
 
   // F1 — Esc: handled per-input by CommentInput's own keydown handler;
   // no global plumb-through is needed.
@@ -181,9 +190,14 @@ export default function App() {
             <IconFolder /> Open Folder
           </button>
           <button
-            className={`toolbar-btn toolbar-btn-toggle${commentsPaneVisible ? " active" : ""}`}
+            className={`toolbar-btn toolbar-btn-toggle${commentsPaneVisible && !activeIsSidecar ? " active" : ""}`}
             onClick={toggleCommentsPane}
-            title="Toggle comments pane (Ctrl+Shift+C)"
+            disabled={activeIsSidecar}
+            title={
+              activeIsSidecar
+                ? "Comments are disabled on .review.yaml/.review.json sidecar files"
+                : "Toggle comments pane (Ctrl+Shift+C)"
+            }
           >
             <IconComment /> Comments
           </button>
@@ -221,7 +235,7 @@ export default function App() {
           </ErrorBoundary>
         </div>
 
-        {commentsPaneVisible && activeTabPath && (
+        {commentsPaneVisible && activeTabPath && !activeIsSidecar && (
           <ErrorBoundary>
             <CommentsPanel filePath={activeTabPath} />
           </ErrorBoundary>

--- a/src/components/FolderTree/FolderTree.tsx
+++ b/src/components/FolderTree/FolderTree.tsx
@@ -232,11 +232,17 @@ export function FolderTree({ onFileOpen, onCloseFolder }: FolderTreeProps) {
   ) => {
     const isActive = activeTabPath === path;
     const expanded = opts.isDir ? expandedFolders[path] : undefined;
+    const isSidecar =
+      !opts.isDir && (name.endsWith(".review.yaml") || name.endsWith(".review.json"));
     return (
       <div
         key={path}
         data-path={path}
-        className={`tree-entry${isActive ? " active" : ""}${opts.isGhost ? " tree-entry--ghost" : ""}`}
+        className={
+          `tree-entry${isActive ? " active" : ""}` +
+          `${opts.isGhost ? " tree-entry--ghost" : ""}` +
+          `${isSidecar ? " tree-entry--sidecar" : ""}`
+        }
         tabIndex={0}
         role={opts.isDir ? "treeitem" : "option"}
         aria-selected={isActive}

--- a/src/components/viewers/MarkdownViewer.tsx
+++ b/src/components/viewers/MarkdownViewer.tsx
@@ -39,6 +39,7 @@ import { useSelectionToolbar } from "@/hooks/useSelectionToolbar";
 import { useViewerContextMenu } from "@/hooks/useViewerContextMenu";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { FindInPageBar } from "@/components/FindInPageBar";
+import { isSidecarFile } from "@/lib/file-types";
 import "@/styles/markdown.css";
 import "@/styles/find-in-page.css";
 import "@/styles/viewer-banner.css";
@@ -99,6 +100,11 @@ export function MarkdownViewer({ content, filePath, fileSize }: Props) {
   const { zoom } = useZoom(".md");
   const [commentingLine, setCommentingLine] = useState<number | null>(null);
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
+  // Sidecar files (.review.yaml/.review.json) are app-managed metadata,
+  // not commentable content. Suppress the gutter "+" affordance, the
+  // selection toolbar, and the right-click context menu so users can't
+  // attach comments to a comment-storage file.
+  const commentable = !isSidecarFile(filePath);
 
   const lines = useMemo(() => body.split("\n"), [body]);
 
@@ -327,9 +333,9 @@ export function MarkdownViewer({ content, filePath, fileSize }: Props) {
           <div
             className="markdown-body md-wrap-cascade"
             ref={bodyRef}
-            onClick={handleGutterClick}
-            onMouseUp={handleMouseUp}
-            onContextMenu={handleContextMenu}
+            onClick={commentable ? handleGutterClick : undefined}
+            onMouseUp={commentable ? handleMouseUp : undefined}
+            onContextMenu={commentable ? handleContextMenu : undefined}
             style={{ position: "relative" }}
           >
             <ReactMarkdown
@@ -339,31 +345,33 @@ export function MarkdownViewer({ content, filePath, fileSize }: Props) {
             >
               {body}
             </ReactMarkdown>
-            <MarkdownInteractionLayer
-              expandedLine={expandedLine}
-              commentingLine={commentingLine}
-              bodyRef={bodyRef}
-              threadsByLine={threadsByLine}
-              filePath={filePath}
-              lines={lines}
-              pendingSelectionAnchor={pendingSelectionAnchor}
-              addComment={addComment}
-              setCommentingLine={setCommentingLine}
-              setExpandedLine={setExpandedLine}
-              clearSelection={clearSelection}
-              selectionToolbar={selectionToolbar}
-              dismissSelectionToolbar={() => setSelectionToolbar(null)}
-              onAddSelectionComment={handleSelectionAdd}
-              contextMenu={{
-                open: ctxMenu.state.open,
-                x: ctxMenu.state.x,
-                y: ctxMenu.state.y,
-                hasSelection: ctxMenu.state.payload?.hasSelection ?? false,
-                hasLine: ctxMenu.state.payload?.line != null,
-              }}
-              onContextMenuAction={handleContextAction}
-              onContextMenuClose={closeContextMenu}
-            />
+            {commentable && (
+              <MarkdownInteractionLayer
+                expandedLine={expandedLine}
+                commentingLine={commentingLine}
+                bodyRef={bodyRef}
+                threadsByLine={threadsByLine}
+                filePath={filePath}
+                lines={lines}
+                pendingSelectionAnchor={pendingSelectionAnchor}
+                addComment={addComment}
+                setCommentingLine={setCommentingLine}
+                setExpandedLine={setExpandedLine}
+                clearSelection={clearSelection}
+                selectionToolbar={selectionToolbar}
+                dismissSelectionToolbar={() => setSelectionToolbar(null)}
+                onAddSelectionComment={handleSelectionAdd}
+                contextMenu={{
+                  open: ctxMenu.state.open,
+                  x: ctxMenu.state.x,
+                  y: ctxMenu.state.y,
+                  hasSelection: ctxMenu.state.payload?.hasSelection ?? false,
+                  hasLine: ctxMenu.state.payload?.line != null,
+                }}
+                onContextMenuAction={handleContextAction}
+                onContextMenuClose={closeContextMenu}
+              />
+            )}
           </div>
         </MdCommentContext.Provider>
         <ReadingWidthHandle containerRef={readingContainerRef} side="left" />

--- a/src/components/viewers/SourceView.tsx
+++ b/src/components/viewers/SourceView.tsx
@@ -14,6 +14,7 @@ import { useViewerContextMenu } from "@/hooks/useViewerContextMenu";
 import { SearchBar } from "./SearchBar";
 import { SourceLine } from "./source/SourceLine";
 import { SIZE_WARN_THRESHOLD } from "@/lib/comment-utils";
+import { isSidecarFile } from "@/lib/file-types";
 import "@/styles/source-viewer.css";
 
 interface Props {
@@ -29,6 +30,10 @@ export function SourceView({ content, path, filePath, fileSize, wordWrap, zoom }
   const [commentingLine, setCommentingLine] = useState<number | null>(null);
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
+  // Sidecar files (.review.yaml/.review.json) are app-managed metadata,
+  // not commentable content. Disable every "add comment" affordance and
+  // suppress the selection toolbar / context menu while one is open.
+  const commentable = !isSidecarFile(filePath);
   // Zoom is owned by `EnhancedViewer` (single owner of `useZoom` for the
   // active sub-view) and forwarded as a prop. The `--source-zoom` CSS
   // custom property below scales `.source-lines` text in CSS itself,
@@ -169,7 +174,12 @@ export function SourceView({ content, path, filePath, fileSize, wordWrap, zoom }
           This file is large ({Math.round((fileSize ?? 0) / 1024)} KB) — rendering may be slow
         </div>
       )}
-      <div className="source-lines" ref={sourceLinesRef} onMouseUp={handleMouseUp} onContextMenu={handleContextMenu}>
+      <div
+        className="source-lines"
+        ref={sourceLinesRef}
+        onMouseUp={commentable ? handleMouseUp : undefined}
+        onContextMenu={commentable ? handleContextMenu : undefined}
+      >
         {model.map((item) => {
           // Build the per-line save callback only for the currently-commenting
           // line; all other lines receive `undefined` (a stable reference) so
@@ -195,6 +205,7 @@ export function SourceView({ content, path, filePath, fileSize, wordWrap, zoom }
               lineThreads={item.lineThreads}
               isCommenting={item.isCommenting}
               isExpanded={item.isExpanded}
+              commentable={commentable}
               onToggleFold={toggleFold}
               onCommentButtonClick={handleCommentButtonClick}
               onCloseInput={handleCloseInput}
@@ -204,22 +215,24 @@ export function SourceView({ content, path, filePath, fileSize, wordWrap, zoom }
           );
         })}
       </div>
-      {selectionToolbar && (
+      {commentable && selectionToolbar && (
         <SelectionToolbar
           position={selectionToolbar.position}
           onAddComment={() => handleAddSelectionComment(setCommentingLine)}
           onDismiss={() => setSelectionToolbar(null)}
         />
       )}
-      <CommentContextMenu
-        open={ctxMenu.state.open}
-        x={ctxMenu.state.x}
-        y={ctxMenu.state.y}
-        hasSelection={ctxMenu.state.payload?.hasSelection ?? false}
-        hasLine={ctxMenu.state.payload?.line != null}
-        onAction={handleContextAction}
-        onClose={closeContextMenu}
-      />
+      {commentable && (
+        <CommentContextMenu
+          open={ctxMenu.state.open}
+          x={ctxMenu.state.x}
+          y={ctxMenu.state.y}
+          hasSelection={ctxMenu.state.payload?.hasSelection ?? false}
+          hasLine={ctxMenu.state.payload?.line != null}
+          onAction={handleContextAction}
+          onClose={closeContextMenu}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/viewers/ViewerRouter.tsx
+++ b/src/components/viewers/ViewerRouter.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useStore } from "@/store";
 import { useFileContent } from "@/hooks/useFileContent";
+import { isSidecarFile } from "@/lib/file-types";
 import { SkeletonLoader } from "./SkeletonLoader";
 import { EnhancedViewer } from "./EnhancedViewer";
 import { ImageViewerShell } from "./ImageViewerShell";
@@ -53,9 +54,15 @@ export function ViewerRouter({ path }: Props) {
   // point. Reading through `useStore.getState()` at click time (not via a
   // selector) keeps this off the render path; the action itself is a stable
   // store reference so callers don't need to re-render when it changes.
+  // Sidecar files (.review.yaml/.review.json) are app-managed metadata —
+  // omit the callback so every viewer's "Comment on file" button is
+  // suppressed at the toolbar level (ViewerToolbar already gates rendering
+  // on the callback being defined).
+  const isSidecar = isSidecarFile(path);
   const handleCommentOnFile = useCallback(() => {
     useStore.getState().requestFileLevelInput(path);
   }, [path]);
+  const commentOnFile = isSidecar ? undefined : handleCommentOnFile;
 
   // Guard flag: suppresses scroll-save during programmatic scroll restore
   const restoringRef = useRef(false);
@@ -152,7 +159,7 @@ export function ViewerRouter({ path }: Props) {
   // mount a minimal `ViewerToolbar` (toggle hidden, no zoom) above each one
   // to surface the file-anchored "Comment on file" entry point universally.
   if (status === "image") {
-    return <ImageViewerShell key={path} path={path} onCommentOnFile={handleCommentOnFile} />;
+    return <ImageViewerShell key={path} path={path} onCommentOnFile={commentOnFile} />;
   }
 
   if (status === "audio") {
@@ -162,7 +169,7 @@ export function ViewerRouter({ path }: Props) {
           activeView="visual"
           onViewChange={() => {}}
           hidden
-          onCommentOnFile={handleCommentOnFile}
+          onCommentOnFile={commentOnFile}
           trailing={<FileActionsBar path={path} />}
         />
         <AudioViewer key={path} path={path} />
@@ -177,7 +184,7 @@ export function ViewerRouter({ path }: Props) {
           activeView="visual"
           onViewChange={() => {}}
           hidden
-          onCommentOnFile={handleCommentOnFile}
+          onCommentOnFile={commentOnFile}
           trailing={<FileActionsBar path={path} />}
         />
         <TooLargePlaceholder key={path} path={path} size={sizeBytes} />
@@ -186,7 +193,7 @@ export function ViewerRouter({ path }: Props) {
   }
 
   if (status === "binary") {
-    return <BinaryViewerShell key={path} path={path} size={sizeBytes} mtime={mtimeMs} onCommentOnFile={handleCommentOnFile} />;
+    return <BinaryViewerShell key={path} path={path} size={sizeBytes} mtime={mtimeMs} onCommentOnFile={commentOnFile} />;
   }
 
   if (status === "error") {
@@ -197,7 +204,7 @@ export function ViewerRouter({ path }: Props) {
             activeView="visual"
             onViewChange={() => {}}
             hidden
-            onCommentOnFile={handleCommentOnFile}
+            onCommentOnFile={commentOnFile}
           />
           <DeletedFileViewer key={path} filePath={path} />
         </div>
@@ -209,7 +216,7 @@ export function ViewerRouter({ path }: Props) {
           activeView="visual"
           onViewChange={() => {}}
           hidden
-          onCommentOnFile={handleCommentOnFile}
+          onCommentOnFile={commentOnFile}
           trailing={<FileActionsBar path={path} />}
         />
         <div className="viewer-placeholder">
@@ -227,7 +234,7 @@ export function ViewerRouter({ path }: Props) {
         path={path}
         filePath={path}
         fileSize={fileSize}
-        onCommentOnFile={handleCommentOnFile}
+        onCommentOnFile={commentOnFile}
       />
     </div>
   );

--- a/src/components/viewers/source/SourceLine.tsx
+++ b/src/components/viewers/source/SourceLine.tsx
@@ -15,6 +15,13 @@ export interface SourceLineProps {
   lineThreads: CommentThread[];
   isCommenting: boolean;
   isExpanded: boolean;
+  /**
+   * When false, the per-line "+" add-comment button is hidden and the
+   * comment-input margin is suppressed. Used for sidecar files where
+   * the user cannot add comments. Defaults to true so callers that
+   * don't pass this prop keep the previous behaviour.
+   */
+  commentable?: boolean;
   onToggleFold: (lineNum: number) => void;
   onCommentButtonClick: (lineNum: number) => void;
   onCloseInput: () => void;
@@ -42,13 +49,14 @@ function SourceLineImpl({
   lineThreads,
   isCommenting,
   isExpanded,
+  commentable = true,
   onToggleFold,
   onCommentButtonClick,
   onCloseInput,
   onRequestInput,
   onSaveComment,
 }: SourceLineProps) {
-  const showMargin = isCommenting || isExpanded || lineThreads.length > 0;
+  const showMargin = commentable && (isCommenting || isExpanded || lineThreads.length > 0);
 
   return (
     <>
@@ -58,13 +66,15 @@ function SourceLineImpl({
       >
         <span className="source-line-gutter">
           <span className="source-line-comment-zone">
-            <button
-              className="comment-plus-btn"
-              aria-label="Add comment"
-              onClick={() => onCommentButtonClick(lineNum)}
-            >
-              +
-            </button>
+            {commentable && (
+              <button
+                className="comment-plus-btn"
+                aria-label="Add comment"
+                onClick={() => onCommentButtonClick(lineNum)}
+              >
+                +
+              </button>
+            )}
           </span>
           <span className="source-line-fold-zone">
             {foldRegion && (

--- a/src/hooks/__tests__/useFolderChildren.test.ts
+++ b/src/hooks/__tests__/useFolderChildren.test.ts
@@ -17,8 +17,13 @@ vi.mock("@/logger", () => ({
   trace: vi.fn(),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
+  // Reset Zustand store fields the hook reads — tests share the global
+  // store so leaked expandedFolders / showSidecarFiles would skew the
+  // per-test readDir call counts.
+  const { useStore } = await import("@/store");
+  useStore.setState({ expandedFolders: {}, showSidecarFiles: false });
 });
 
 /** Wrap DirEntry[] in the ReadDirResult shape returned by the Rust command. */
@@ -108,6 +113,61 @@ describe("useFolderChildren", () => {
       entries = await result.current.loadChildren("/other");
     });
     expect(entries).toEqual([]);
+  });
+
+  it("reloads root + expanded folders when showSidecarFiles toggles", async () => {
+    // Reproduces the "blank pane after toggle" + "default mismatch on
+    // persist rehydrate" bugs: when showSidecarFiles flips, the cache
+    // must be cleared AND every visible folder must be re-fetched with
+    // the new filter. Previously the load short-circuited on the stale
+    // cached entries and the tree rendered empty.
+    const { useStore } = await import("@/store");
+    useStore.setState({ expandedFolders: { "/root/sub": true } });
+
+    const rootHidden = [{ name: "a.md", path: "/root/a.md", is_dir: false }];
+    const subHidden = [{ name: "x.md", path: "/root/sub/x.md", is_dir: false }];
+    const rootShown = [
+      { name: "a.md", path: "/root/a.md", is_dir: false },
+      { name: "a.md.review.yaml", path: "/root/a.md.review.yaml", is_dir: false },
+    ];
+    const subShown = [
+      { name: "x.md", path: "/root/sub/x.md", is_dir: false },
+      { name: "x.md.review.yaml", path: "/root/sub/x.md.review.yaml", is_dir: false },
+    ];
+    vi.mocked(commands.readDir)
+      .mockResolvedValueOnce(wrapEntries(rootHidden)) // initial root (hidden)
+      .mockResolvedValueOnce(wrapEntries(subHidden))  // expanded sub (hidden)
+      .mockResolvedValueOnce(wrapEntries(rootShown))  // root reload after toggle
+      .mockResolvedValueOnce(wrapEntries(subShown));  // sub reload after toggle
+
+    useStore.setState({ showSidecarFiles: false });
+    const { result } = renderHook(() => useFolderChildren("/root"));
+    await act(async () => {});
+
+    // Trigger the expanded-sub fetch the same way the FolderTree would
+    await act(async () => {
+      await result.current.loadChildren("/root/sub");
+    });
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(rootHidden);
+    expect(result.current.childrenCache["/root/sub"]?.entries).toEqual(subHidden);
+
+    // Flip the toggle — the hook must wipe the cache AND re-fetch root +
+    // every currently-expanded folder with show_sidecars=true.
+    await act(async () => {
+      useStore.setState({ showSidecarFiles: true });
+    });
+
+    expect(result.current.childrenCache["/root"]?.entries).toEqual(rootShown);
+    expect(result.current.childrenCache["/root/sub"]?.entries).toEqual(subShown);
+
+    // Verify the IPC was called with the new filter for both folders.
+    const calls = vi.mocked(commands.readDir).mock.calls;
+    const reloadCalls = calls.slice(2);
+    const reloadedPaths = reloadCalls.map((c) => c[0]).sort();
+    expect(reloadedPaths).toEqual(["/root", "/root/sub"]);
+    for (const c of reloadCalls) {
+      expect(c[2]).toBe(true); // show_sidecars
+    }
   });
 
   it("does not load when root is null", async () => {

--- a/src/hooks/useCrossWindowPrefsSync.ts
+++ b/src/hooks/useCrossWindowPrefsSync.ts
@@ -31,8 +31,10 @@ export function useCrossWindowPrefsSync(): void {
         if (!state) return;
 
         // Apply only global prefs — NOT per-window layout state.
-        // folderPaneWidth, commentsPaneVisible, showSidecarFiles are persisted
-        // as defaults for new windows but never synced cross-window (issue #248).
+        // folderPaneWidth, commentsPaneVisible are persisted as defaults
+        // for new windows but never synced cross-window (issue #248).
+        // showSidecarFiles is per-window AND not persisted — every fresh
+        // window starts with the toggle OFF.
         // zoomByFiletype is session-only (not persisted or synced).
         //
         // Equality guard: only include fields whose value actually changed to

--- a/src/hooks/useFolderChildren.ts
+++ b/src/hooks/useFolderChildren.ts
@@ -43,12 +43,30 @@ export function useFolderChildren(root: string | null) {
     [showSidecarFiles]
   );
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on prop change
-  useEffect(() => { setChildrenCache({}); }, [root, showSidecarFiles]);
-
+  // Reset cache and reload visible folders when root or the show-sidecars
+  // filter changes. The ref is updated synchronously so that loadChildren
+  // calls within this same effect (and any concurrent listener) see the
+  // cleared state and re-fetch with the new filter — without this, the
+  // load below would short-circuit on the stale cached entries and the
+  // tree would render empty until the next manual reload (issue: blank
+  // folder pane after toggling "Show sidecar files").
   useEffect(() => {
-    if (root) loadChildren(root);
-  }, [root, loadChildren]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on filter change
+    setChildrenCache({});
+    childrenCacheRef.current = {};
+    if (!root) return;
+    // Reload root + every currently-expanded folder so the user's view is
+    // preserved across the toggle. Snapshot via getState to avoid
+    // re-subscribing on every expand/collapse.
+    const expanded = useStore.getState().expandedFolders;
+    const paths = new Set<string>([root]);
+    for (const [p, isExpanded] of Object.entries(expanded)) {
+      if (isExpanded) paths.add(p);
+    }
+    for (const p of paths) {
+      void loadChildren(p);
+    }
+  }, [root, showSidecarFiles, loadChildren]);
 
   // Refresh cached entries when Rust reports a folder change. We only refresh
   // dirs we already have in the cache — unknown dirs would be loaded lazily

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -73,6 +73,16 @@ export function getFileCategory(path: string): FileCategory {
 }
 
 /**
+ * True for `<file>.review.yaml` / `<file>.review.json` MRSF sidecar files.
+ * Mirrors `is_sidecar_file` in `src-tauri/src/commands/mod.rs`. Used by the
+ * UI to gate commenting affordances — sidecars are app-managed metadata
+ * about other files, not commentable content of their own.
+ */
+export function isSidecarFile(path: string): boolean {
+  return path.endsWith(".review.yaml") || path.endsWith(".review.json");
+}
+
+/**
  * Canonical filetype key used by the per-filetype zoom store
  * (`zoomByFiletype`). Several extensions collapse to one key (`.md` covers
  * both md/mdx; `.image` covers all bitmap/vector image extensions); the

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -342,6 +342,10 @@ export const useStore = create<Store>()(
       },
       // Only persist global prefs — per-window state (tabs, activeTabPath,
       // expandedFolders, root) starts fresh each window / app launch.
+      // `showSidecarFiles` is also intentionally NOT persisted — it's a
+      // per-window viewing toggle that must default to OFF on every fresh
+      // window so a user who flipped it on in one workspace doesn't have
+      // raw sidecars surfaced when they open another.
       partialize: (state) => ({
         theme: state.theme,
         folderPaneWidth: state.folderPaneWidth,
@@ -350,7 +354,6 @@ export const useStore = create<Store>()(
         readingWidth: state.readingWidth,
         recentItems: state.recentItems,
         updateChannel: state.updateChannel,
-        showSidecarFiles: state.showSidecarFiles,
       }),
     }
   )

--- a/src/styles/folder-tree.css
+++ b/src/styles/folder-tree.css
@@ -124,6 +124,15 @@
   opacity: 0.4;
 }
 
+/* Sidecar entry (.review.yaml/.review.json sibling visible via the
+   "Show sidecar files in folder pane" setting). Dimmed + italic to
+   signal it is metadata, not a primary source file. */
+.tree-entry--sidecar .tree-name,
+.tree-entry--sidecar .tree-icon {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 /* Comment count badge */
 .tree-comment-badge {
   font-size: 10px;


### PR DESCRIPTION
Stack of four fixes that landed while dogfooding the new `Show sidecar files in folder pane` toggle. Each commit is independently reviewable.

## 1. Folder pane goes blank after toggle / default-mismatch on persist rehydrate (a1827ba)

`useFolderChildren` split cache reset and reload across two effects. `setChildrenCache({})` is async, so the load effect ran with the still-stale ref, short-circuited on the cached entries, and never re-fetched. Combined into one effect that clears the ref synchronously and reloads root + every currently-expanded folder so the user's view is preserved.

Also fixed in the same commit:
- `read_dir` `is_sidecar_file` check now gates on `!meta.is_dir()` so a directory named `foo.review.yaml/` (legal on every FS) isn't silently filtered.
- `SidecarConfigDialog` claimed `(dimmed/italic)` rendering for sidecar entries that never existed  added `.tree-entry--sidecar` CSS rule + `isSidecar` thread through `renderRow`.

## 2. Disable commenting on .review.{yaml,json} sidecars (a8ed13c)

Sidecars are app-managed metadata about other files, not commentable content of their own. With the toggle ON users could attach comments to a sidecar file, creating stray `foo.md.review.yaml.review.yaml` files. Introduced `isSidecarFile()` in `src/lib/file-types.ts` (mirror of the Rust helper) and gated every add-comment entry point:

- App.tsx  hides `CommentsPanel`, grays out the Comments toolbar button, makes `Ctrl/Cmd+Shift+M` no-op while a sidecar is active.
- ViewerRouter  passes `undefined` for `onCommentOnFile` so every viewer's `Comment on file` toolbar button is suppressed.
- SourceView/SourceLine  new `commentable` prop suppresses the per-line `+` button, selection toolbar, context menu, and `onMouseUp` wiring.
- MarkdownViewer  skips `MarkdownInteractionLayer` and the gutter `onClick`/`onMouseUp`/`onContextMenu` handlers entirely.

## 3. Show-Sidecars defaults OFF + `.reviews/` files no longer show as ghosts (6267fa3)

- `showSidecarFiles` was being persisted across windows, so a user who flipped it on once would see raw `.review.yaml` files in every subsequent fresh window. Removed from the persist partialize so every new window starts with the toggle OFF (per-window state, like zoom).
- Under `.reviews/` mode, files inside `.reviews/` were rendering as ghosts (strikethrough) because `find_review_files` derived source paths by trimming `.review.yaml` from the sidecar location  producing `<root>/.reviews/<rel>` which doesn't exist. Added `find_review_files_with_config(root, cap, sidecar_root)` that recognises the redirect and remaps to `<root>/<rel>`.

## 4. `.mrsf.yaml` support in CLI, shared with GUI (d645d2f)

The CLI's `read --folder` was suffix-trimming sidecar paths so a workspace using `sidecar_root: .reviews/` would print `.reviews/foo.md` as the source. `read --file foo.md` couldn't find sidecars under the redirect. `respond foo.md` would write to a stale co-located location.

Factored shared helpers used by both CLI and GUI:

| Helper | Used by |
|---|---|
| `core::scanner::scan_workspace(root, cap)` | GUI `scan_review_files` IPC + CLI `read --folder` |
| `core::paths::source_for_sidecar_with_config` | Scanner per-entry mapping + CLI single-file `read --file` |
| `core::paths::resolve_sidecar_with_config` | CLI `read --file` and `respond` |
| `core::paths::try_load_mrsf_config` | Silent canonicalize + load (loud callers keep `load_mrsf_config`) |

## Tests
- **Rust unit tests:** 4 `scan_workspace_*` (both modes + conversion + malformed fallback + mixed), 5 `try_load_mrsf_config_*` (none/valid/malformed/empty/nonexistent), 6 `resolve_with_config_*` (parity, yaml/json under redirect, co-located priority, literal bypass, error), 5 `source_with_config_*` (default, remap, subdir, passthrough, non-sidecar), 4 scanner redirect tests.
- **Rust integration tests:** 3 CLI redirected-layout tests (`read --folder`, `read --file`, `respond`), 3 `read_dir` tests (show=true surfaces sidecars, `.reviews/` visible when toggle ON, directories with `.review.yaml` suffix not filtered).
- **Vitest:** `useFolderChildren` reloads root + expanded folders when `showSidecarFiles` toggles.

**419 unit tests + 109 integration tests + TypeScript clean + ESLint 0 errors.**