### PR TITLE
fix: rescue stranded .reviews/ files when toggle is disabled

### DIFF
--- a/src-tauri/src/commands/sidecar_config.rs
+++ b/src-tauri/src/commands/sidecar_config.rs
@@ -16,7 +16,7 @@ use tauri::{Emitter, Manager};
 // `#[serde(rename_all = "camelCase")]` here — that silently turns every
 // numeric field into `undefined` on the JS side and the dialog falls
 // back to 0/0 (issue #240 regression).
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Debug)]
 pub struct SidecarConfigResult {
     pub enabled: bool,
     pub sidecar_root: Option<String>,
@@ -24,7 +24,7 @@ pub struct SidecarConfigResult {
     pub count_colocated: u32,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Debug)]
 pub struct MigrateSidecarsResult {
     pub moved: u32,
     pub failed: Vec<String>,
@@ -126,24 +126,48 @@ pub fn migrate_sidecars_cmd(
 ) -> Result<MigrateSidecarsResult, String> {
     let root = canon(&root)?;
 
-    let sidecar_root = match config_state.resolve_for_file(&root) {
+    let configured = match config_state.resolve_for_file(&root) {
         Some((_, sr)) => sr,
         None => load_mrsf_config(&root)?,
     };
 
-    let sr = sidecar_root
-        .as_ref()
-        .ok_or_else(|| "no sidecar_root configured — enable sidecar folder first".to_string())?;
-
-    let result = migration::migrate_sidecars(&root, sr, direction);
-
-    // Re-count after migration
-    let config = build_result(&root, &sidecar_root);
+    let result = migrate_sidecars_inner(&root, configured.as_deref(), direction)?;
     emit_config_changed(&window.app_handle(), &root);
+    Ok(result)
+}
 
+/// Pure variant of [`migrate_sidecars_cmd`] used by the command and by
+/// integration tests. `configured` is the explicit `sidecar_root` resolved
+/// from `SidecarConfigState`/`.mrsf.yaml`. Callers do NOT pre-apply the
+/// `.reviews/` fallback — that lives in [`migration::effective_sidecar_root`]
+/// so the count and migrate paths share one source of truth.
+pub fn migrate_sidecars_inner(
+    root: &std::path::Path,
+    configured: Option<&std::path::Path>,
+    direction: MigrateDirection,
+) -> Result<MigrateSidecarsResult, String> {
+    let configured_owned = configured.map(|p| p.to_path_buf());
+    let effective = migration::effective_sidecar_root(root, configured);
+
+    let migration_outcome = match (effective, &direction) {
+        (Some(sr), _) => migration::migrate_sidecars(root, &sr, direction.clone()),
+        // No `.reviews/` exists and no config — nothing to rescue. Returning
+        // an empty result (rather than an error) keeps the UI quiet when the
+        // user has nothing stranded.
+        (None, MigrateDirection::ToColocated) => migration::MigrationResult::default(),
+        // Migrating *into* a folder needs an explicit destination; without
+        // one we surface an error so the dialog can prompt the user.
+        (None, MigrateDirection::ToFolder) => {
+            return Err(
+                "no sidecar_root configured — enable sidecar folder first".to_string(),
+            );
+        }
+    };
+
+    let config = build_result(&root.to_path_buf(), &configured_owned);
     Ok(MigrateSidecarsResult {
-        moved: result.moved,
-        failed: result.failed,
+        moved: migration_outcome.moved,
+        failed: migration_outcome.failed,
         config,
     })
 }
@@ -190,5 +214,79 @@ mod tests {
         let cfg = json.get("config").unwrap();
         assert!(cfg.get("count_in_folder").is_some());
         assert!(cfg.get("count_colocated").is_some());
+    }
+
+    // ── migrate_sidecars_inner ─────────────────────────────────────────
+
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write_sidecar(path: &Path) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(path, b"comments: []\n").unwrap();
+    }
+
+    /// Regression: dialog used to silently fail when the user toggled
+    /// `Use .reviews/ folder` OFF but `.reviews/` still contained sidecars.
+    /// The command now mirrors `count_sidecars`'s `.reviews/` fallback so
+    /// stranded files can be rescued without re-enabling the toggle.
+    #[test]
+    fn migrate_to_colocated_uses_dot_reviews_fallback_when_no_config() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_sidecar(&root.join(".reviews/src/main.rs.review.yaml"));
+        write_sidecar(&root.join(".reviews/docs/readme.md.review.json"));
+
+        let result = migrate_sidecars_inner(root, None, MigrateDirection::ToColocated)
+            .expect("rescue path should succeed without explicit config");
+
+        assert_eq!(result.moved, 2, "stranded files should be moved");
+        assert!(result.failed.is_empty(), "no failures expected: {:?}", result.failed);
+        assert!(root.join("src/main.rs.review.yaml").exists());
+        assert!(root.join("docs/readme.md.review.json").exists());
+        assert!(!root.join(".reviews/src/main.rs.review.yaml").exists());
+        assert!(!root.join(".reviews/docs/readme.md.review.json").exists());
+    }
+
+    /// `ToColocated` with no config and no `.reviews/` folder is a harmless
+    /// no-op — there is genuinely nothing to do, so we return an empty
+    /// result rather than an error (the dialog would surface the latter as
+    /// a banner pointlessly).
+    #[test]
+    fn migrate_to_colocated_no_config_no_dot_reviews_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let result =
+            migrate_sidecars_inner(tmp.path(), None, MigrateDirection::ToColocated).unwrap();
+        assert_eq!(result.moved, 0);
+        assert!(result.failed.is_empty());
+    }
+
+    /// `ToFolder` requires an explicit destination; without one we surface
+    /// an error so the dialog can prompt the user to enable the toggle.
+    #[test]
+    fn migrate_to_folder_errors_without_config() {
+        let tmp = TempDir::new().unwrap();
+        let err = migrate_sidecars_inner(tmp.path(), None, MigrateDirection::ToFolder)
+            .expect_err("ToFolder without config must error");
+        assert!(err.contains("no sidecar_root configured"), "got: {err}");
+    }
+
+    #[test]
+    fn migrate_to_colocated_with_explicit_config_works() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_sidecar(&root.join("custom-folder/a.rs.review.yaml"));
+
+        let result = migrate_sidecars_inner(
+            root,
+            Some(Path::new("custom-folder")),
+            MigrateDirection::ToColocated,
+        )
+        .unwrap();
+
+        assert_eq!(result.moved, 1);
+        assert!(root.join("a.rs.review.yaml").exists());
     }
 }

--- a/src-tauri/src/core/sidecar/migration.rs
+++ b/src-tauri/src/core/sidecar/migration.rs
@@ -11,6 +11,34 @@ use std::path::{Path, PathBuf};
 /// Hard ceiling on sidecar files matched during a walk (performance.md rule 1).
 const MAX_FILES_SCANNED: usize = 10_000;
 
+/// Canonical default folder name used when no `sidecar_root` is configured
+/// in `.mrsf.yaml`. This is the same name written by `set_sidecar_config`
+/// when the dialog toggle is enabled, so users who flip the toggle off can
+/// still see (and rescue) any files left behind in `<root>/.reviews/`.
+pub const DEFAULT_SIDECAR_FOLDER: &str = ".reviews";
+
+/// Resolve the effective sidecar-root folder for both counting and migration.
+///
+/// * If `configured` is `Some`, it is returned as-is.
+/// * If `configured` is `None` and `<root>/.reviews/` exists as a directory,
+///   `Some(".reviews")` is returned so stranded files can be detected and
+///   migrated back to co-located positions even after the toggle has been
+///   disabled (or when the user opens a workspace whose `.reviews/` folder
+///   pre-dates `.mrsf.yaml`).
+/// * If `configured` is `None` and `.reviews/` does not exist, returns
+///   `None` — there is genuinely nothing to do.
+pub fn effective_sidecar_root(root: &Path, configured: Option<&Path>) -> Option<PathBuf> {
+    if let Some(sr) = configured {
+        return Some(sr.to_path_buf());
+    }
+    let p = root.join(DEFAULT_SIDECAR_FOLDER);
+    if p.is_dir() {
+        Some(PathBuf::from(DEFAULT_SIDECAR_FOLDER))
+    } else {
+        None
+    }
+}
+
 /// Create a walker for sidecar scanning. Respects `.gitignore` so heavy
 /// directories (`node_modules/`, `target/`, etc.) are skipped — but uses
 /// override whitelists so `.review.yaml` and `.review.json` files are
@@ -45,18 +73,13 @@ pub struct SidecarCounts {
 ///
 /// When `sidecar_root` is `Some`, sidecars whose path starts with
 /// `root/sidecar_root` are counted as *in-folder*; all others are
-/// *co-located*. When `None`, every sidecar is co-located.
+/// *co-located*. When `None`, the function still falls back to
+/// `<root>/.reviews/` (see [`effective_sidecar_root`]) so users can
+/// detect — and subsequently rescue — files stranded in the default
+/// folder after the toggle has been disabled.
 pub fn count_sidecars(root: &Path, sidecar_root: Option<&Path>) -> SidecarCounts {
-    let folder_prefix: Option<PathBuf> = sidecar_root.map(|sr| root.join(sr));
-    // When disabled, still detect files in the default .reviews/ dir so users
-    // can see stranded sidecars and re-enable to migrate them back.
-    let fallback_prefix: Option<PathBuf> = if folder_prefix.is_none() {
-        let p = root.join(".reviews");
-        if p.is_dir() { Some(p) } else { None }
-    } else {
-        None
-    };
-    let effective_prefix = folder_prefix.as_ref().or(fallback_prefix.as_ref());
+    let effective = effective_sidecar_root(root, sidecar_root);
+    let folder_prefix: Option<PathBuf> = effective.as_ref().map(|sr| root.join(sr));
     let mut counts = SidecarCounts::default();
     let mut visited: usize = 0;
 
@@ -68,7 +91,7 @@ pub fn count_sidecars(root: &Path, sidecar_root: Option<&Path>) -> SidecarCounts
         if visited > MAX_FILES_SCANNED {
             break;
         }
-        if let Some(prefix) = effective_prefix {
+        if let Some(prefix) = folder_prefix.as_ref() {
             if entry.path().starts_with(prefix) {
                 counts.count_in_folder += 1;
             } else {
@@ -349,5 +372,45 @@ mod tests {
 
         assert_eq!(result.moved, 1);
         assert!(root.join(".reviews/a/b/c/deep.rs.review.yaml").exists());
+    }
+
+    // ── effective_sidecar_root ─────────────────────────────────────────
+
+    #[test]
+    fn effective_returns_configured_when_some() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let custom = PathBuf::from("custom-folder");
+        let r = effective_sidecar_root(root, Some(&custom));
+        assert_eq!(r, Some(custom));
+    }
+
+    #[test]
+    fn effective_falls_back_to_dot_reviews_when_dir_exists() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".reviews")).unwrap();
+        let r = effective_sidecar_root(root, None);
+        assert_eq!(r, Some(PathBuf::from(".reviews")));
+    }
+
+    #[test]
+    fn effective_returns_none_when_no_config_and_no_dot_reviews() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let r = effective_sidecar_root(root, None);
+        assert_eq!(r, None);
+    }
+
+    /// `.reviews` may exist as a regular file (unusual but legal). Treat it
+    /// as "no folder" so the rescue path is a harmless no-op rather than an
+    /// error chasing a non-directory target.
+    #[test]
+    fn effective_returns_none_when_dot_reviews_is_a_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join(".reviews"), b"not a dir").unwrap();
+        let r = effective_sidecar_root(root, None);
+        assert_eq!(r, None);
     }
 }

--- a/src/components/SidecarConfigDialog.tsx
+++ b/src/components/SidecarConfigDialog.tsx
@@ -14,6 +14,17 @@ interface Props {
   onClose: () => void;
 }
 
+/** Render an IPC rejection (string | Error | unknown) as a user-facing string. */
+function formatErr(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
 export function SidecarConfigDialog({ root, onClose }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [config, setConfig] = useState<SidecarConfigResult | null>(null);
@@ -23,6 +34,7 @@ export function SidecarConfigDialog({ root, onClose }: Props) {
     moved: number;
     failed: string[];
   } | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const showSidecarFiles = useStore((s) => s.showSidecarFiles);
   const toggleShowSidecarFiles = useStore((s) => s.toggleShowSidecarFiles);
@@ -52,7 +64,11 @@ export function SidecarConfigDialog({ root, onClose }: Props) {
       .then((result) => {
         if (!cancelled) setConfig(result);
       })
-      .catch((err) => warn(`[SidecarConfigDialog] load failed: ${err}`))
+      .catch((err) => {
+        const msg = formatErr(err);
+        warn(`[SidecarConfigDialog] load failed: ${msg}`);
+        if (!cancelled) setError(`Failed to load sidecar config: ${msg}`);
+      })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
@@ -65,12 +81,15 @@ export function SidecarConfigDialog({ root, onClose }: Props) {
   const handleToggleEnabled = async () => {
     if (!config) return;
     setLoading(true);
+    setError(null);
     try {
       const result = await setSidecarConfig(root, !config.enabled);
       setConfig(result);
       setMigrateResult(null);
     } catch (err) {
-      void warn(`[SidecarConfigDialog] toggle failed: ${err}`);
+      const msg = formatErr(err);
+      void warn(`[SidecarConfigDialog] toggle failed: ${msg}`);
+      setError(`Failed to update sidecar config: ${msg}`);
     } finally {
       setLoading(false);
     }
@@ -81,13 +100,20 @@ export function SidecarConfigDialog({ root, onClose }: Props) {
     if (!config) return;
     setMigrating(true);
     setMigrateResult(null);
+    setError(null);
     try {
+      // Direction tracks the toggle: enabled means move co-located → folder,
+      // disabled means rescue stranded folder files → co-located. The
+      // backend now mirrors `count_sidecars`'s `.reviews/` fallback so the
+      // disabled-with-stranded-files rescue path works without re-enabling.
       const direction = config.enabled ? "to_folder" : "to_colocated";
       const result = await migrateSidecars(root, direction);
       setConfig(result.config);
       setMigrateResult({ moved: result.moved, failed: result.failed });
     } catch (err) {
-      void warn(`[SidecarConfigDialog] migrate failed: ${err}`);
+      const msg = formatErr(err);
+      void warn(`[SidecarConfigDialog] migrate failed: ${msg}`);
+      setError(`Migration failed: ${msg}`);
     } finally {
       setMigrating(false);
     }
@@ -140,6 +166,19 @@ export function SidecarConfigDialog({ root, onClose }: Props) {
         </div>
 
         <div className="sidecar-config-body">
+          {error && (
+            <div className="sidecar-config-error" role="alert">
+              <span className="sidecar-config-error-text">{error}</span>
+              <button
+                type="button"
+                className="sidecar-config-error-dismiss"
+                onClick={() => setError(null)}
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </div>
+          )}
           {loading && !config ? (
             <div className="sidecar-config-loading">Loading…</div>
           ) : config ? (

--- a/src/components/__tests__/SidecarConfigDialog.test.tsx
+++ b/src/components/__tests__/SidecarConfigDialog.test.tsx
@@ -132,6 +132,101 @@ describe("SidecarConfigDialog", () => {
     expect(btn).not.toBeDisabled();
   });
 
+  /// Regression for the silent-failure bug: when toggle is OFF but the
+  /// `.reviews/` folder still has stranded sidecars (e.g., user disabled
+  /// the toggle without migrating first), the dialog must show an enabled
+  /// "Move N from .reviews/ → co-located" button and clicking it must
+  /// invoke `migrate_sidecars_cmd` with `direction: "to_colocated"`.
+  /// See `migrate_sidecars_inner` rescue path.
+  it("shows rescue button and triggers to_colocated migration when toggle is off but .reviews/ has files", async () => {
+    const STRANDED_CONFIG = {
+      enabled: false,
+      sidecar_root: null,
+      count_in_folder: 3, // stranded files
+      count_colocated: 0,
+    };
+    mockedInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "get_sidecar_config") return STRANDED_CONFIG;
+      if (cmd === "migrate_sidecars_cmd") {
+        return {
+          moved: 3,
+          failed: [],
+          config: { ...STRANDED_CONFIG, count_in_folder: 0, count_colocated: 3 },
+        };
+      }
+      return undefined;
+    });
+
+    await act(async () => {
+      render(<SidecarConfigDialog root="/workspace" onClose={onCloseMock} />);
+    });
+
+    const btn = screen.getByText(/Move 3 from \.reviews\/ → co-located/);
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("migrate_sidecars_cmd", {
+      root: "/workspace",
+      direction: "to_colocated",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Moved 3 files/)).toBeInTheDocument();
+    });
+  });
+
+  /// Regression: migrate failures used to be swallowed by `void warn(...)`,
+  /// leaving the user staring at an unchanged dialog. Ensure rejected IPC
+  /// surfaces via the dismissable `.sidecar-config-error` banner.
+  it("surfaces an error banner when migrate_sidecars_cmd rejects", async () => {
+    mockedInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "get_sidecar_config") return ENABLED_CONFIG;
+      if (cmd === "migrate_sidecars_cmd") {
+        throw "no sidecar_root configured — enable sidecar folder first";
+      }
+      return undefined;
+    });
+
+    await act(async () => {
+      render(<SidecarConfigDialog root="/workspace" onClose={onCloseMock} />);
+    });
+
+    const btn = screen.getByText(/Move 2 co-located → \.reviews\//);
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent(/Migration failed/);
+    expect(banner).toHaveTextContent(/no sidecar_root configured/);
+
+    // Dismiss removes the banner
+    const dismiss = screen.getByLabelText("Dismiss error");
+    await act(async () => {
+      fireEvent.click(dismiss);
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("surfaces an error banner when get_sidecar_config rejects", async () => {
+    mockedInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "get_sidecar_config") throw new Error("disk on fire");
+      return undefined;
+    });
+
+    await act(async () => {
+      render(<SidecarConfigDialog root="/workspace" onClose={onCloseMock} />);
+    });
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent(/Failed to load sidecar config/);
+    expect(banner).toHaveTextContent(/disk on fire/);
+  });
+
   it("disables migrate button when nothing to migrate", async () => {
     mockedInvoke.mockImplementation(async (cmd: string) => {
       if (cmd === "get_sidecar_config") return { ...ENABLED_CONFIG, count_colocated: 0 };

--- a/src/styles/sidecar-config-dialog.css
+++ b/src/styles/sidecar-config-dialog.css
@@ -127,3 +127,33 @@
   border-top: 1px solid var(--color-border);
   margin: 8px 0;
 }
+
+/* ── Error banner ───────────────────────────────────────────────────── */
+
+.sidecar-config-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background: var(--color-error-bg, rgba(207, 34, 46, 0.08));
+  border: 1px solid var(--color-error, #cf222e);
+  border-radius: 4px;
+  color: var(--color-error, #cf222e);
+  font-size: 12px;
+}
+
+.sidecar-config-error-text {
+  flex: 1;
+  word-break: break-word;
+}
+
+.sidecar-config-error-dismiss {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+}


### PR DESCRIPTION
## The bug

In the `.review.yaml Sidecar Config` dialog, the **"Move N from .reviews/  co-located"** button silently did nothing when the user toggled `Use .reviews/ folder` OFF (or opened a workspace whose `.reviews/` folder pre-dated `.mrsf.yaml`), even though the dialog correctly showed N stranded files.

### Root cause  backend asymmetry + frontend swallow

| Layer | Behavior |
|---|---|
| `count_sidecars` (`core/sidecar/migration.rs`) | Falls back to `<root>/.reviews/` when no config  users see N |
| `migrate_sidecars_cmd` (`commands/sidecar_config.rs`) | Did NOT fall back; returned `Err("no sidecar_root configured")` |
| `handleMigrate` (`SidecarConfigDialog.tsx`) | Caught the error with `void warn(...)`  no UI surface |

Result: silent dead-end. Click the button, nothing happens.

## Fix

**1. One source of truth for the fallback policy**  extracted `core::sidecar::migration::effective_sidecar_root(root, configured)` so both counting and migration agree on when `.reviews/` is the rescue target. `count_sidecars` now calls it (behavior unchanged).

**2. Symmetric command behavior**  new `migrate_sidecars_inner` helper. `ToColocated + None` uses the rescue path. `ToFolder + None` still errors (no explicit destination = no implicit target). `ToColocated + None + no .reviews/` is a no-op (not an error).

**3. Loud failures**  IPC rejections in load/toggle/migrate now surface via a dismissable `.sidecar-config-error` banner instead of being swallowed by `warn()`. Prevents future silent-failure regressions.

## Tests

* **Rust (8 new)**  `effective_sidecar_root` (4 cases) + `migrate_sidecars_inner` (rescue, no-op, ToFolder error, explicit-config pass-through)
* **React (3 new)**  rescue button dispatches `to_colocated`; migrate rejection surfaces banner + dismiss; load rejection surfaces banner
* **All 1626 Vitest + 427 Rust tests pass**; clippy warning count unchanged (1257  1257)

## How to verify locally

1. Open a workspace, enable `Use .reviews/ folder`, add a comment to create a sidecar
2. Toggle OFF  dialog shows `Move 1 from .reviews/  co-located`
3. Click the button  file moves to co-located, count flips to 0/1

## Repro steps for the silent failure (before this PR)

Same as above, but step 3 produced no visible change and only a `[SidecarConfigDialog] migrate failed` line in the log.