### PR TITLE
fix: link handling in markdown + HTML viewers

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "dialog:allow-open",
     "clipboard-manager:allow-write-text",
     "opener:allow-open-url",
+    "opener:allow-default-urls",
     "updater:default"
   ]
 }

--- a/src/components/viewers/HtmlPreviewView.tsx
+++ b/src/components/viewers/HtmlPreviewView.tsx
@@ -8,6 +8,7 @@ import {
 import { dirname } from "@/lib/path-utils";
 import { routeLinkClick } from "@/lib/url-policy";
 import { rewriteRemoteImages } from "@/lib/html-image-rewrite";
+import { injectAnchorTitles } from "@/lib/html-anchor-titles";
 import { useStore } from "@/store";
 import { useZoom } from "@/hooks/useZoom";
 import { warn } from "@/logger";
@@ -63,7 +64,11 @@ export function HtmlPreviewView({ content, filePath }: Props) {
     });
   }, [filePath]);
 
-  // Effect 1 — local-asset resolution.
+  // Effect 1 — local-asset resolution + anchor-title injection. Title
+  // stamping runs over the asset-resolved HTML so any rewritten `href`s
+  // already reflect their final shape, and lives in this effect (rather
+  // than in the resolveHtmlAssets Rust path) because it depends on the
+  // window-side workspaceRoot.
   useEffect(() => {
     if (!filePath) {
       setResolvedBase(content); // eslint-disable-line react-hooks/set-state-in-effect
@@ -75,7 +80,11 @@ export function HtmlPreviewView({ content, filePath }: Props) {
     resolveHtmlAssets(content, dirname(filePath))
       .then((resolved) => {
         if (cancelled) return;
-        setResolvedBase(resolved);
+        const titled = injectAnchorTitles(resolved, {
+          baseDir: dirname(filePath),
+          workspaceRoot,
+        });
+        setResolvedBase(titled);
       })
       .catch(() => {
         if (!cancelled) setResolvedBase(content);
@@ -86,7 +95,7 @@ export function HtmlPreviewView({ content, filePath }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [content, filePath]);
+  }, [content, filePath, workspaceRoot]);
 
   // Effect 2 — remote-image rewrite over the cached resolved-base HTML.
   useEffect(() => {
@@ -152,6 +161,12 @@ export function HtmlPreviewView({ content, filePath }: Props) {
             className="html-preview-iframe"
             style={{ background: "white" }}
             onLoad={() => {
+              const scrollIframeToFragment = (doc: Document, fragment: string) => {
+                let id = fragment;
+                try { id = decodeURIComponent(fragment); } catch { /* keep raw */ }
+                const el = doc.getElementById(id);
+                el?.scrollIntoView({ behavior: "smooth", block: "start" });
+              };
               const installClickHandler = (doc: Document) => {
                 doc.addEventListener("click", (event) => {
                   const target = event.target as Element | null;
@@ -177,14 +192,33 @@ export function HtmlPreviewView({ content, filePath }: Props) {
                       return;
                     case "workspace":
                       event.preventDefault();
-                      useStore.getState().openFile(route.path);
+                      if (filePath && route.path === filePath) {
+                        // Same-file link — scroll inside this iframe; openFile
+                        // would be a no-op and `srcDoc` doesn't navigate to a
+                        // sub-URL, so we have to do the scroll ourselves.
+                        if (route.fragment) scrollIframeToFragment(doc, route.fragment);
+                      } else {
+                        if (route.fragment) {
+                          useStore.getState().setPendingFragment({
+                            path: route.path,
+                            fragment: route.fragment,
+                          });
+                        }
+                        useStore.getState().openFile(route.path);
+                      }
                       return;
                   }
                 });
               };
+              const consumePendingForThisFile = (doc: Document) => {
+                if (!filePath) return;
+                const fragment = useStore.getState().consumePendingFragment(filePath);
+                if (fragment) scrollIframeToFragment(doc, fragment);
+              };
               const doc = iframeRef.current?.contentDocument;
               if (doc) {
                 installClickHandler(doc);
+                consumePendingForThisFile(doc);
                 return;
               }
               // Bounded retry — contentDocument can be null when the load
@@ -194,6 +228,7 @@ export function HtmlPreviewView({ content, filePath }: Props) {
                 const retryDoc = iframeRef.current?.contentDocument;
                 if (retryDoc) {
                   installClickHandler(retryDoc);
+                  consumePendingForThisFile(retryDoc);
                 } else {
                   void warn("[HtmlPreviewView] contentDocument unavailable after rAF retry");
                 }

--- a/src/components/viewers/HtmlPreviewView.tsx
+++ b/src/components/viewers/HtmlPreviewView.tsx
@@ -177,7 +177,13 @@ export function HtmlPreviewView({ content, filePath }: Props) {
                   const route = routeLinkClick(href, { baseDir, workspaceRoot });
                   switch (route.kind) {
                     case "fragment":
-                      return; // let the browser scroll natively
+                      // Native fragment scroll inside `srcdoc` iframes is
+                      // unreliable in WebView2 (the synthetic `about:srcdoc`
+                      // URL doesn't update its hash, so the browser skips
+                      // the scroll). Always scroll explicitly.
+                      event.preventDefault();
+                      scrollIframeToFragment(doc, route.fragment);
+                      return;
                     case "blocked":
                       event.preventDefault();
                       void warn(

--- a/src/components/viewers/MarkdownViewer.tsx
+++ b/src/components/viewers/MarkdownViewer.tsx
@@ -188,6 +188,26 @@ export function MarkdownViewer({ content, filePath, fileSize }: Props) {
   }, []);
   useScrollToLine(bodyRef, "data-source-line", undefined, handleScrollTo, filePath);
 
+  // Consume cross-file fragment requests left by anchor clicks. The link
+  // handler stashes `{path, fragment}` in the store, then `openFile` swaps
+  // the active tab. ViewerRouter remounts this viewer (keyed on `path`) and
+  // we land here with the new content already in `body`. rehype-slug emits
+  // ids synchronously during ReactMarkdown's first commit, so the heading
+  // exists in the DOM by the time this useEffect fires. Only the same-tab,
+  // already-mounted case is handled in the click handler directly.
+  useEffect(() => {
+    if (!body) return;
+    const fragment = useStore.getState().consumePendingFragment(filePath);
+    if (!fragment) return;
+    let id = fragment;
+    try { id = decodeURIComponent(fragment); } catch { /* keep raw */ }
+    const handle = requestAnimationFrame(() => {
+      const el = document.getElementById(id);
+      el?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [filePath, body]);
+
   const showSizeWarning = fileSize !== undefined && fileSize > SIZE_WARN_THRESHOLD;
 
   const handleLineClick = useCallback(

--- a/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
+++ b/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
@@ -220,6 +220,40 @@ describe("HtmlPreviewView — safe-mode link interception (H3)", () => {
     expect(useStore.getState().openFile).toHaveBeenCalledWith("/wk/other.html");
     cleanup();
   });
+
+  // Regression: fragment-only links (`<a href="#section">`) inside the
+  // sandboxed `srcdoc` iframe must scroll explicitly. WebView2 does not
+  // perform native fragment navigation against `about:srcdoc`, so the
+  // browser-default code path silently skipped the scroll. Issue
+  // surfaced manually with site/index.html in dev.
+  it("fragment-only link scrolls inside iframe (no native default)", async () => {
+    const { container } = render(
+      <HtmlPreviewView content="<p>test</p>" filePath="/wk/page.html" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const doc = iframe.contentDocument!;
+    fireEvent.load(iframe);
+
+    const target = doc.createElement("section");
+    target.id = "how-it-works";
+    const scrollSpy = vi.fn();
+    target.scrollIntoView = scrollSpy;
+    doc.body.appendChild(target);
+
+    const anchor = doc.createElement("a");
+    anchor.setAttribute("href", "#how-it-works");
+    anchor.textContent = "jump";
+    doc.body.appendChild(anchor);
+    const event = new doc.defaultView!.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    anchor.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    cleanup();
+  });
 });
 
 describe("HtmlPreviewView — anchor title injection", () => {

--- a/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
+++ b/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
@@ -32,6 +32,16 @@ vi.mock("@/store", () => {
     bumpZoom: () => {},
     setZoom: () => {},
     openFile: vi.fn(),
+    pendingFragment: null as { path: string; fragment: string } | null,
+    setPendingFragment: vi.fn((entry: { path: string; fragment: string } | null) => {
+      state.pendingFragment = entry;
+    }),
+    consumePendingFragment: vi.fn((path: string) => {
+      const p = state.pendingFragment;
+      if (!p || p.path !== path) return null;
+      state.pendingFragment = null;
+      return p.fragment;
+    }),
   };
   const useStore = (selector: (s: typeof state) => unknown) => selector(state);
   (useStore as unknown as { getState: () => typeof state }).getState = () => state;
@@ -158,6 +168,74 @@ describe("HtmlPreviewView — safe-mode link interception (H3)", () => {
     doc.body.appendChild(anchor);
     fireEvent.click(anchor);
     expect(openExternalUrl).toHaveBeenCalledWith("https://example.com");
+    cleanup();
+  });
+
+  it("same-file workspace fragment click scrolls inside the iframe (no openFile)", async () => {
+    const { useStore } = await import("@/store");
+    const { container } = render(
+      <HtmlPreviewView content="<p>test</p>" filePath="/wk/page.html" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const doc = iframe.contentDocument!;
+    fireEvent.load(iframe);
+
+    const target = doc.createElement("h2");
+    target.id = "section-y";
+    target.textContent = "Section Y";
+    const scrollSpy = vi.fn();
+    target.scrollIntoView = scrollSpy;
+    doc.body.appendChild(target);
+
+    const anchor = doc.createElement("a");
+    anchor.setAttribute("href", "./page.html#section-y");
+    anchor.textContent = "same";
+    doc.body.appendChild(anchor);
+    fireEvent.click(anchor);
+
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    expect(useStore.getState().openFile).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("cross-file workspace fragment click sets pendingFragment then opens the file", async () => {
+    const { useStore } = await import("@/store");
+    const { container } = render(
+      <HtmlPreviewView content="<p>test</p>" filePath="/wk/page.html" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const doc = iframe.contentDocument!;
+    fireEvent.load(iframe);
+
+    const anchor = doc.createElement("a");
+    anchor.setAttribute("href", "./other.html#section-x");
+    anchor.textContent = "other";
+    doc.body.appendChild(anchor);
+    fireEvent.click(anchor);
+
+    expect(useStore.getState().setPendingFragment).toHaveBeenCalledWith({
+      path: "/wk/other.html",
+      fragment: "section-x",
+    });
+    expect(useStore.getState().openFile).toHaveBeenCalledWith("/wk/other.html");
+    cleanup();
+  });
+});
+
+describe("HtmlPreviewView — anchor title injection", () => {
+  it("stamps title attributes on anchors in the resolved srcDoc", async () => {
+    const { container } = render(
+      <HtmlPreviewView
+        content='<a href="./other.html">x</a> <a href="https://example.com">y</a>'
+        filePath="/wk/page.html"
+      />,
+    );
+    await waitFor(() => {
+      const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+      const srcDoc = iframe.getAttribute("srcdoc") ?? "";
+      expect(srcDoc).toContain('title="other.html"');
+      expect(srcDoc).toContain('title="https://example.com"');
+    });
     cleanup();
   });
 });

--- a/src/components/viewers/markdown/MarkdownComponentsMap.tsx
+++ b/src/components/viewers/markdown/MarkdownComponentsMap.tsx
@@ -10,9 +10,10 @@ import React, {
 import type { Components, ExtraProps } from "react-markdown";
 import { getSharedHighlighter } from "@/lib/shiki";
 import { openExternalUrl } from "@/lib/tauri-commands";
-import { warn, info } from "@/logger";
+import { warn } from "@/logger";
 import { dirname } from "@/lib/path-utils";
 import { routeLinkClick } from "@/lib/url-policy";
+import { tooltipForRoute } from "@/lib/html-anchor-titles";
 import { useStore } from "@/store";
 import { lazyWithSuspense } from "../lazy";
 import {
@@ -85,17 +86,28 @@ const MermaidEmbed = lazyWithSuspense<{ content: string }>(() =>
 // resolution and external-scheme dispatch. See MarkdownViewer for the original
 // rationale: openExternalUrl already enforces an allowlist, but we should not
 // even call it for known-bad schemes.
+//
+// Also computes a `title` tooltip per link via the shared `tooltipForRoute`
+// chokepoint so hover on a relative-path link shows the resolved workspace
+// path rather than just `./other.md`. Mirrors the behaviour the HTML preview
+// gets via `injectAnchorTitles` in its asset-resolve pipeline.
 function makeAnchorComponent(filePath: string, workspaceRoot: string) {
   const baseDir = filePath ? dirname(filePath) : "";
   return function MarkdownAnchor({
     href,
     children,
     node: _node,
+    title,
     ...props
   }: ComponentPropsWithoutRef<"a"> & ExtraProps) {
+    const route = href
+      ? routeLinkClick(href, { baseDir: baseDir || undefined, workspaceRoot })
+      : null;
+    // Don't override an author-supplied title (markdown's `[label](url "title")`).
+    const computedTitle =
+      title ?? (route ? tooltipForRoute(route, workspaceRoot) ?? undefined : undefined);
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (!href) return;
-      const route = routeLinkClick(href, { baseDir: baseDir || undefined, workspaceRoot });
+      if (!route) return;
       switch (route.kind) {
         case "fragment":
           // In-document scroll — let the browser handle it natively.
@@ -106,23 +118,48 @@ function makeAnchorComponent(filePath: string, workspaceRoot: string) {
           return;
         case "external":
           e.preventDefault();
-          openExternalUrl(route.href).catch((e) => warn(`[MarkdownViewer] link open failed: ${e}`));
+          openExternalUrl(route.href).catch((err) =>
+            warn(`[MarkdownViewer] link open failed: ${err}`),
+          );
           return;
         case "workspace":
           e.preventDefault();
-          useStore.getState().openFile(route.path);
-          if (route.fragment) {
-            void info(`MarkdownViewer: link fragment "#${route.fragment}" not yet scrolled`);
+          if (route.path === filePath) {
+            // Same-file link — file is already active; openFile would be a
+            // no-op. Scroll directly to the requested heading id (rehype-slug
+            // emits `id="…"` on every heading; ids are document-unique).
+            if (route.fragment) scrollToFragment(route.fragment);
+          } else {
+            // Cross-file link — stash the fragment for the destination viewer
+            // to consume on first render, then open the file.
+            if (route.fragment) {
+              useStore.getState().setPendingFragment({
+                path: route.path,
+                fragment: route.fragment,
+              });
+            }
+            useStore.getState().openFile(route.path);
           }
           return;
       }
     };
     return (
-      <a href={href} onClick={handleClick} {...props}>
+      <a href={href} title={computedTitle} onClick={handleClick} {...props}>
         {children}
       </a>
     );
   };
+}
+
+function scrollToFragment(fragment: string): void {
+  let id = fragment;
+  try {
+    id = decodeURIComponent(fragment);
+  } catch {
+    /* keep raw on malformed input */
+  }
+  const el = document.getElementById(id);
+  el?.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 // Build the components map for ReactMarkdown. The `pre`, `img`, and anchor

--- a/src/components/viewers/markdown/__tests__/MarkdownComponentsMap.test.tsx
+++ b/src/components/viewers/markdown/__tests__/MarkdownComponentsMap.test.tsx
@@ -176,4 +176,96 @@ describe("buildMarkdownComponents — anchor link handling", () => {
       );
     });
   });
+
+  it("renders title attribute showing resolved external URL", async () => {
+    const { container } = renderMd("[link](https://example.com)\n");
+    await waitFor(() => {
+      expect(container.querySelector("a")?.getAttribute("title")).toBe(
+        "https://example.com",
+      );
+    });
+  });
+
+  it("renders title attribute showing workspace-relative path for relative links", async () => {
+    const { container } = renderMd("[link](./other.md)\n");
+    await waitFor(() => {
+      expect(container.querySelector("a")?.getAttribute("title")).toBe("other.md");
+    });
+  });
+
+  it("preserves an author-supplied title attribute (markdown `[label](url \"title\")`)", async () => {
+    const { container } = renderMd('[link](https://example.com "Hover text")\n');
+    await waitFor(() => {
+      expect(container.querySelector("a")?.getAttribute("title")).toBe("Hover text");
+    });
+  });
+
+  it("does not add a title attribute for blocked schemes", async () => {
+    const { container } = renderMd("[link](javascript:alert(1))\n");
+    await waitFor(() => {
+      const a = container.querySelector("a");
+      expect(a).not.toBeNull();
+      expect(a!.getAttribute("title")).toBeNull();
+    });
+  });
+});
+
+describe("buildMarkdownComponents — workspace fragment routing", () => {
+  beforeEach(async () => {
+    const { useStore } = await import("@/store");
+    useStore.setState({ pendingFragment: null });
+  });
+
+  it("same-file fragment click scrolls to the matching id (no openFile, no pending)", async () => {
+    const { useStore } = await import("@/store");
+    const openFile = vi.fn();
+    useStore.setState({ openFile });
+
+    // Insert a target heading the same way rehype-slug would.
+    const target = document.createElement("h2");
+    target.id = "section-x";
+    target.textContent = "Section X";
+    const scrollSpy = vi.fn();
+    target.scrollIntoView = scrollSpy;
+    document.body.appendChild(target);
+
+    const { container } = renderMd("[same](./x.md#section-x)\n");
+    await waitFor(() => expect(container.querySelector("a")).not.toBeNull());
+    fireEvent.click(container.querySelector("a")!);
+
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    expect(openFile).not.toHaveBeenCalled();
+    expect(useStore.getState().pendingFragment).toBeNull();
+
+    document.body.removeChild(target);
+  });
+
+  it("cross-file fragment click sets pendingFragment then opens the new file", async () => {
+    const { useStore } = await import("@/store");
+    const openFile = vi.fn();
+    useStore.setState({ openFile });
+
+    const { container } = renderMd("[other](./other.md#part-2)\n");
+    await waitFor(() => expect(container.querySelector("a")).not.toBeNull());
+    fireEvent.click(container.querySelector("a")!);
+
+    expect(useStore.getState().pendingFragment).toEqual({
+      path: "/docs/other.md",
+      fragment: "part-2",
+    });
+    expect(openFile).toHaveBeenCalledWith("/docs/other.md");
+  });
+
+  it("cross-file link without fragment does NOT set pendingFragment", async () => {
+    const { useStore } = await import("@/store");
+    const openFile = vi.fn();
+    useStore.setState({ openFile, pendingFragment: null });
+
+    const { container } = renderMd("[other](./other.md)\n");
+    await waitFor(() => expect(container.querySelector("a")).not.toBeNull());
+    fireEvent.click(container.querySelector("a")!);
+
+    expect(useStore.getState().pendingFragment).toBeNull();
+    expect(openFile).toHaveBeenCalledWith("/docs/other.md");
+  });
 });

--- a/src/lib/__tests__/capabilities-least-privilege.test.ts
+++ b/src/lib/__tests__/capabilities-least-privilege.test.ts
@@ -67,6 +67,14 @@ describe("Tauri capabilities least-privilege", () => {
     expect(caps.permissions).toContain("opener:allow-open-url");
   });
 
+  // Without `opener:allow-default-urls` the URL-scope check rejects every
+  // call to `openUrl()`, so external links from the markdown / HTML viewers
+  // silently fail. This permission is the canned scope for http(s)/mailto/tel,
+  // matching the JS-side `EXTERNAL_LINK_SCHEME` allowlist in `lib/url-policy.ts`.
+  it("includes opener:allow-default-urls so http(s)/mailto/tel URLs pass the scope check", () => {
+    expect(caps.permissions).toContain("opener:allow-default-urls");
+  });
+
   it("includes updater permissions for auto-update workflow", () => {
     expect(caps.permissions).toContain("updater:default");
   });

--- a/src/lib/__tests__/html-anchor-titles.test.ts
+++ b/src/lib/__tests__/html-anchor-titles.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { tooltipForRoute, injectAnchorTitles } from "../html-anchor-titles";
+import type { LinkRoute } from "../url-policy";
+
+describe("tooltipForRoute", () => {
+  it("returns the URL for external routes", () => {
+    const route: LinkRoute = { kind: "external", href: "https://tauri.app" };
+    expect(tooltipForRoute(route, "/wk")).toBe("https://tauri.app");
+  });
+
+  it("returns workspace-relative path for workspace routes", () => {
+    const route: LinkRoute = { kind: "workspace", path: "/wk/docs/intro.md" };
+    expect(tooltipForRoute(route, "/wk")).toBe("docs/intro.md");
+  });
+
+  it("appends decoded fragment for workspace routes", () => {
+    const route: LinkRoute = {
+      kind: "workspace",
+      path: "/wk/docs/intro.md",
+      fragment: "getting-started",
+    };
+    expect(tooltipForRoute(route, "/wk")).toBe("docs/intro.md#getting-started");
+  });
+
+  it("URL-decodes fragments (%C3%A9 → é)", () => {
+    const route: LinkRoute = { kind: "fragment", fragment: "caf%C3%A9" };
+    expect(tooltipForRoute(route, "/wk")).toBe("#café");
+  });
+
+  it("falls back to absolute path when not under workspace root", () => {
+    const route: LinkRoute = { kind: "workspace", path: "/other/file.md" };
+    expect(tooltipForRoute(route, "/wk")).toBe("/other/file.md");
+  });
+
+  it("returns the workspace root itself when path equals root", () => {
+    const route: LinkRoute = { kind: "workspace", path: "/wk" };
+    expect(tooltipForRoute(route, "/wk")).toBe("/wk");
+  });
+
+  it("returns null for blocked routes (caller should omit title)", () => {
+    const route: LinkRoute = { kind: "blocked", href: "javascript:x", reason: "blocked-scheme" };
+    expect(tooltipForRoute(route, "/wk")).toBeNull();
+  });
+
+  it("normalises Windows-style separators in workspace path", () => {
+    const route: LinkRoute = { kind: "workspace", path: "C:\\wk\\sub\\page.md" };
+    expect(tooltipForRoute(route, "C:\\wk")).toBe("sub/page.md");
+  });
+});
+
+describe("injectAnchorTitles", () => {
+  const ctx = { baseDir: "/wk/sub", workspaceRoot: "/wk" };
+
+  it("stamps a title onto an external anchor", () => {
+    const html = '<a href="https://example.com">x</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(
+      '<a href="https://example.com" title="https://example.com">x</a>',
+    );
+  });
+
+  it("stamps workspace-relative title with fragment", () => {
+    const html = '<a href="./other.html#part-1">x</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(
+      '<a href="./other.html#part-1" title="sub/other.html#part-1">x</a>',
+    );
+  });
+
+  it("preserves an author-supplied title attribute", () => {
+    const html = '<a href="https://example.com" title="Existing">x</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(html);
+  });
+
+  it("skips anchors with no href", () => {
+    const html = '<a name="x">y</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(html);
+  });
+
+  it("skips empty href", () => {
+    const html = '<a href="">y</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(html);
+  });
+
+  it("skips blocked URL schemes (no title attribute added)", () => {
+    const html = '<a href="javascript:alert(1)">x</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(html);
+  });
+
+  it("supports single-quoted href attribute", () => {
+    const html = "<a href='https://example.com'>x</a>";
+    const out = injectAnchorTitles(html, ctx);
+    expect(out).toContain('title="https://example.com"');
+  });
+
+  it("HTML-escapes characters inside the title value", () => {
+    const html = '<a href="https://x.com/?q=&lt;hi&gt;">x</a>';
+    const out = injectAnchorTitles(html, ctx);
+    // The href value already contains literal `&lt;`/`&gt;`; in the title
+    // attribute the `&` gets re-escaped to `&amp;` so the browser preserves
+    // the original character sequence on display.
+    expect(out).toContain('title="https://x.com/?q=&amp;lt;hi&amp;gt;"');
+  });
+
+  it("emits a #fragment title for fragment-only anchors", () => {
+    const html = '<a href="#sec">x</a>';
+    expect(injectAnchorTitles(html, ctx)).toBe(
+      '<a href="#sec" title="#sec">x</a>',
+    );
+  });
+
+  it("processes multiple anchors independently", () => {
+    const html = '<a href="https://a.com">a</a> and <a href="./b.md">b</a>';
+    const out = injectAnchorTitles(html, ctx);
+    expect(out).toContain('title="https://a.com"');
+    expect(out).toContain('title="sub/b.md"');
+  });
+});

--- a/src/lib/html-anchor-titles.ts
+++ b/src/lib/html-anchor-titles.ts
@@ -1,0 +1,80 @@
+/**
+ * Anchor tooltip helpers — shared between MarkdownViewer and HtmlPreviewView.
+ *
+ * `tooltipForRoute` produces a human-readable label for a routed link:
+ *   • external  → the full URL                         e.g. `https://tauri.app`
+ *   • workspace → workspace-relative path (+ #frag)    e.g. `docs/intro.md#install`
+ *   • fragment  → `#fragment`
+ *   • blocked   → null (caller should omit the title attribute)
+ *
+ * `injectAnchorTitles` walks anchor tags in a raw HTML string and stamps a
+ * `title="…"` attribute when one is absent. Used by the HTML preview's
+ * resolve-assets pipeline so author-supplied HTML gets the same hover hints
+ * the markdown viewer renders natively via the React anchor component.
+ *
+ * Pure string transforms — no DOM, no React, no IPC. Mirrors the regex-based
+ * shape of `lib/html-image-rewrite.ts`. The regex misses pathological cases
+ * (e.g. `>` inside attribute values); the worst-case failure is that a tag
+ * keeps its original lack-of-title, never that we corrupt the HTML.
+ */
+
+import { routeLinkClick, type LinkRoute, type RouteLinkContext } from "./url-policy";
+
+// `<a` followed by attribute glob then closing `>`. `[^>]*` deliberately
+// non-greedy across `>`-in-attribute-quotes — safe failure mode is a missed
+// injection (see file header).
+const A_TAG_RE = /<a\b([^>]*)>/gi;
+const HREF_RE = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+const TITLE_PRESENT_RE = /\btitle\s*=/i;
+
+export function tooltipForRoute(
+  route: LinkRoute,
+  workspaceRoot: string,
+): string | null {
+  switch (route.kind) {
+    case "fragment":
+      return `#${decodeFragment(route.fragment)}`;
+    case "external":
+      return route.href;
+    case "workspace": {
+      const root = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+      const path = route.path.replace(/\\/g, "/");
+      const rel = root && (path === root || path.startsWith(`${root}/`))
+        ? path.slice(root.length + 1) || path
+        : path;
+      return route.fragment ? `${rel}#${decodeFragment(route.fragment)}` : rel;
+    }
+    case "blocked":
+      return null;
+  }
+}
+
+function decodeFragment(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function htmlEscapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function injectAnchorTitles(html: string, ctx: RouteLinkContext): string {
+  return html.replace(A_TAG_RE, (full, attrs: string) => {
+    if (TITLE_PRESENT_RE.test(attrs)) return full;
+    const hrefMatch = HREF_RE.exec(attrs);
+    if (!hrefMatch) return full;
+    const href = hrefMatch[1] ?? hrefMatch[2] ?? "";
+    if (!href) return full;
+    const route = routeLinkClick(href, ctx);
+    const tooltip = tooltipForRoute(route, ctx.workspaceRoot);
+    if (!tooltip) return full;
+    return `<a${attrs} title="${htmlEscapeAttr(tooltip)}">`;
+  });
+}

--- a/src/store/__tests__/pendingFragment.test.ts
+++ b/src/store/__tests__/pendingFragment.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `pendingFragment` slice contract.
+ *
+ * Fragment-aware cross-file link navigation (markdown + HTML preview):
+ * the producer (link click handler) stashes `{path, fragment}`; the
+ * destination viewer consumes by matching path on first render. Tests
+ * mirror the `pendingScrollTarget` contract so the two transient slots
+ * behave identically.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useStore } from "@/store";
+
+beforeEach(() => {
+  useStore.setState({ pendingFragment: null });
+});
+
+describe("pendingFragment slice", () => {
+  it("starts null", () => {
+    expect(useStore.getState().pendingFragment).toBeNull();
+  });
+
+  it("set then consume by matching path returns fragment and clears", () => {
+    useStore.getState().setPendingFragment({ path: "/wk/a.md", fragment: "intro" });
+    expect(useStore.getState().pendingFragment).toEqual({
+      path: "/wk/a.md",
+      fragment: "intro",
+    });
+
+    expect(useStore.getState().consumePendingFragment("/wk/a.md")).toBe("intro");
+    expect(useStore.getState().pendingFragment).toBeNull();
+  });
+
+  it("consume with non-matching path returns null and leaves entry intact", () => {
+    useStore.getState().setPendingFragment({ path: "/wk/a.md", fragment: "x" });
+    expect(useStore.getState().consumePendingFragment("/wk/b.md")).toBeNull();
+    expect(useStore.getState().pendingFragment).toEqual({
+      path: "/wk/a.md",
+      fragment: "x",
+    });
+  });
+
+  it("subsequent set supersedes prior entry", () => {
+    useStore.getState().setPendingFragment({ path: "/wk/a.md", fragment: "first" });
+    useStore.getState().setPendingFragment({ path: "/wk/b.md", fragment: "second" });
+    expect(useStore.getState().pendingFragment).toEqual({
+      path: "/wk/b.md",
+      fragment: "second",
+    });
+  });
+
+  it("consume is one-shot — second call returns null", () => {
+    useStore.getState().setPendingFragment({ path: "/wk/a.md", fragment: "x" });
+    expect(useStore.getState().consumePendingFragment("/wk/a.md")).toBe("x");
+    expect(useStore.getState().consumePendingFragment("/wk/a.md")).toBeNull();
+  });
+
+  it("explicit null clear empties the field", () => {
+    useStore.getState().setPendingFragment({ path: "/wk/a.md", fragment: "x" });
+    useStore.getState().setPendingFragment(null);
+    expect(useStore.getState().pendingFragment).toBeNull();
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -81,6 +81,14 @@ interface UISlice {
    * NOT persisted (never carried across reloads).
    */
   pendingFileLevelInputFor: string | null;
+  /**
+   * Transient: a `{path, fragment}` request to scroll the next viewer for
+   * `path` to the given heading id. Set by viewer link handlers when they
+   * open another file (or the same file) with a `#fragment`. Consumed by
+   * the destination viewer (markdown or HTML iframe) once its content has
+   * rendered. NOT persisted.
+   */
+  pendingFragment: { path: string; fragment: string } | null;
   setTheme: (theme: Theme) => void;
   setFolderPaneWidth: (width: number) => void;
   toggleCommentsPane: () => void;
@@ -88,6 +96,9 @@ interface UISlice {
   setReadingWidth: (n: number) => void;
   requestFileLevelInput: (filePath: string) => void;
   clearFileLevelInput: () => void;
+  setPendingFragment: (entry: { path: string; fragment: string } | null) => void;
+  /** Returns + clears the pending fragment iff its path matches; else null. */
+  consumePendingFragment: (path: string) => string | null;
   /** When true, .review.yaml/.review.json files appear in the folder tree. */
   showSidecarFiles: boolean;
   toggleShowSidecarFiles: () => void;
@@ -224,6 +235,7 @@ export const useStore = create<Store>()(
       authorName: "",
       readingWidth: 720,
       pendingFileLevelInputFor: null,
+      pendingFragment: null,
       setTheme: (theme) => set({ theme }),
       setFolderPaneWidth: (width) => set({ folderPaneWidth: width }),
       toggleCommentsPane: () => set((s) => ({ commentsPaneVisible: !s.commentsPaneVisible })),
@@ -231,6 +243,13 @@ export const useStore = create<Store>()(
       setReadingWidth: (n) => set({ readingWidth: Math.max(400, Math.min(1600, n)) }),
       requestFileLevelInput: (filePath) => set({ pendingFileLevelInputFor: filePath, commentsPaneVisible: true }),
       clearFileLevelInput: () => set({ pendingFileLevelInputFor: null }),
+      setPendingFragment: (entry) => set({ pendingFragment: entry }),
+      consumePendingFragment: (path) => {
+        const pending = get().pendingFragment;
+        if (!pending || pending.path !== path) return null;
+        set({ pendingFragment: null });
+        return pending.fragment;
+      },
       showSidecarFiles: false,
       toggleShowSidecarFiles: () => set((s) => ({ showSidecarFiles: !s.showSidecarFiles })),
       sidecarConfigDialogOpen: false,


### PR DESCRIPTION
Three related defects in viewer link routing  surfaced when the user tried to click links inside the HTML preview and noticed external + same-page anchors did nothing. Fixed all three with surgical changes plus a follow-up for fragment-only `#anchor` links observed in dev-build manual validation against `site/index.html`.

## 1. External links never opened

The Tauri opener plugin gates `open_url` through a URL scope; `opener:allow-open-url` alone leaves the scope empty, so every URL was rejected. Add `opener:allow-default-urls` (the canned scope for `http(s)`/`mailto`/`tel`)  matches the JS-side `EXTERNAL_LINK_SCHEME` allowlist in `lib/url-policy.ts`.

## 2. Same-file fragment links did nothing

`routeLinkClick` returns `kind:'workspace'` for `file.md#anchor`; both viewers called `openFile(currentPath)`  a no-op when the file is already active  then dropped the fragment.

- **Same file**: scroll directly to the heading id (markdown via `document.getElementById`, HTML inside the iframe `contentDocument`).
- **Cross file**: stash a new `pendingFragment` store entry and `openFile`; the destination viewer consumes the fragment on first render. Mirrors the existing `pendingScrollTarget` pattern.

## 3. No tooltips on links

`MarkdownAnchor` now sets `title=` from the routed result (external URL / workspace path / `#fragment`). Author-supplied titles (`[label](url \"title\")`) are preserved. HTML preview gets the same treatment via a new `lib/html-anchor-titles.ts` helper applied in the `resolveHtmlAssets` pipeline.

## 4. (follow-up) Fragment-only links inside iframe

Native fragment scroll against `about:srcdoc` is unreliable in WebView2  the synthetic URL doesn't update its hash, so the browser silently skips the scroll. The iframe click handler now `preventDefault` and scrolls explicitly via `getElementById(id).scrollIntoView()` for `kind:'fragment'` too.

## Files

- `src-tauri/capabilities/default.json`  add opener scope
- `src/lib/html-anchor-titles.ts` (new)  shared tooltip + iframe title injector
- `src/store/index.ts`  `pendingFragment` slot in UI slice
- `src/components/viewers/markdown/MarkdownComponentsMap.tsx`  title attr + same-file scroll + pending
- `src/components/viewers/MarkdownViewer.tsx`  consume pending fragment on render
- `src/components/viewers/HtmlPreviewView.tsx`  same-file scroll inside iframe + cross-file pending + title injection + explicit fragment scroll

## Tests

- `src/lib/__tests__/html-anchor-titles.test.ts` (new, 18 cases)
- `src/store/__tests__/pendingFragment.test.ts` (new, 6 cases)
- `capabilities-least-privilege.test.ts`  assert new opener scope
- `MarkdownComponentsMap.test.tsx`  title attribute, same-file scroll, cross-file pending
- `HtmlPreviewView.test.tsx`  title injection, same-file scroll, cross-file pending, fragment-only explicit scroll

## Verification

- `npx tsc --noEmit`: clean
- `npx eslint` on changed files: 0 errors
- `npm test -- --run`: 1623 passed (1 skipped)
- `cargo check`: clean
- `npm run tauri dev` + manual click-through on `site/index.html`: external opens in browser, `#how-it-works` / `#install` scroll inside iframe, hovers show resolved tooltips