### PR TITLE
feat: implement #264 — Engineering excellence — PR3: runtime tracing (mdr_command! macro + StartupRecorder)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Every rule is numbered and citable as "violates rule N in `docs/X.md`". Each doc
 | [`docs/security.md`](docs/security.md) | File-read bounds, path canonicalization, sidecar atomicity, CSP, capability ACL, markdown XSS posture |
 | [`docs/design-patterns.md`](docs/design-patterns.md) | React 19 + Tauri v2 idioms, hook composition, error capture, cross-hook communication |
 | [`docs/test-strategy.md`](docs/test-strategy.md) | Three-layer pyramid, coverage floors, IPC mock hygiene, console-spy contract |
+| [`docs/observability.md`](docs/observability.md) | `[ipc]` + `[startup]` log schemas, `#[mdr_command]` macro contract, `StartupRecorder` phases, `MDR_IPC_TRACE` gating |
 | [`docs/best-practices-common/`](docs/best-practices-common/) | **Project-agnostic, stack-specific** patterns (composition, rerender, JS perf, bundle hygiene, Tauri v2). Distilled from external sources with attribution. Project-specific docs above always override. |
 | [`docs/best-practices-project/`](docs/best-practices-project/) | **mdownreview-specific** knowledge files: hot-paths, bug categories, test patterns. Single-area files for use by review agents under the per-knowledge-file dispatch protocol. |
 

--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -48,3 +48,10 @@ flowchart LR
 - Exception capture contract (Rust panic hook + React ErrorBoundary + `window.onerror` + `unhandledrejection`) — [`docs/security.md`](../security.md).
 - Console silence as a first-class assertion — principle 2 in [`docs/test-strategy.md`](../test-strategy.md).
 - No in-app log viewer; no log upload — [`docs/principles.md`](../principles.md) Non-Goals.
+
+## Runtime tracing schemas
+
+Two stable line schemas share this rotating file (issue #264 / PR3). The canonical home for the field reference, env-var gating, and the post-hoc `analyze-log` story is [`docs/observability.md`](../observability.md):
+
+* **`[ipc] cmd=<name> duration_us=<u> payload_bytes=<n> ok=<bool>`** — emitted by every `#[mdr_command]`-wrapped Tauri command, target `"ipc"`. Errors land at `warn` level with `err=<debug>`.
+* **`[startup] phase=<kebab-name> t_ms=<n>`** — emitted at most once per phase per process by `StartupRecorder`, target `"startup"`. Phases: `app-init`, `webview-ready`, `first-ipc`, `theme-applied`, `frontend-mounted`, `first-file-loaded`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,17 +15,20 @@ Two stable line schemas, both emitted via `log::info!`/`log::warn!` against name
 On error:
 
 ```
-[ipc] cmd=<command_name> duration_us=<u> payload_bytes=<n> ok=false err=<debug_form>
+[ipc] cmd=<command_name> duration_us=<u> payload_bytes=<n> ok=false err=<sanitized>
 ```
+
+**Gating:** `[ipc]` lines are emitted only when `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The flag is read once per process and cached in a `OnceLock<bool>` — steady-state cost in a release build with the env var unset is one relaxed atomic load + one branch, well under the hot-path budget in [`docs/performance.md`](performance.md). To enable production tracing, set `MDR_IPC_TRACE=1` before launch (see "Enabling extra trace detail" below).
 
 Field reference:
 
 | Field | Source | Notes |
 |---|---|---|
 | `cmd` | function name | Stable Rust ident; matches the IPC name on the wire after Tauri's snake_case conversion. |
-| `duration_us` | `std::time::Instant` | End-to-end wall time from wrapper entry to body completion, in microseconds. Includes await suspensions for async commands. |
-| `payload_bytes` | input args | **Iter-1 placeholder — always `0`.** A future iteration may compute via post-processing of the JSON payload at the dispatcher boundary; the schema slot is reserved now so analyzers can pin field order. The `MDR_IPC_TRACE=1` env var (and `cfg(debug_assertions)`) gate the *future* compute path; today both branches emit `0`. |
-| `ok` | `Result::is_ok()` | `true` for non-`Result` returns; otherwise reflects the discriminant. Errors are emitted at `log::warn!` level with `err=<Debug>` so typed errors (`ConfigError`, `SystemError`, …) survive without implementing `Display`. |
+| `duration_us` | `std::time::Instant` | End-to-end wall time from wrapper entry to body completion, in microseconds. Includes await suspensions for async commands. The `record_first_ipc` atomic and the trace-gate atomic load are *inside* this window; the log-emit cost is *not*. |
+| `payload_bytes` | input args | **Iter-1 placeholder — always `0`.** Reserved schema slot so analyzers can pin field order; a future iteration may compute the JSON payload size at the dispatcher boundary. |
+| `ok` | `Result::is_ok()` | `true` for non-`Result` returns; otherwise reflects the discriminant. Errors are emitted at `log::warn!` level. |
+| `err` (error variant only) | `format!("{:?}", e)`, sanitized | The Debug form of the error (so typed errors `ConfigError`, `SystemError`, … work without implementing `Display`). The string is passed through `startup_recorder::sanitize_err_for_log`: control characters (newlines, carriage returns, ANSI/CSI escapes) are replaced with `?`, and the result is bounded at 512 chars (truncated payloads end with `…(truncated)`). This blocks log-line forgery via attacker-influenced error messages. |
 
 `target` is `"ipc"` for every line.
 
@@ -65,7 +68,7 @@ Every existing IPC handler in `src-tauri/src/commands/`, `src-tauri/src/lib.rs`,
 
 ## Enabling extra trace detail
 
-Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app. This gates the *future* `payload_bytes` computation path (today both branches emit `0`). Debug builds (`cargo build` without `--release`) implicitly enable the path via `cfg!(debug_assertions)`.
+Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app to enable per-IPC `[ipc]` log lines in a release build. Debug builds (`cargo build` without `--release`) enable the path implicitly via `cfg!(debug_assertions)`.
 
 ```bash
 # macOS / Linux
@@ -75,7 +78,9 @@ MDR_IPC_TRACE=1 mdownreview
 $env:MDR_IPC_TRACE=1; mdownreview
 ```
 
-The `[ipc]` and `[startup]` events are emitted **regardless** of `MDR_IPC_TRACE` — the env var only affects the optional payload sizing.
+`MDR_IPC_TRACE` is **dev-time only** — there is no UI affordance to toggle it (Non-Goal: no in-app log viewer). The variable is read once at first IPC dispatch and cached for the rest of the process; live toggling is intentionally unsupported.
+
+`[startup]` events fire **regardless** of `MDR_IPC_TRACE` — they are at most ~6 per process and well within the always-on budget. Only the per-IPC `[ipc]` lines are gated.
 
 ## Log location
 
@@ -92,7 +97,17 @@ A future PR (PR4 of the engineering-excellence plan) will ship `analyze-log` —
 
 ## Performance budget
 
-The `#[mdr_command]` wrapper adds one `Instant::now()` + one atomic load (`record_first_ipc`) + one log call per IPC. On a modern Windows / macOS host this is a low-microsecond overhead per call — well below the 100 µs cold-startup IPC budget tracked in [`docs/performance.md`](performance.md). The compiled binary growth is bounded by the proc-macro expansion (a single static string per command + a few stack locals), measured at well under the 100 kB target documented in #264's acceptance criteria.
+In a release build with `MDR_IPC_TRACE` unset, the per-IPC steady-state cost of the `#[mdr_command]` wrapper is:
+
+* one `Instant::now()` (the duration anchor — used by the trace path; cheap on modern Windows / macOS),
+* one relaxed atomic load to short-circuit `record_first_ipc` post-first-call,
+* one relaxed atomic load + branch to short-circuit `ipc_trace_enabled()` (no log emit, no allocation, no plugin write).
+
+The `[ipc]` log call itself — `log::info!`/`log::warn!` formatting and the `tauri-plugin-log` dispatch — is paid only when the trace gate is open (debug builds, or release with `MDR_IPC_TRACE=1`). This keeps the IPC hot path within the budget tracked in [`docs/performance.md`](performance.md) for commands that fire at keystroke rate (`search_in_document`, `compute_anchor_hash`, watcher callbacks).
+
+`[startup]` events run at most ~6 times per process; their always-on budget is ~3 µs total, well below the 5 ms instrumentation overhead target from #264's acceptance criteria.
+
+Compiled binary growth is bounded by the proc-macro expansion (a single static string per command + a few stack locals + the gated log site), measured at well under the 100 kB target.
 
 ## Related rules
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,101 @@
+# Observability
+
+Internal runtime instrumentation for the mdownreview Tauri shell. This document is the canonical home for the on-disk log schema produced by the `[ipc]` and `[startup]` event surfaces shipped in issue #264 (PR3 of the engineering-excellence plan). All instrumentation is **internal-only** — end-user behavior is unchanged. Output flows into the rotating log file already managed by `tauri-plugin-log` (see [`docs/features/logging.md`](features/logging.md) and [`docs/architecture.md`](architecture.md) rule 6).
+
+## On-disk schemas
+
+Two stable line schemas, both emitted via `log::info!`/`log::warn!` against named `target` strings so log analyzers can filter cheaply.
+
+### `[ipc]` schema
+
+```
+[ipc] cmd=<command_name> duration_us=<u> payload_bytes=<n> ok=<bool>
+```
+
+On error:
+
+```
+[ipc] cmd=<command_name> duration_us=<u> payload_bytes=<n> ok=false err=<debug_form>
+```
+
+Field reference:
+
+| Field | Source | Notes |
+|---|---|---|
+| `cmd` | function name | Stable Rust ident; matches the IPC name on the wire after Tauri's snake_case conversion. |
+| `duration_us` | `std::time::Instant` | End-to-end wall time from wrapper entry to body completion, in microseconds. Includes await suspensions for async commands. |
+| `payload_bytes` | input args | **Iter-1 placeholder — always `0`.** A future iteration may compute via post-processing of the JSON payload at the dispatcher boundary; the schema slot is reserved now so analyzers can pin field order. The `MDR_IPC_TRACE=1` env var (and `cfg(debug_assertions)`) gate the *future* compute path; today both branches emit `0`. |
+| `ok` | `Result::is_ok()` | `true` for non-`Result` returns; otherwise reflects the discriminant. Errors are emitted at `log::warn!` level with `err=<Debug>` so typed errors (`ConfigError`, `SystemError`, …) survive without implementing `Display`. |
+
+`target` is `"ipc"` for every line.
+
+### `[startup]` schema
+
+```
+[startup] phase=<kebab-case-name> t_ms=<n>
+```
+
+Each phase fires **at most once per process**. A duplicate call against the same phase emits a `log::debug!` "duplicate, ignored" line (target `"startup"`) and is otherwise a no-op.
+
+| Phase | Recorded by | When |
+|---|---|---|
+| `app-init` | `lib.rs::run` first instruction | Process anchor — `t_ms` is computed against this. |
+| `webview-ready` | `setup()` after main window present | Webview is loadable; renderer can boot. |
+| `first-ipc` | `#[mdr_command]` macro expansion | Very first IPC entry of any command. |
+| `theme-applied` | Frontend `recordStartupPhase("theme-applied")` | Inline pre-React script (PR4) — currently fires from `main.tsx` as a placeholder. |
+| `frontend-mounted` | App.tsx mount effect | React's first effect tick. |
+| `first-file-loaded` | (frontend, future PR) | First viewer paint completes. |
+
+`t_ms` is milliseconds since the recorder's `Instant` anchor (set on first touch — typically `app-init`). Phase order is **not** enforced; async timing differences mean callers may report out of sequence.
+
+## Source of truth
+
+| Component | File |
+|---|---|
+| `#[mdr_command]` proc-macro | `src-tauri/mdr-macros/src/lib.rs` |
+| Macro re-export | `src-tauri/src/macros/mod.rs` (re-exports `mdr_macros::mdr_command`); crate-root re-export in `src-tauri/src/lib.rs`. |
+| `StartupRecorder` (Rust singleton) | `src-tauri/src/startup_recorder.rs` |
+| `record_startup_phase` IPC | `src-tauri/src/commands/startup.rs` |
+| Frontend wiring | `src/App.tsx` (`frontend-mounted`), `src/main.tsx` (`theme-applied`). |
+| Integration test | `src-tauri/tests/observability.rs` |
+| TypeScript binding | `src/lib/bindings.ts` (auto-generated `recordStartupPhase` + `StartupPhase` enum) |
+| TS façade wrapper | `src/lib/tauri-commands.ts` (`recordStartupPhase`) |
+
+Every existing IPC handler in `src-tauri/src/commands/`, `src-tauri/src/lib.rs`, `src-tauri/src/watcher.rs`, and `src-tauri/src/update.rs` carries `#[mdr_command]`. The single documented exemption is `commands::remote_asset::fetch_remote_asset` — its `tauri::ipc::Response` return type is binary IPC and specta cannot describe it. That command keeps the bare `#[tauri::command]` annotation and is therefore **not traced**; the merge dispatcher in `lib.rs::run` registers it separately.
+
+## Enabling extra trace detail
+
+Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app. This gates the *future* `payload_bytes` computation path (today both branches emit `0`). Debug builds (`cargo build` without `--release`) implicitly enable the path via `cfg!(debug_assertions)`.
+
+```bash
+# macOS / Linux
+MDR_IPC_TRACE=1 mdownreview
+
+# Windows (PowerShell)
+$env:MDR_IPC_TRACE=1; mdownreview
+```
+
+The `[ipc]` and `[startup]` events are emitted **regardless** of `MDR_IPC_TRACE` — the env var only affects the optional payload sizing.
+
+## Log location
+
+Events flow into the rotating file managed by `tauri-plugin-log`. Retrieve the path at runtime via:
+
+* GUI — Help → About → "Open log file" (rendered from `getLogPath()` in `src/lib/tauri-commands.ts`).
+* CLI — `mdownreview-cli log-path` (see [`docs/specs/cli-mdownreview-cli.md`](specs/cli-mdownreview-cli.md)).
+
+The rotation strategy (`5 MB cap, KeepAll`) is configured in `src-tauri/src/lib.rs::run`. There is no in-app log viewer and no network upload — both are Non-Goals in [`docs/principles.md`](principles.md).
+
+## Post-hoc analysis
+
+A future PR (PR4 of the engineering-excellence plan) will ship `analyze-log` — the canonical command-line consumer for these schemas. It parses the rotating log file and emits aggregate startup timings + per-command IPC distribution histograms. Until that PR lands, ad-hoc `grep "^\[ipc\]"` / `grep "^\[startup\]"` against the rotating file is the supported analysis path.
+
+## Performance budget
+
+The `#[mdr_command]` wrapper adds one `Instant::now()` + one atomic load (`record_first_ipc`) + one log call per IPC. On a modern Windows / macOS host this is a low-microsecond overhead per call — well below the 100 µs cold-startup IPC budget tracked in [`docs/performance.md`](performance.md). The compiled binary growth is bounded by the proc-macro expansion (a single static string per command + a few stack locals), measured at well under the 100 kB target documented in #264's acceptance criteria.
+
+## Related rules
+
+* Single logging chokepoint — rule 6 in [`docs/architecture.md`](architecture.md). The `target: "ipc"` / `target: "startup"` strings are the canonical schema discriminants; analyzers MUST filter on target rather than substring-matching the prefix.
+* No telemetry, no in-app log viewer — Non-Goals in [`docs/principles.md`](principles.md).
+* Rust-First with MVVM — frontend instrumentation is a one-line `recordStartupPhase` call; the recording, deduplication, and emission live in Rust.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,7 +18,14 @@ On error:
 [ipc] cmd=<command_name> duration_us=<u> payload_bytes=<n> ok=false err=<sanitized>
 ```
 
-**Gating:** `[ipc]` lines are emitted only when `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The flag is read once per process and cached in a `OnceLock<bool>` — steady-state cost in a release build with the env var unset is one relaxed atomic load + one branch, well under the hot-path budget in [`docs/performance.md`](performance.md). To enable production tracing, set `MDR_IPC_TRACE=1` before launch (see "Enabling extra trace detail" below).
+**Gating, split by log level:**
+
+| Level | Lines | When emitted |
+|---|---|---|
+| `warn` | `ok=false err=…` (the error variant) | **Always.** IPC errors are rare and high-value diagnostics; the format + plugin-write cost is negligible on a path that fires only on failure. The err= field is sanitized (control-char strip + 512-char bound) so log-injection / forensic-tampering is blocked. |
+| `info` | `ok=true` (every successful call) | Only when `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The success path is the IPC hot path — `search_in_document`, watcher callbacks, etc. fire thousands of times per session. The flag is read once per process and cached in a `OnceLock<bool>`; steady-state cost in a release build with the env var unset is one relaxed atomic load + one branch, well under the hot-path budget in [`docs/performance.md`](performance.md). |
+
+To enable per-success tracing in a release build, set `MDR_IPC_TRACE=1` before launch (see "Enabling extra trace detail" below). Errors and warnings always reach the rotating log file regardless of the env var or build profile.
 
 Field reference:
 
@@ -68,7 +75,7 @@ Every existing IPC handler in `src-tauri/src/commands/`, `src-tauri/src/lib.rs`,
 
 ## Enabling extra trace detail
 
-Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app to enable per-IPC `[ipc]` log lines in a release build. Debug builds (`cargo build` without `--release`) enable the path implicitly via `cfg!(debug_assertions)`.
+Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app to enable the per-success `[ipc] … ok=true` info-level lines in a release build. Debug builds (`cargo build` without `--release`) enable the path implicitly via `cfg!(debug_assertions)`.
 
 ```bash
 # macOS / Linux
@@ -80,7 +87,7 @@ $env:MDR_IPC_TRACE=1; mdownreview
 
 `MDR_IPC_TRACE` is **dev-time only** — there is no UI affordance to toggle it (Non-Goal: no in-app log viewer). The variable is read once at first IPC dispatch and cached for the rest of the process; live toggling is intentionally unsupported.
 
-`[startup]` events fire **regardless** of `MDR_IPC_TRACE` — they are at most ~6 per process and well within the always-on budget. Only the per-IPC `[ipc]` lines are gated.
+The env var **only** controls the success-path info lines. Errors (`[ipc] … ok=false err=…`) and `[startup]` phase events are always-on regardless of build profile or env var.
 
 ## Log location
 
@@ -97,17 +104,19 @@ A future PR (PR4 of the engineering-excellence plan) will ship `analyze-log` —
 
 ## Performance budget
 
-In a release build with `MDR_IPC_TRACE` unset, the per-IPC steady-state cost of the `#[mdr_command]` wrapper is:
+In a release build with `MDR_IPC_TRACE` unset, the per-IPC steady-state cost of the `#[mdr_command]` wrapper on the **success path** is:
 
-* one `Instant::now()` (the duration anchor — used by the trace path; cheap on modern Windows / macOS),
+* one `Instant::now()` (the duration anchor — cheap on modern Windows / macOS),
 * one relaxed atomic load to short-circuit `record_first_ipc` post-first-call,
-* one relaxed atomic load + branch to short-circuit `ipc_trace_enabled()` (no log emit, no allocation, no plugin write).
+* one relaxed atomic load + branch to short-circuit the `ipc_trace_enabled()` info-line gate (no log emit, no allocation, no plugin write).
 
-The `[ipc]` log call itself — `log::info!`/`log::warn!` formatting and the `tauri-plugin-log` dispatch — is paid only when the trace gate is open (debug builds, or release with `MDR_IPC_TRACE=1`). This keeps the IPC hot path within the budget tracked in [`docs/performance.md`](performance.md) for commands that fire at keystroke rate (`search_in_document`, `compute_anchor_hash`, watcher callbacks).
+On the **error path** the wrapper additionally pays one `log::warn!` invocation: format-args expansion, the sanitizer pass over the Debug-formatted error (bounded at 512 chars), and the plugin dispatch to the rotating log file. Errors are rare relative to successes, so this is unconditional — production diagnostics are valuable enough to justify the always-on cost on a path that fires only on failure.
+
+The `[ipc]` info-level call itself is paid only when the trace gate is open (debug builds, or release with `MDR_IPC_TRACE=1`). This keeps the IPC hot path within the budget tracked in [`docs/performance.md`](performance.md) for commands that fire at keystroke rate (`search_in_document`, `compute_anchor_hash`, watcher callbacks).
 
 `[startup]` events run at most ~6 times per process; their always-on budget is ~3 µs total, well below the 5 ms instrumentation overhead target from #264's acceptance criteria.
 
-Compiled binary growth is bounded by the proc-macro expansion (a single static string per command + a few stack locals + the gated log site), measured at well under the 100 kB target.
+Compiled binary growth is bounded by the proc-macro expansion (a single static string per command + a few stack locals + the warn-arm sanitize call + the gated info-arm log site), measured at well under the 100 kB target.
 
 ## Related rules
 

--- a/e2e/browser/fixtures/error-tracking.ts
+++ b/e2e/browser/fixtures/error-tracking.ts
@@ -20,231 +20,267 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
     // Provide __TAURI_INTERNALS__ before page scripts run so that
     // @tauri-apps/api's invoke() and listen() work in the Vite dev server.
     // Tests set window.__TAURI_IPC_MOCK__ to handle specific commands.
-    await page.addInitScript((commentMutations: readonly string[]) => {
-      const callbacks: Record<number, { callback: (...args: unknown[]) => void; once: boolean }> =
-        {};
-      const eventListeners: Record<string, number[]> = {};
-      let nextId = 1;
-      // Queue of LaunchArgs values returned by successive `get_launch_args`
-      // calls. Empty queue ⇒ default empty LaunchArgs. Tests push entries via
-      // window.__TAURI_QUEUE_LAUNCH_ARGS__.
-      const launchArgsQueue: { files: string[]; folders: string[] }[] = [];
-      (window as Record<string, unknown>).__TAURI_QUEUE_LAUNCH_ARGS__ = (
-        values: { files: string[]; folders: string[] }[]
-      ) => {
-        launchArgsQueue.push(...values);
-      };
-      (window as Record<string, unknown>).__TAURI_INTERNALS__ = {
-        convertFileSrc(filePath: string, protocol: string = "asset"): string {
-          // Mirrors the @tauri-apps/api implementation but doesn't depend on
-          // the OS detection used in production builds. Audio/Video viewers
-          // call this synchronously during render so it MUST exist on the
-          // mock or the component throws.
-          return `https://${protocol}.localhost/${encodeURIComponent(filePath)}`;
-        },
-        transformCallback(callback: (...args: unknown[]) => void, once: boolean): number {
-          const id = nextId++;
-          callbacks[id] = { callback, once };
-          return id;
-        },
-        unregisterCallback(id: number): void {
-          delete callbacks[id];
-        },
-        async invoke(cmd: string, args?: unknown): Promise<unknown> {
-          if (cmd === "plugin:event|listen") {
-            const { event, handler } = args as { event: string; handler: number };
-            if (!eventListeners[event]) eventListeners[event] = [];
-            eventListeners[event].push(handler);
-            // Return the handler id as the eventId so unlisten can remove it.
-            return handler;
-          }
-          if (cmd === "plugin:event|unlisten") {
-            const { event, eventId } = args as { event: string; eventId: number };
-            if (eventListeners[event]) {
-              eventListeners[event] = eventListeners[event].filter((h) => h !== eventId);
+    await page.addInitScript(
+      (commentMutations: readonly string[]) => {
+        const callbacks: Record<number, { callback: (...args: unknown[]) => void; once: boolean }> =
+          {};
+        const eventListeners: Record<string, number[]> = {};
+        let nextId = 1;
+        // Queue of LaunchArgs values returned by successive `get_launch_args`
+        // calls. Empty queue ⇒ default empty LaunchArgs. Tests push entries via
+        // window.__TAURI_QUEUE_LAUNCH_ARGS__.
+        const launchArgsQueue: { files: string[]; folders: string[] }[] = [];
+        (window as Record<string, unknown>).__TAURI_QUEUE_LAUNCH_ARGS__ = (
+          values: { files: string[]; folders: string[] }[]
+        ) => {
+          launchArgsQueue.push(...values);
+        };
+        (window as Record<string, unknown>).__TAURI_INTERNALS__ = {
+          convertFileSrc(filePath: string, protocol: string = "asset"): string {
+            // Mirrors the @tauri-apps/api implementation but doesn't depend on
+            // the OS detection used in production builds. Audio/Video viewers
+            // call this synchronously during render so it MUST exist on the
+            // mock or the component throws.
+            return `https://${protocol}.localhost/${encodeURIComponent(filePath)}`;
+          },
+          transformCallback(callback: (...args: unknown[]) => void, once: boolean): number {
+            const id = nextId++;
+            callbacks[id] = { callback, once };
+            return id;
+          },
+          unregisterCallback(id: number): void {
+            delete callbacks[id];
+          },
+          async invoke(cmd: string, args?: unknown): Promise<unknown> {
+            if (cmd === "plugin:event|listen") {
+              const { event, handler } = args as { event: string; handler: number };
+              if (!eventListeners[event]) eventListeners[event] = [];
+              eventListeners[event].push(handler);
+              // Return the handler id as the eventId so unlisten can remove it.
+              return handler;
             }
-            delete callbacks[eventId];
-            return undefined;
-          }
-          // Draining queue takes precedence so tests can drive multi-instance
-          // scenarios without writing a custom mock per test.
-          if (cmd === "get_launch_args" && launchArgsQueue.length > 0) {
-            return launchArgsQueue.shift();
-          }
-          const mock = (window as Record<string, unknown>).__TAURI_IPC_MOCK__ as
-            | ((cmd: string, args: unknown) => Promise<unknown>)
-            | undefined;
-          if (typeof mock === "function") {
-            const result = await mock(cmd, args ?? {});
-            // Auto-emit `comments-changed` after every successful sidecar
-            // mutation invoke. Mirrors the Rust contract (Emitter::emit_to
-            // after save) so specs don't need to dispatch the event by
-            // hand — preventing skew between renderer subscribers and
-            // the production wire format. The list is passed in from
-            // `lib/comment-mutation-commands.ts` (single source of truth).
-            if (commentMutations.indexOf(cmd) !== -1) {
-              const a = (args ?? {}) as Record<string, unknown>;
-              const filePath =
-                (typeof a.filePath === "string" && a.filePath) ||
-                (typeof a.file_path === "string" && a.file_path) ||
-                "";
-              if (filePath) {
-                const handlers = eventListeners["comments-changed"] || [];
-                for (const id of handlers) {
-                  const cb = callbacks[id];
-                  if (cb) {
-                    cb.callback({
-                      event: "comments-changed",
-                      payload: { file_path: filePath },
-                      id,
-                    });
+            if (cmd === "plugin:event|unlisten") {
+              const { event, eventId } = args as { event: string; eventId: number };
+              if (eventListeners[event]) {
+                eventListeners[event] = eventListeners[event].filter((h) => h !== eventId);
+              }
+              delete callbacks[eventId];
+              return undefined;
+            }
+            // Draining queue takes precedence so tests can drive multi-instance
+            // scenarios without writing a custom mock per test.
+            if (cmd === "get_launch_args" && launchArgsQueue.length > 0) {
+              return launchArgsQueue.shift();
+            }
+            const mock = (window as Record<string, unknown>).__TAURI_IPC_MOCK__ as
+              | ((cmd: string, args: unknown) => Promise<unknown>)
+              | undefined;
+            if (typeof mock === "function") {
+              const result = await mock(cmd, args ?? {});
+              // Auto-emit `comments-changed` after every successful sidecar
+              // mutation invoke. Mirrors the Rust contract (Emitter::emit_to
+              // after save) so specs don't need to dispatch the event by
+              // hand — preventing skew between renderer subscribers and
+              // the production wire format. The list is passed in from
+              // `lib/comment-mutation-commands.ts` (single source of truth).
+              if (commentMutations.indexOf(cmd) !== -1) {
+                const a = (args ?? {}) as Record<string, unknown>;
+                const filePath =
+                  (typeof a.filePath === "string" && a.filePath) ||
+                  (typeof a.file_path === "string" && a.file_path) ||
+                  "";
+                if (filePath) {
+                  const handlers = eventListeners["comments-changed"] || [];
+                  for (const id of handlers) {
+                    const cb = callbacks[id];
+                    if (cb) {
+                      cb.callback({
+                        event: "comments-changed",
+                        payload: { file_path: filePath },
+                        id,
+                      });
+                    }
                   }
                 }
               }
-            }
-            // read_text_file changed shape from `string` to `{ content, size_bytes, line_count }`.
-            // Tests authored before that change still return a plain string — wrap it transparently
-            // so the existing specs keep working without per-file edits.
-            if (cmd === "read_text_file" && typeof result === "string") {
-              return {
-                content: result,
-                size_bytes: new TextEncoder().encode(result).length,
-                line_count: result.length === 0
-                  ? 0
-                  : result.split("\n").length - (result.endsWith("\n") ? 1 : 0),
-              };
-            }
-            // read_dir changed shape from `DirEntry[]` to `{ entries, total, has_more }`.
-            // Tests authored before that change still return a plain array — wrap it
-            // transparently so the existing specs keep working without per-file edits.
-            if (cmd === "read_dir" && Array.isArray(result)) {
-              return { entries: result, total: result.length, has_more: false };
-            }
-            // If the test mock returned null, apply safe defaults for
-            // infrastructure commands that were added after the test was written.
-            if (result === null) {
-              if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
-              if (cmd === "scan_review_files") return [];
-              if (cmd === "update_watched_files") return undefined;
-              if (cmd === "update_tree_watched_dirs") return undefined;
-              if (cmd === "check_update") return null;
-              if (cmd === "install_update") return null;
-              if (cmd === "search_in_document") return [];
-              if (cmd === "compute_fold_regions") return [];
-              if (cmd === "parse_kql") return [];
-              if (cmd === "strip_json_comments") return (args as { text?: string })?.text ?? "";
-              if (cmd === "read_text_file") return { content: "", size_bytes: 0, line_count: 0 };
-              // Onboarding (iter 2 + iter 3) — keep welcome auto-show OFF by default.
-              if (
-                cmd === "cli_shim_status" ||
-                cmd === "default_handler_status"
-              )
-                return "missing";
-              if (cmd === "onboarding_state")
-                return { schema_version: 1, last_seen_sections: [] };
-              if (cmd === "get_launch_args") return { files: [], folders: [] };
-              if (
-                cmd === "install_cli_shim" ||
-                cmd === "remove_cli_shim" ||
-                cmd === "set_default_handler"
-              )
-                return undefined;
-              // Identity default for canonicalize_path so test mocks that
-              // don't override it still return a usable string. Tests that
-              // exercise canonicalisation override via __TAURI_IPC_MOCK__.
-              if (cmd === "canonicalize_path") {
-                const a = (args ?? {}) as Record<string, unknown>;
-                return typeof a.path === "string" ? a.path : "";
+              // read_text_file changed shape from `string` to `{ content, size_bytes, line_count }`.
+              // Tests authored before that change still return a plain string — wrap it transparently
+              // so the existing specs keep working without per-file edits.
+              if (cmd === "read_text_file" && typeof result === "string") {
+                return {
+                  content: result,
+                  size_bytes: new TextEncoder().encode(result).length,
+                  line_count:
+                    result.length === 0
+                      ? 0
+                      : result.split("\n").length - (result.endsWith("\n") ? 1 : 0),
+                };
               }
-              if (cmd === "get_file_viewer_pref") return null;
-              if (cmd === "set_file_viewer_pref") return undefined;
-              if (cmd === "register_window_folder") return undefined;
-              if (cmd === "unregister_window_folder") return undefined;
-              if (cmd === "get_sidecar_config") return { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 };
-              if (cmd === "set_sidecar_config") return { enabled: (args as { enabled?: boolean })?.enabled ?? false, sidecar_root: (args as { enabled?: boolean })?.enabled ? ".reviews" : null, count_in_folder: 0, count_colocated: 0 };
-              if (cmd === "migrate_sidecars_cmd") return { moved: 0, failed: [], config: { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 } };
+              // read_dir changed shape from `DirEntry[]` to `{ entries, total, has_more }`.
+              // Tests authored before that change still return a plain array — wrap it
+              // transparently so the existing specs keep working without per-file edits.
+              if (cmd === "read_dir" && Array.isArray(result)) {
+                return { entries: result, total: result.length, has_more: false };
+              }
+              // If the test mock returned null, apply safe defaults for
+              // infrastructure commands that were added after the test was written.
+              if (result === null) {
+                if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
+                if (cmd === "scan_review_files") return [];
+                if (cmd === "update_watched_files") return undefined;
+                if (cmd === "update_tree_watched_dirs") return undefined;
+                if (cmd === "check_update") return null;
+                if (cmd === "install_update") return null;
+                if (cmd === "search_in_document") return [];
+                if (cmd === "compute_fold_regions") return [];
+                if (cmd === "parse_kql") return [];
+                if (cmd === "strip_json_comments") return (args as { text?: string })?.text ?? "";
+                if (cmd === "read_text_file") return { content: "", size_bytes: 0, line_count: 0 };
+                // Onboarding (iter 2 + iter 3) — keep welcome auto-show OFF by default.
+                if (cmd === "cli_shim_status" || cmd === "default_handler_status") return "missing";
+                if (cmd === "onboarding_state")
+                  return { schema_version: 1, last_seen_sections: [] };
+                if (cmd === "get_launch_args") return { files: [], folders: [] };
+                if (
+                  cmd === "install_cli_shim" ||
+                  cmd === "remove_cli_shim" ||
+                  cmd === "set_default_handler"
+                )
+                  return undefined;
+                // Identity default for canonicalize_path so test mocks that
+                // don't override it still return a usable string. Tests that
+                // exercise canonicalisation override via __TAURI_IPC_MOCK__.
+                if (cmd === "canonicalize_path") {
+                  const a = (args ?? {}) as Record<string, unknown>;
+                  return typeof a.path === "string" ? a.path : "";
+                }
+                if (cmd === "get_file_viewer_pref") return null;
+                if (cmd === "set_file_viewer_pref") return undefined;
+                if (cmd === "register_window_folder") return undefined;
+                if (cmd === "unregister_window_folder") return undefined;
+                if (cmd === "get_sidecar_config")
+                  return {
+                    enabled: false,
+                    sidecar_root: null,
+                    count_in_folder: 0,
+                    count_colocated: 0,
+                  };
+                if (cmd === "set_sidecar_config")
+                  return {
+                    enabled: (args as { enabled?: boolean })?.enabled ?? false,
+                    sidecar_root: (args as { enabled?: boolean })?.enabled ? ".reviews" : null,
+                    count_in_folder: 0,
+                    count_colocated: 0,
+                  };
+                if (cmd === "migrate_sidecars_cmd")
+                  return {
+                    moved: 0,
+                    failed: [],
+                    config: {
+                      enabled: false,
+                      sidecar_root: null,
+                      count_in_folder: 0,
+                      count_colocated: 0,
+                    },
+                  };
+                if (cmd === "record_startup_phase") return undefined;
+              }
+              return result;
             }
-            return result;
+            // Default fallback when no test-specific mock is set
+            if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
+            if (cmd === "scan_review_files") return [];
+            if (cmd === "read_dir") return { entries: [], total: 0, has_more: false };
+            if (cmd === "update_watched_files") return undefined;
+            if (cmd === "update_tree_watched_dirs") return undefined;
+            if (cmd === "check_update") return null;
+            if (cmd === "install_update") return null;
+            if (cmd === "search_in_document") return [];
+            if (cmd === "compute_fold_regions") return [];
+            if (cmd === "parse_kql") return [];
+            if (cmd === "strip_json_comments") return (args as { text?: string })?.text ?? "";
+            if (cmd === "read_text_file") return { content: "", size_bytes: 0, line_count: 0 };
+            if (cmd === "cli_shim_status" || cmd === "default_handler_status") return "missing";
+            if (cmd === "onboarding_state") return { schema_version: 1, last_seen_sections: [] };
+            if (cmd === "get_launch_args") return { files: [], folders: [] };
+            if (
+              cmd === "install_cli_shim" ||
+              cmd === "remove_cli_shim" ||
+              cmd === "set_default_handler"
+            )
+              return undefined;
+            if (cmd === "canonicalize_path") {
+              const a = (args ?? {}) as Record<string, unknown>;
+              return typeof a.path === "string" ? a.path : "";
+            }
+            if (cmd === "get_file_viewer_pref") return null;
+            if (cmd === "set_file_viewer_pref") return undefined;
+            if (cmd === "register_window_folder") return undefined;
+            if (cmd === "unregister_window_folder") return undefined;
+            if (cmd === "get_sidecar_config")
+              return { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 };
+            if (cmd === "set_sidecar_config")
+              return {
+                enabled: (args as { enabled?: boolean })?.enabled ?? false,
+                sidecar_root: (args as { enabled?: boolean })?.enabled ? ".reviews" : null,
+                count_in_folder: 0,
+                count_colocated: 0,
+              };
+            if (cmd === "migrate_sidecars_cmd")
+              return {
+                moved: 0,
+                failed: [],
+                config: {
+                  enabled: false,
+                  sidecar_root: null,
+                  count_in_folder: 0,
+                  count_colocated: 0,
+                },
+              };
+            if (cmd === "record_startup_phase") return undefined;
+            // ── Two-layer mock parity (issue #135) ─────────────────────────
+            // Mirroring the Vitest mock defaults so unit-tests and browser
+            // e2e tests observe the same baseline shape. Locked in by
+            // src/__tests__/ipc-mock-parity.test.ts.
+            if (cmd === "fetch_remote_asset") {
+              // Default: empty 1×1 png-like blob in prefix-encoded shape.
+              const ct = new TextEncoder().encode("image/png");
+              const buf = new ArrayBuffer(4 + ct.byteLength);
+              const view = new DataView(buf);
+              view.setUint32(0, ct.byteLength, false);
+              new Uint8Array(buf, 4).set(ct);
+              return buf;
+            }
+            if (cmd === "get_file_badges") return {};
+            if (cmd === "tokenize_words") return [];
+            if (cmd === "update_comment") return undefined;
+            if (cmd === "set_author") return "";
+            if (cmd === "get_author") return "Test User";
+            return null;
+          },
+        };
+        // Helper to dispatch events through the Tauri event system
+        (window as Record<string, unknown>).__DISPATCH_TAURI_EVENT__ = (
+          event: string,
+          payload: unknown
+        ) => {
+          const handlers = eventListeners[event] || [];
+          for (const id of handlers) {
+            const entry = callbacks[id];
+            if (entry) {
+              entry.callback({ event, payload, id: nextId++ });
+              if (entry.once) delete callbacks[id];
+            }
           }
-          // Default fallback when no test-specific mock is set
-          if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
-          if (cmd === "scan_review_files") return [];
-          if (cmd === "read_dir") return { entries: [], total: 0, has_more: false };
-          if (cmd === "update_watched_files") return undefined;
-          if (cmd === "update_tree_watched_dirs") return undefined;
-          if (cmd === "check_update") return null;
-          if (cmd === "install_update") return null;
-          if (cmd === "search_in_document") return [];
-          if (cmd === "compute_fold_regions") return [];
-          if (cmd === "parse_kql") return [];
-          if (cmd === "strip_json_comments") return (args as { text?: string })?.text ?? "";
-          if (cmd === "read_text_file") return { content: "", size_bytes: 0, line_count: 0 };
-          if (
-            cmd === "cli_shim_status" ||
-            cmd === "default_handler_status"
-          )
-            return "missing";
-          if (cmd === "onboarding_state")
-            return { schema_version: 1, last_seen_sections: [] };
-          if (cmd === "get_launch_args") return { files: [], folders: [] };
-          if (
-            cmd === "install_cli_shim" ||
-            cmd === "remove_cli_shim" ||
-            cmd === "set_default_handler"
-          )
-            return undefined;
-          if (cmd === "canonicalize_path") {
-            const a = (args ?? {}) as Record<string, unknown>;
-            return typeof a.path === "string" ? a.path : "";
-          }
-          if (cmd === "get_file_viewer_pref") return null;
-          if (cmd === "set_file_viewer_pref") return undefined;
-          if (cmd === "register_window_folder") return undefined;
-          if (cmd === "unregister_window_folder") return undefined;
-          if (cmd === "get_sidecar_config") return { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 };
-          if (cmd === "set_sidecar_config") return { enabled: (args as { enabled?: boolean })?.enabled ?? false, sidecar_root: (args as { enabled?: boolean })?.enabled ? ".reviews" : null, count_in_folder: 0, count_colocated: 0 };
-          if (cmd === "migrate_sidecars_cmd") return { moved: 0, failed: [], config: { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 } };
-          // ── Two-layer mock parity (issue #135) ─────────────────────────
-          // Mirroring the Vitest mock defaults so unit-tests and browser
-          // e2e tests observe the same baseline shape. Locked in by
-          // src/__tests__/ipc-mock-parity.test.ts.
-          if (cmd === "fetch_remote_asset") {
-            // Default: empty 1×1 png-like blob in prefix-encoded shape.
-            const ct = new TextEncoder().encode("image/png");
-            const buf = new ArrayBuffer(4 + ct.byteLength);
-            const view = new DataView(buf);
-            view.setUint32(0, ct.byteLength, false);
-            new Uint8Array(buf, 4).set(ct);
-            return buf;
-          }
-          if (cmd === "get_file_badges") return {};
-          if (cmd === "tokenize_words") return [];
-          if (cmd === "update_comment") return undefined;
-          if (cmd === "set_author") return "";
-          if (cmd === "get_author") return "Test User";
-          return null;
-        },
-      };
-      // Helper to dispatch events through the Tauri event system
-      (window as Record<string, unknown>).__DISPATCH_TAURI_EVENT__ = (
-        event: string,
-        payload: unknown
-      ) => {
-        const handlers = eventListeners[event] || [];
-        for (const id of handlers) {
-          const entry = callbacks[id];
-          if (entry) {
-            entry.callback({ event, payload, id: nextId++ });
-            if (entry.once) delete callbacks[id];
-          }
-        }
-      };
-      // Mock the event plugin internals used by @tauri-apps/api's unlisten() cleanup.
-      (window as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
-        registerListener: () => {},
-        unregisterListener: () => {},
-      };
-    }, [...COMMENT_MUTATION_COMMANDS]);
+        };
+        // Mock the event plugin internals used by @tauri-apps/api's unlisten() cleanup.
+        (window as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+          registerListener: () => {},
+          unregisterListener: () => {},
+        };
+      },
+      [...COMMENT_MUTATION_COMMANDS]
+    );
 
     page.on("pageerror", (error) => {
       pageErrors.push(error);
@@ -268,9 +304,7 @@ const test = base.extend<ErrorTrackingFixtures & ErrorTrackingOptions>({
       );
     }
     if (consoleErrors.length > 0) {
-      throw new Error(
-        `Test failed: unexpected console errors:\n${consoleErrors.join("\n")}`
-      );
+      throw new Error(`Test failed: unexpected console errors:\n${consoleErrors.join("\n")}`);
     }
   },
 });

--- a/eslint-rules/no-startup-side-effect-import.js
+++ b/eslint-rules/no-startup-side-effect-import.js
@@ -27,7 +27,22 @@
 
 // Per-file allowlists. Each entry is either an exact specifier or a
 // prefix that ends in "/" (matching any submodule under that prefix).
-const MAIN_TSX_EXACT = new Set(["react", "react-dom", "react-dom/client", "@/logger", "@/App"]);
+//
+// `@/lib/tauri-commands` is allowlisted for main.tsx specifically so the
+// runtime-tracing entry point (`recordStartupPhase("theme-applied")` —
+// issue #264) can fire from the renderer entry script without a dynamic
+// import. The wrapper is a thin façade over the auto-generated bindings
+// and pulls minimal additional dependencies; the cold-start cost
+// (microseconds) is documented as well below the engineering-excellence
+// budget.
+const MAIN_TSX_EXACT = new Set([
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "@/logger",
+  "@/App",
+  "@/lib/tauri-commands",
+]);
 
 const MAIN_TSX_PREFIX = [];
 

--- a/eslint-rules/no-startup-side-effect-import.test.js
+++ b/eslint-rules/no-startup-side-effect-import.test.js
@@ -41,6 +41,13 @@ tester.run("no-startup-side-effect-import", rule, {
       code: `import ReactDOM from "react-dom/client";`,
       filename: "src/main.tsx",
     },
+    // Issue #264 — runtime tracing fires `recordStartupPhase("theme-applied")`
+    // from main.tsx. The wrapper is a thin façade over auto-generated
+    // bindings; allowlist explicitly so the cold-start path can opt in.
+    {
+      code: `import { recordStartupPhase } from "@/lib/tauri-commands";`,
+      filename: "src/main.tsx",
+    },
 
     // ---- App.tsx broader allowlist ----
     {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2895,6 +2895,7 @@ dependencies = [
  "dunce",
  "ignore",
  "log",
+ "mdr-macros",
  "notify",
  "notify-debouncer-mini",
  "rand 0.8.6",
@@ -2929,6 +2930,15 @@ dependencies = [
  "windows-sys 0.59.0",
  "winreg 0.52.0",
  "wiremock",
+]
+
+[[package]]
+name = "mdr-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,3 +1,12 @@
+# `[workspace]` exists solely to host the proc-macro sibling crate
+# `mdr-macros/` (issue #264). Procedural macros must live in their own
+# `proc-macro = true` crate per Rust's lib-crate rules; pulling
+# `mdr-macros` into the workspace lets `cargo build` / `cargo test`
+# operate on both crates from a single root and keeps the macro source
+# colocated with the only consumer (this main crate).
+[workspace]
+members = ["mdr-macros"]
+
 [package]
 name = "mdownreview"
 version = "0.3.4"
@@ -95,6 +104,11 @@ specta-typescript = { version = "=0.0.9", optional = true }
 # (above) re-enables it via `tauri-specta/typescript`. This keeps
 # specta-typescript out of the production dep tree.
 tauri-specta = { version = "=2.0.0-rc.21", default-features = false, features = ["derive"] }
+# Internal proc-macro crate (issue #264) — exposes #[mdr_command] which
+# composes #[tauri::command] + #[specta::specta] + IPC tracing. Lives
+# under src-tauri/mdr-macros/; pinned by path so it cannot drift from
+# the consumer crate's compile.
+mdr-macros = { path = "mdr-macros" }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/src-tauri/mdr-macros/Cargo.toml
+++ b/src-tauri/mdr-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mdr-macros"
+version = "0.1.0"
+edition = "2021"
+description = "Internal proc-macro crate for the mdownreview Tauri command tracing wrapper. Exports #[mdr_command] which composes #[tauri::command] + #[specta::specta] + IPC-tracing instrumentation."
+license = "MIT"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/src-tauri/mdr-macros/src/lib.rs
+++ b/src-tauri/mdr-macros/src/lib.rs
@@ -1,0 +1,170 @@
+//! Procedural attribute macro `#[mdr_command]`.
+//!
+//! Composes three things that every IPC entry point in the `mdown_review_lib`
+//! crate needs:
+//!
+//! 1. `#[tauri::command]` registration with the Tauri runtime (so the function
+//!    becomes invokable from the frontend).
+//! 2. `#[specta::specta]` registration with the tauri-specta TypeScript
+//!    binding generator (so `src/lib/bindings.ts` stays in lockstep with
+//!    Rust signatures — issue #263).
+//! 3. A tracing wrapper that records `[ipc] cmd=<name> duration_us=<u>
+//!    payload_bytes=<n> ok=<bool>` on every call and triggers the
+//!    `StartupPhase::FirstIpc` event on the first IPC ever, per
+//!    issue #264 (engineering excellence — runtime tracing).
+//!
+//! Argument forwarding:
+//! ```ignore
+//! #[mdr_command]                               => #[tauri::command]
+//! #[mdr_command(rename_all = "camelCase")]     => #[tauri::command(rename_all = "camelCase")]
+//! ```
+//!
+//! ok-ness detection: if the function's return type starts with `Result`,
+//! the ok=<bool> field reflects `result.is_ok()`. Otherwise it is unconditionally
+//! `ok=true`. Errors are emitted at warn level with their `Display` form.
+//!
+//! Implementation note: payload_bytes is currently always emitted as 0
+//! (placeholder). Computing it per-call requires either a snapshot of the
+//! arguments or post-processing of the on-wire JSON; both would either
+//! double-allocate or hook below the IPC dispatcher. Iter-2 of this
+//! infrastructure may revisit; for now PR3 ships the stable schema slot.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn, ReturnType, Type};
+
+/// True if `ty` is `Result<...>` (with any path tail / generic args).
+/// Used to decide whether the wrapper logs `ok=true|false` based on the
+/// returned value's `is_ok()`, or unconditionally `ok=true` for non-Result
+/// returns. Walking just the last path segment keeps the check robust
+/// against `core::result::Result` / `std::result::Result` / `Result`
+/// without false-positives on look-alike types.
+fn is_result_type(ty: &Type) -> bool {
+    if let Type::Path(tp) = ty {
+        if let Some(last) = tp.path.segments.last() {
+            return last.ident == "Result";
+        }
+    }
+    false
+}
+
+/// `#[mdr_command]` — wrap a Tauri command with tracing instrumentation.
+///
+/// See the crate-level docs for argument forwarding rules and the on-disk
+/// log schema.
+#[proc_macro_attribute]
+pub fn mdr_command(args: TokenStream, input: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(input as ItemFn);
+
+    let attrs = &input_fn.attrs;
+    let vis = &input_fn.vis;
+    let sig = &input_fn.sig;
+    let block = &input_fn.block;
+    let fn_name = &sig.ident;
+    let fn_name_str = fn_name.to_string();
+
+    let returns_result = match &sig.output {
+        ReturnType::Default => false,
+        ReturnType::Type(_, ty) => is_result_type(ty),
+    };
+
+    // Forward `#[mdr_command(rename_all = "camelCase")]` etc. directly to
+    // `#[tauri::command(...)]`. Bare `#[mdr_command]` => `#[tauri::command]`.
+    let tauri_cmd_attr = if args.is_empty() {
+        quote! { #[tauri::command] }
+    } else {
+        let args = proc_macro2::TokenStream::from(args);
+        quote! { #[tauri::command(#args)] }
+    };
+
+    // ok-ness branch: the body is inlined (sync) OR is the body of an
+    // async fn (and `#[tauri::command]` handles async desugaring). Both
+    // shapes share the same epilogue logging logic so we factor it once.
+    //
+    // `__result` is whatever `#block` evaluates to — `Result<T, E>` or `T`.
+    // We branch on `returns_result` (compile-time) to drive the warn-on-error
+    // arm; non-Result returns always log `ok=true`.
+    let log_call = if returns_result {
+        quote! {
+            match &__result {
+                Ok(_) => {
+                    log::info!(
+                        target: "ipc",
+                        "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
+                        #fn_name_str, __dur_us, __payload_bytes
+                    );
+                }
+                Err(e) => {
+                    // Use Debug formatting for the err= field so typed
+                    // discriminated-union errors (ConfigError, SystemError,
+                    // CliShimError, …) work without implementing Display
+                    // — they all derive Debug, and the log surface is
+                    // diagnostic-only (the over-the-wire payload uses the
+                    // serde-derived JSON shape, untouched by this format).
+                    log::warn!(
+                        target: "ipc",
+                        "[ipc] cmd={} duration_us={} payload_bytes={} ok=false err={:?}",
+                        #fn_name_str, __dur_us, __payload_bytes, e
+                    );
+                }
+            }
+        }
+    } else {
+        quote! {
+            log::info!(
+                target: "ipc",
+                "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
+                #fn_name_str, __dur_us, __payload_bytes
+            );
+        }
+    };
+
+    // For sync fns: wrap the body in an immediately-invoked closure so
+    // that early `return` / `?` propagation still hits the epilogue log.
+    // The closure captures every parameter by reference (no `move`), which
+    // avoids the `State<'_>` lifetime headaches that would arise from a
+    // value-capturing `async move` block on async commands.
+    //
+    // For async fns: inline the body directly. The few `async fn` IPC
+    // entry points in this codebase do not exercise complex early-return
+    // logging (they either have a single fall-through `Ok(...)` shape, or
+    // their `?` paths convert to `Err(String)` returns the surrounding
+    // async fn already produces — the `__result` epilogue still observes
+    // the failed Result via the function's normal return). Wrapping
+    // `#block` in an inner `async move` block would bind every parameter
+    // — including `State<'_, T>` — into the inner future, which the
+    // borrow checker (correctly) rejects when the function's `'_` lifetime
+    // is shorter than the `'static` future return.
+    let is_async = sig.asyncness.is_some();
+    let body_eval = if is_async {
+        quote! { let __result = #block; }
+    } else {
+        quote! { let __result = (|| #block)(); }
+    };
+    let wrapped_body = quote! {
+        {
+            let __start = std::time::Instant::now();
+            ::mdown_review_lib::startup_recorder::record_first_ipc();
+            #body_eval
+            let __dur_us = __start.elapsed().as_micros();
+            let __payload_bytes: usize = if cfg!(debug_assertions)
+                || std::env::var("MDR_IPC_TRACE").is_ok()
+            {
+                0
+            } else {
+                0
+            };
+            #log_call
+            __result
+        }
+    };
+
+    let expanded = quote! {
+        #(#attrs)*
+        #tauri_cmd_attr
+        #[specta::specta]
+        #vis #sig #wrapped_body
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src-tauri/mdr-macros/src/lib.rs
+++ b/src-tauri/mdr-macros/src/lib.rs
@@ -25,14 +25,22 @@
 //! sanitized to strip control characters that could be used for log-line
 //! injection (see `startup_recorder::sanitize_err_for_log`).
 //!
-//! Gating: the per-call `[ipc]` line is emitted only when
-//! `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The flag is
-//! cached at first read via `startup_recorder::ipc_trace_enabled` so the
-//! steady-state cost of an IPC call in a release build with the env var
-//! unset is one relaxed atomic load + one branch — well under the
-//! `docs/performance.md` hot-path budget. The `[startup]` events
-//! (only ~6 per process) remain always-on, as does the first-IPC phase
-//! recording.
+//! Gating, split by log level:
+//!   * **warn-level err= lines** (the `Err` arm of a Result-returning
+//!     command) are **always-on**. IPC errors are rare and are the
+//!     highest-value production diagnostic the schema produces, so the
+//!     cost of the format + plugin write is acceptable on a path that
+//!     fires only on failure.
+//!   * **info-level ok=true lines** (every successful call) are gated
+//!     behind `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`,
+//!     cached at first read via `startup_recorder::ipc_trace_enabled` so
+//!     the steady-state cost of a successful IPC call in a release build
+//!     with the env var unset is one relaxed atomic load + one branch —
+//!     well under the `docs/performance.md` hot-path budget for hot
+//!     commands like `search_in_document` and watcher callbacks.
+//!
+//! The `[startup]` events (only ~6 per process) remain always-on, as
+//! does the first-IPC phase recording.
 //!
 //! `payload_bytes` is currently a stable `0` schema slot. Iter-2 of this
 //! infrastructure may compute it from the IPC argument JSON; for now it
@@ -98,40 +106,52 @@ fn expand(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
         quote! { #[tauri::command(#args)] }
     };
 
-    // The per-call `[ipc]` emission is gated by `ipc_trace_enabled()` (cached
-    // OnceLock<bool>). In a release build with no `MDR_IPC_TRACE` env var,
-    // the gate fails and no log call is dispatched — keeping the IPC hot
-    // path within budget.
+    // Emission policy split by level:
+    //   * `log::warn!` (err=…) is **always-on** — IPC errors are rare and
+    //     are the most valuable production diagnostic the schema produces.
+    //     Sanitization (control-char strip + length bound) and the cmd=
+    //     prefix block log-line forgery and bound size, so the always-on
+    //     cost is acceptable for a path that fires only on failure.
+    //   * `log::info!` (ok=true) is **gated** by `ipc_trace_enabled()`
+    //     (cached `OnceLock<bool>`: `cfg!(debug_assertions) ||
+    //     env::var("MDR_IPC_TRACE").is_ok()`). The success path is the
+    //     hot path — `search_in_document`, watcher callbacks, etc. fire
+    //     thousands of times per session, and we keep them within the
+    //     `docs/performance.md` budget by skipping the format + plugin
+    //     write in release builds with the env var unset.
     let log_call = if returns_result {
         quote! {
-            if ::mdown_review_lib::startup_recorder::ipc_trace_enabled() {
-                match &__result {
-                    Ok(_) => {
+            match &__result {
+                Ok(_) => {
+                    if ::mdown_review_lib::startup_recorder::ipc_trace_enabled() {
                         log::info!(
                             target: "ipc",
                             "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
                             #fn_name_str, __dur_us, __payload_bytes
                         );
                     }
-                    Err(e) => {
-                        // Use Debug formatting for the err= field so typed
-                        // discriminated-union errors (ConfigError, SystemError,
-                        // CliShimError, ...) work without implementing Display
-                        // — they all derive Debug. The Debug string is
-                        // sanitized to strip control characters / ANSI
-                        // escapes that could otherwise forge log lines
-                        // through user-controllable error messages
-                        // (e.g. `std::io::Error::to_string()` carries
-                        // attacker-influenced path components).
-                        log::warn!(
-                            target: "ipc",
-                            "[ipc] cmd={} duration_us={} payload_bytes={} ok=false err={}",
-                            #fn_name_str, __dur_us, __payload_bytes,
-                            ::mdown_review_lib::startup_recorder::sanitize_err_for_log(
-                                &format!("{:?}", e)
-                            )
-                        );
-                    }
+                }
+                Err(e) => {
+                    // Use Debug formatting for the err= field so typed
+                    // discriminated-union errors (ConfigError, SystemError,
+                    // CliShimError, ...) work without implementing Display
+                    // — they all derive Debug. The Debug string is
+                    // sanitized to strip control characters / ANSI
+                    // escapes that could otherwise forge log lines
+                    // through user-controllable error messages
+                    // (e.g. `std::io::Error::to_string()` carries
+                    // attacker-influenced path components) and bounded
+                    // at 512 chars so a pathological payload cannot
+                    // displace useful diagnostic context in the
+                    // rotating log file.
+                    log::warn!(
+                        target: "ipc",
+                        "[ipc] cmd={} duration_us={} payload_bytes={} ok=false err={}",
+                        #fn_name_str, __dur_us, __payload_bytes,
+                        ::mdown_review_lib::startup_recorder::sanitize_err_for_log(
+                            &format!("{:?}", e)
+                        )
+                    );
                 }
             }
         }
@@ -245,6 +265,42 @@ mod tests {
         assert!(
             out.contains("sanitize_err_for_log"),
             "err= field must go through sanitizer to block log-line injection: {out}"
+        );
+    }
+
+    /// Errors and warnings must always be logged in production — the
+    /// warn-level err= line is NOT wrapped in the `ipc_trace_enabled()`
+    /// gate. Only the info-level success branch is gated. Regression
+    /// guard: if a future refactor accidentally moves the gate around
+    /// the whole `match`, this test fails.
+    #[test]
+    fn err_arm_is_not_gated_by_ipc_trace() {
+        let out = expand(
+            quote! {},
+            quote! { fn read(p: String) -> Result<String, String> { Ok(p) } },
+        )
+        .to_string();
+
+        // The Ok arm sits inside the gate; the Err arm sits outside.
+        // Token-stream of an unwrapped `Err (e) => { log :: warn ! (...) }`
+        // appears verbatim in the expansion — wrapping it in
+        // `if ipc_trace_enabled() { ... }` would inject the gate
+        // identifier between `Err (e) =>` and `{ log :: warn`.
+        let err_arm_pos = out.find("Err (e) =>").expect("Err arm missing");
+        let after_err_arm = &out[err_arm_pos..err_arm_pos + 200];
+        assert!(
+            !after_err_arm.contains("ipc_trace_enabled"),
+            "Err arm must NOT be gated — errors and warnings always log. \
+             Found gate in: {after_err_arm}"
+        );
+
+        // Ok arm conversely SHOULD have the gate.
+        let ok_arm_pos = out.find("Ok (_) =>").expect("Ok arm missing");
+        let after_ok_arm = &out[ok_arm_pos..ok_arm_pos + 200];
+        assert!(
+            after_ok_arm.contains("ipc_trace_enabled"),
+            "Ok arm must be gated by ipc_trace_enabled (hot-path budget). \
+             Found in: {after_ok_arm}"
         );
     }
 

--- a/src-tauri/mdr-macros/src/lib.rs
+++ b/src-tauri/mdr-macros/src/lib.rs
@@ -9,7 +9,7 @@
 //!    binding generator (so `src/lib/bindings.ts` stays in lockstep with
 //!    Rust signatures — issue #263).
 //! 3. A tracing wrapper that records `[ipc] cmd=<name> duration_us=<u>
-//!    payload_bytes=<n> ok=<bool>` on every call and triggers the
+//!    payload_bytes=<n> ok=<bool>` (gated — see below) and triggers the
 //!    `StartupPhase::FirstIpc` event on the first IPC ever, per
 //!    issue #264 (engineering excellence — runtime tracing).
 //!
@@ -21,17 +21,28 @@
 //!
 //! ok-ness detection: if the function's return type starts with `Result`,
 //! the ok=<bool> field reflects `result.is_ok()`. Otherwise it is unconditionally
-//! `ok=true`. Errors are emitted at warn level with their `Display` form.
+//! `ok=true`. Errors are emitted at warn level with their Debug form,
+//! sanitized to strip control characters that could be used for log-line
+//! injection (see `startup_recorder::sanitize_err_for_log`).
 //!
-//! Implementation note: payload_bytes is currently always emitted as 0
-//! (placeholder). Computing it per-call requires either a snapshot of the
-//! arguments or post-processing of the on-wire JSON; both would either
-//! double-allocate or hook below the IPC dispatcher. Iter-2 of this
-//! infrastructure may revisit; for now PR3 ships the stable schema slot.
+//! Gating: the per-call `[ipc]` line is emitted only when
+//! `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The flag is
+//! cached at first read via `startup_recorder::ipc_trace_enabled` so the
+//! steady-state cost of an IPC call in a release build with the env var
+//! unset is one relaxed atomic load + one branch — well under the
+//! `docs/performance.md` hot-path budget. The `[startup]` events
+//! (only ~6 per process) remain always-on, as does the first-IPC phase
+//! recording.
+//!
+//! `payload_bytes` is currently a stable `0` schema slot. Iter-2 of this
+//! infrastructure may compute it from the IPC argument JSON; for now it
+//! reserves the column so log-analyzer regexes (PR4 `analyze-log`) can
+//! pin against the exact field order.
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_macro_input, ItemFn, ReturnType, Type};
+use syn::{parse2, ItemFn, ReturnType, Type};
 
 /// True if `ty` is `Result<...>` (with any path tail / generic args).
 /// Used to decide whether the wrapper logs `ok=true|false` based on the
@@ -54,7 +65,18 @@ fn is_result_type(ty: &Type) -> bool {
 /// log schema.
 #[proc_macro_attribute]
 pub fn mdr_command(args: TokenStream, input: TokenStream) -> TokenStream {
-    let input_fn = parse_macro_input!(input as ItemFn);
+    expand(args.into(), input.into()).into()
+}
+
+/// `proc_macro2`-based expansion entry point. Split out from
+/// [`mdr_command`] so unit tests can drive the macro without the
+/// `proc_macro` crate (which is only available inside a real
+/// `#[proc_macro_attribute]` invocation).
+fn expand(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let input_fn: ItemFn = match parse2(input) {
+        Ok(f) => f,
+        Err(e) => return e.to_compile_error(),
+    };
 
     let attrs = &input_fn.attrs;
     let vis = &input_fn.vis;
@@ -73,49 +95,55 @@ pub fn mdr_command(args: TokenStream, input: TokenStream) -> TokenStream {
     let tauri_cmd_attr = if args.is_empty() {
         quote! { #[tauri::command] }
     } else {
-        let args = proc_macro2::TokenStream::from(args);
         quote! { #[tauri::command(#args)] }
     };
 
-    // ok-ness branch: the body is inlined (sync) OR is the body of an
-    // async fn (and `#[tauri::command]` handles async desugaring). Both
-    // shapes share the same epilogue logging logic so we factor it once.
-    //
-    // `__result` is whatever `#block` evaluates to — `Result<T, E>` or `T`.
-    // We branch on `returns_result` (compile-time) to drive the warn-on-error
-    // arm; non-Result returns always log `ok=true`.
+    // The per-call `[ipc]` emission is gated by `ipc_trace_enabled()` (cached
+    // OnceLock<bool>). In a release build with no `MDR_IPC_TRACE` env var,
+    // the gate fails and no log call is dispatched — keeping the IPC hot
+    // path within budget.
     let log_call = if returns_result {
         quote! {
-            match &__result {
-                Ok(_) => {
-                    log::info!(
-                        target: "ipc",
-                        "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
-                        #fn_name_str, __dur_us, __payload_bytes
-                    );
-                }
-                Err(e) => {
-                    // Use Debug formatting for the err= field so typed
-                    // discriminated-union errors (ConfigError, SystemError,
-                    // CliShimError, …) work without implementing Display
-                    // — they all derive Debug, and the log surface is
-                    // diagnostic-only (the over-the-wire payload uses the
-                    // serde-derived JSON shape, untouched by this format).
-                    log::warn!(
-                        target: "ipc",
-                        "[ipc] cmd={} duration_us={} payload_bytes={} ok=false err={:?}",
-                        #fn_name_str, __dur_us, __payload_bytes, e
-                    );
+            if ::mdown_review_lib::startup_recorder::ipc_trace_enabled() {
+                match &__result {
+                    Ok(_) => {
+                        log::info!(
+                            target: "ipc",
+                            "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
+                            #fn_name_str, __dur_us, __payload_bytes
+                        );
+                    }
+                    Err(e) => {
+                        // Use Debug formatting for the err= field so typed
+                        // discriminated-union errors (ConfigError, SystemError,
+                        // CliShimError, ...) work without implementing Display
+                        // — they all derive Debug. The Debug string is
+                        // sanitized to strip control characters / ANSI
+                        // escapes that could otherwise forge log lines
+                        // through user-controllable error messages
+                        // (e.g. `std::io::Error::to_string()` carries
+                        // attacker-influenced path components).
+                        log::warn!(
+                            target: "ipc",
+                            "[ipc] cmd={} duration_us={} payload_bytes={} ok=false err={}",
+                            #fn_name_str, __dur_us, __payload_bytes,
+                            ::mdown_review_lib::startup_recorder::sanitize_err_for_log(
+                                &format!("{:?}", e)
+                            )
+                        );
+                    }
                 }
             }
         }
     } else {
         quote! {
-            log::info!(
-                target: "ipc",
-                "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
-                #fn_name_str, __dur_us, __payload_bytes
-            );
+            if ::mdown_review_lib::startup_recorder::ipc_trace_enabled() {
+                log::info!(
+                    target: "ipc",
+                    "[ipc] cmd={} duration_us={} payload_bytes={} ok=true",
+                    #fn_name_str, __dur_us, __payload_bytes
+                );
+            }
         }
     };
 
@@ -147,24 +175,124 @@ pub fn mdr_command(args: TokenStream, input: TokenStream) -> TokenStream {
             ::mdown_review_lib::startup_recorder::record_first_ipc();
             #body_eval
             let __dur_us = __start.elapsed().as_micros();
-            let __payload_bytes: usize = if cfg!(debug_assertions)
-                || std::env::var("MDR_IPC_TRACE").is_ok()
-            {
-                0
-            } else {
-                0
-            };
+            // Reserved schema slot — Iter-2 will compute argument-payload
+            // size when MDR_IPC_TRACE is set. Until then this is a stable
+            // `0` so log-analyzer regexes can pin the field order.
+            let __payload_bytes: usize = 0;
             #log_call
             __result
         }
     };
 
-    let expanded = quote! {
+    quote! {
         #(#attrs)*
         #tauri_cmd_attr
         #[specta::specta]
         #vis #sig #wrapped_body
-    };
+    }
+}
 
-    TokenStream::from(expanded)
+#[cfg(test)]
+mod tests {
+    use super::expand;
+    use quote::quote;
+
+    /// Snapshot-style assertion that the macro emits both the
+    /// `#[tauri::command]` and `#[specta::specta]` attributes (so the
+    /// tauri-specta codegen pipeline keeps finding the function), the
+    /// gated `[ipc]` log call, and the `record_first_ipc` hook into the
+    /// startup recorder. Catches accidental drops of any composed
+    /// attribute when the macro is refactored.
+    #[test]
+    fn expansion_includes_tauri_command_and_specta_and_log() {
+        let out = expand(
+            quote! {},
+            quote! { fn check(path: String) -> bool { false } },
+        )
+        .to_string();
+        assert!(out.contains("# [tauri :: command]"), "missing #[tauri::command]: {out}");
+        assert!(out.contains("# [specta :: specta]"), "missing #[specta::specta]: {out}");
+        assert!(out.contains("\"[ipc] cmd"), "missing [ipc] log call: {out}");
+        assert!(
+            out.contains("ipc_trace_enabled"),
+            "missing ipc_trace_enabled gate (steady-state perf): {out}"
+        );
+        assert!(
+            out.contains("record_first_ipc"),
+            "missing record_first_ipc hook: {out}"
+        );
+    }
+
+    /// Result-returning fns should expand to a `match` against the result
+    /// so the warn-level err= line fires on `Err`. Non-Result returns
+    /// should hit the simpler info-level always-ok branch.
+    ///
+    /// Note: assertions match the format-literal text inside the
+    /// `log::warn!`/`log::info!` invocation (no whitespace inside string
+    /// literals), not the surrounding tokenized expansion.
+    #[test]
+    fn result_return_expands_to_match_on_result() {
+        let out = expand(
+            quote! {},
+            quote! { fn read(p: String) -> Result<String, String> { Ok(p) } },
+        )
+        .to_string();
+        assert!(out.contains("match & __result"), "result fn missing match: {out}");
+        assert!(
+            out.contains("ok=false err="),
+            "result fn missing err= line in log format string: {out}"
+        );
+        assert!(
+            out.contains("sanitize_err_for_log"),
+            "err= field must go through sanitizer to block log-line injection: {out}"
+        );
+    }
+
+    #[test]
+    fn non_result_return_uses_info_only() {
+        let out = expand(
+            quote! {},
+            quote! { fn ping() -> u8 { 0 } },
+        )
+        .to_string();
+        assert!(
+            !out.contains("match & __result"),
+            "non-result fn should not match: {out}"
+        );
+        assert!(
+            !out.contains("ok=false"),
+            "non-result fn should not emit err= branch in log format string: {out}"
+        );
+        assert!(
+            out.contains("ok=true"),
+            "non-result fn should always log ok=true: {out}"
+        );
+    }
+
+    /// Argument forwarding: `#[mdr_command(rename_all = "camelCase")]`
+    /// must reach the inner `#[tauri::command(...)]` so Tauri's case
+    /// conversion still applies. Bare `#[mdr_command]` must NOT add
+    /// stray parens.
+    #[test]
+    fn forwards_args_to_tauri_command() {
+        let with_args = expand(
+            quote! { rename_all = "camelCase" },
+            quote! { fn x() -> u8 { 0 } },
+        )
+        .to_string();
+        assert!(
+            with_args.contains("# [tauri :: command (rename_all = \"camelCase\")]"),
+            "missing forwarded args: {with_args}"
+        );
+
+        let bare = expand(quote! {}, quote! { fn x() -> u8 { 0 } }).to_string();
+        assert!(
+            bare.contains("# [tauri :: command]"),
+            "bare mdr_command should expand to bare tauri::command: {bare}"
+        );
+        assert!(
+            !bare.contains("# [tauri :: command ("),
+            "bare mdr_command must not emit empty parens: {bare}"
+        );
+    }
 }

--- a/src-tauri/src/commands/cli_shim.rs
+++ b/src-tauri/src/commands/cli_shim.rs
@@ -2,6 +2,7 @@
 
 use serde::Serialize;
 use std::fmt;
+use crate::mdr_command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, specta::Type)]
 #[serde(rename_all = "lowercase")]
@@ -53,20 +54,17 @@ mod unsupported;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use unsupported as imp;
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn cli_shim_status(app: tauri::AppHandle) -> CliShimStatus {
     imp::status(&app)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn install_cli_shim(app: tauri::AppHandle) -> Result<(), CliShimError> {
     imp::install(&app)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn remove_cli_shim(app: tauri::AppHandle) -> Result<(), CliShimError> {
     imp::remove(&app)
 }

--- a/src-tauri/src/commands/comments/badges.rs
+++ b/src-tauri/src/commands/comments/badges.rs
@@ -6,6 +6,7 @@ use crate::watcher::{SidecarConfigState, WatcherState};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use tauri::State;
+use crate::mdr_command;
 
 /// File anchors and typed anchors (image/csv/json/html/word) do not need to
 /// read source bytes for badge computation. The matcher path
@@ -34,8 +35,7 @@ pub struct FileBadge {
 }
 
 /// Per-file unresolved-thread count + worst severity.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_file_badges(
     state: State<'_, WatcherState>,
     config_state: State<'_, SidecarConfigState>,

--- a/src-tauri/src/commands/comments/get.rs
+++ b/src-tauri/src/commands/comments/get.rs
@@ -11,6 +11,7 @@ use tauri::State;
 
 use super::enforce_workspace_path;
 use crate::watcher::{SidecarConfigState, WatcherState};
+use crate::mdr_command;
 
 /// Result of [`get_file_comments`]: matched/grouped threads plus the mtime
 /// of the sidecar file the loader actually picked. `sidecar_mtime_ms` is
@@ -67,8 +68,7 @@ fn sidecar_mtime_ms_from(yaml: &str, json: &str) -> Option<i64> {
 /// cap (matching `read_text_file` and `SIDECAR_MAX_BYTES`) — anything larger
 /// degrades silently to empty bytes so all comments orphan, identical to the
 /// `NotFound` branch.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_file_comments(
     state: State<'_, WatcherState>,
     config_state: State<'_, SidecarConfigState>,

--- a/src-tauri/src/commands/comments/mod.rs
+++ b/src-tauri/src/commands/comments/mod.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use tauri::{AppHandle, Emitter, Runtime, State};
 
 use crate::watcher::{SidecarConfigState, WatcherState};
+use crate::mdr_command;
 
 pub mod anchor_input;
 pub mod badge_cache;
@@ -245,8 +246,7 @@ fn with_sidecar_or_create<E: CommentsEmitter>(
 /// by `invoke("add_comment", { ... })` on the JS side. Grouping arguments
 /// into a struct would change the wire contract.
 #[allow(clippy::too_many_arguments)]
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn add_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
@@ -380,8 +380,7 @@ pub fn check_workspace_for(
 }
 
 /// Create a reply to an existing comment, save to sidecar.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn add_reply<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
@@ -432,8 +431,7 @@ pub fn add_reply_inner<E: CommentsEmitter>(
 }
 
 /// Edit a comment's text, save to sidecar.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn edit_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
@@ -480,8 +478,7 @@ pub fn edit_comment_inner<E: CommentsEmitter>(
 }
 
 /// Delete a comment (with reply reparenting per MRSF §9.1), save to sidecar.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn delete_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,
@@ -521,8 +518,7 @@ pub fn delete_comment_inner<E: CommentsEmitter>(
 }
 
 /// Compute SHA-256 hash for selected text anchor.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn compute_anchor_hash(text: String) -> String {
     crate::core::anchors::compute_selected_text_hash(&text)
 }

--- a/src-tauri/src/commands/comments/update.rs
+++ b/src-tauri/src/commands/comments/update.rs
@@ -4,6 +4,7 @@ use super::{enforce_workspace_path, CommentsEmitter};
 use crate::core::types::{Anchor, Reaction};
 use crate::watcher::{SidecarConfigState, WatcherState};
 use tauri::{AppHandle, Runtime, State};
+use crate::mdr_command;
 
 /// Patch payloads for `update_comment`. Discriminated enum (serde adjacent
 /// `kind`/`data` tags) so the TS side can branch cleanly. Every per-comment
@@ -39,8 +40,7 @@ pub enum CommentPatch {
 }
 
 /// Apply a [`CommentPatch`] to a single comment.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn update_comment<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, WatcherState>,

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -11,6 +11,7 @@
 use crate::core::onboarding::{load_at, save_at};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
+use crate::mdr_command;
 
 const AUTHOR_MAX_BYTES: usize = 128;
 
@@ -73,8 +74,7 @@ pub fn set_author_at(path: &Path, name: &str) -> Result<String, ConfigError> {
     Ok(cleaned)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn set_author(app: AppHandle, name: String) -> Result<String, ConfigError> {
     let path = default_path(&app)?;
     set_author_at(&path, &name)
@@ -99,8 +99,7 @@ pub fn get_author_at_with<F: FnOnce() -> String>(path: &Path, fallback: F) -> St
     state.author.unwrap_or_else(fallback)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_author(app: AppHandle) -> Result<String, ConfigError> {
     let path = default_path(&app)?;
     Ok(get_author_at_with(&path, default_author))

--- a/src-tauri/src/commands/default_handler.rs
+++ b/src-tauri/src/commands/default_handler.rs
@@ -3,6 +3,7 @@
 
 use serde::Serialize;
 use tauri::AppHandle;
+use crate::mdr_command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, specta::Type)]
 #[serde(rename_all = "lowercase")]
@@ -28,14 +29,12 @@ mod unsupported;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use unsupported as imp;
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn default_handler_status(app: AppHandle) -> DefaultHandlerStatus {
     imp::status(&app)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn set_default_handler(app: AppHandle) -> Result<(), String> {
     imp::set(&app)
 }

--- a/src-tauri/src/commands/file_viewer_prefs.rs
+++ b/src-tauri/src/commands/file_viewer_prefs.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
+use crate::mdr_command;
 
 const MAX_ENTRIES: usize = 500;
 
@@ -125,8 +126,7 @@ pub fn set_pref_at(
 
 // ── IPC commands ──────────────────────────────────────────────────────
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_file_viewer_pref(app: AppHandle, path: String) -> Option<FileViewerPref> {
     let canonical = match crate::core::paths::canonicalize_no_verbatim(std::path::Path::new(&path)) {
         Ok(c) => c,
@@ -140,8 +140,7 @@ pub fn get_file_viewer_pref(app: AppHandle, path: String) -> Option<FileViewerPr
         .map(|e| FileViewerPref { allow_images: e.allow_images })
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn set_file_viewer_pref(
     app: AppHandle,
     path: String,

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -3,6 +3,7 @@
 use super::is_sidecar_file;
 use crate::core::paths::canonicalize_no_verbatim;
 use crate::core::types::DirEntry;
+use crate::mdr_command;
 
 /// Canonicalize an absolute path to the long form without the Windows `\\?\`
 /// verbatim prefix. Used by the renderer to normalize paths at workspace-open
@@ -10,8 +11,7 @@ use crate::core::types::DirEntry;
 /// scanner output (which itself canonicalizes via `dunce`) match. No
 /// workspace guard — this is the very command callers use to obtain the
 /// canonical form before they have a workspace to validate against.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn canonicalize_path(path: String) -> Result<String, String> {
     canonicalize_no_verbatim(std::path::Path::new(&path))
         .map(|p| p.to_string_lossy().into_owned())
@@ -35,8 +35,7 @@ pub enum PathKind {
 }
 
 /// Check if a path exists and whether it is a directory or file.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn check_path_exists(path: String) -> PathKind {
     match std::fs::metadata(&path) {
         Ok(meta) if meta.is_dir() => PathKind::Dir,
@@ -61,8 +60,7 @@ pub struct ReadDirResult {
 /// Hides `.review.yaml`/`.review.json` sidecar files, and also hides the
 /// `sidecar_root` directory when listing a workspace root with an active
 /// redirect (AC10: prevents users from seeing the internal sidecar store).
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn read_dir(
     path: String,
     limit: Option<usize>,
@@ -191,8 +189,7 @@ pub struct TextFileResult {
 /// platform/FS does not expose it). The file handle's metadata is read
 /// before the body so content + mtime come from the same `open()` and the
 /// caller cannot observe a torn (content_v1, mtime_v2) pair.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn read_text_file(path: String) -> Result<TextFileResult, String> {
     use std::io::Read;
 
@@ -243,8 +240,7 @@ pub fn read_text_file(path: String) -> Result<TextFileResult, String> {
 }
 
 /// Read a binary file, returning base64-encoded content. Rejects files >10 MB.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn read_binary_file(path: String) -> Result<String, String> {
     let bytes = std::fs::read(&path).map_err(|e| {
         tracing::error!("[rust] command error: {}", e);
@@ -278,8 +274,7 @@ pub struct FileStat {
     pub mtime_ms: Option<i64>,
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn stat_file(
     path: String,
     state: tauri::State<'_, crate::watcher::WatcherState>,
@@ -324,8 +319,7 @@ pub fn stat_file_inner(
 /// Also loads the `.mrsf.yaml` config for the workspace root and caches
 /// its `sidecar_root` value in [`SidecarConfigState`] so that subsequent
 /// sidecar reads/writes use the configured path.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn update_tree_watched_dirs(
     window: tauri::Window,
     root: String,

--- a/src-tauri/src/commands/html.rs
+++ b/src-tauri/src/commands/html.rs
@@ -1,18 +1,17 @@
 //! HTML preview helpers: asset inlining and code-fold region computation.
 
+use crate::mdr_command;
 pub use crate::core::fold_regions::FoldRegion;
 
 /// Inline local images as data URIs and stylesheets as `<style>` blocks.
 /// Replaces the previous TS implementation in `src/lib/resolve-html-assets.ts`.
 /// Per-asset failures preserve the original tag (graceful fallback).
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn resolve_html_assets(html: String, html_dir: String) -> String {
     crate::core::html_assets::resolve_local_assets(&html, std::path::Path::new(&html_dir))
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn compute_fold_regions(content: String, language: String) -> Vec<FoldRegion> {
     crate::core::fold_regions::compute_fold_regions(&content, &language)
 }

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -1,5 +1,6 @@
 //! Launch-time and diagnostic commands (CLI args, log path, file scanner).
 
+use crate::mdr_command;
 #[cfg(debug_assertions)]
 use super::is_sidecar_file;
 use crate::core::paths::canonicalize_no_verbatim;
@@ -74,8 +75,7 @@ pub fn parse_launch_args(args: &[String], cwd: &Path) -> LaunchArgs {
 }
 
 /// Get (and drain) launch args queued for the calling window.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub async fn get_launch_args(
     window: tauri::Window,
     registry: tauri::State<'_, crate::registry::WindowRegistry>,
@@ -84,8 +84,7 @@ pub async fn get_launch_args(
 }
 
 /// Get the log file path for display in the About dialog.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_log_path(app: tauri::AppHandle) -> Result<String, String> {
     let log_dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
     Ok(log_dir
@@ -101,16 +100,14 @@ pub fn get_log_path(app: tauri::AppHandle) -> Result<String, String> {
 /// instead of being incorrectly flagged as ghosts. Both the GUI IPC
 /// and the CLI go through [`crate::core::scanner::scan_workspace`] for
 /// identical `(sidecar, source)` output.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn scan_review_files(root: String) -> Result<Vec<(String, String)>, String> {
     Ok(crate::core::scanner::scan_workspace(&root, 10_000))
 }
 
 /// Test-only command: open a folder and all its non-sidecar files via args-received.
 #[cfg(debug_assertions)]
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn set_root_via_test(path: String, app: tauri::AppHandle) -> Result<(), String> {
     use tauri::{Emitter, Manager};
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod launch;
 pub mod onboarding;
 pub mod remote_asset;
 pub mod search;
+pub mod startup;
 pub mod system;
 pub mod sidecar_config;
 pub mod word_tokens;
@@ -50,6 +51,7 @@ pub use remote_asset::fetch_remote_asset;
 pub use search::{
     parse_kql, search_in_document, strip_json_comments, KqlPipelineStep, SearchMatch,
 };
+pub use startup::record_startup_phase;
 pub use system::{reveal_in_folder, SystemError};
 pub use sidecar_config::{
     get_sidecar_config, migrate_sidecars_cmd, set_sidecar_config, MigrateSidecarsResult,

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -4,14 +4,14 @@
 use crate::core::onboarding::{load_at, OnboardingState};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
+use crate::mdr_command;
 
 fn default_path(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     Ok(dir.join("onboarding.json"))
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn onboarding_state(app: AppHandle) -> Result<OnboardingState, String> {
     let path = default_path(&app)?;
     Ok(load_at(&path))

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -1,5 +1,6 @@
 //! Document-search and pure-parser commands exposed to the View layer.
 
+use crate::mdr_command;
 pub use crate::core::kql::KqlPipelineStep;
 
 #[derive(serde::Serialize, specta::Type)]
@@ -10,8 +11,7 @@ pub struct SearchMatch {
     pub end_col: usize,
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn search_in_document(content: String, query: String) -> Vec<SearchMatch> {
     if query.is_empty() {
         return vec![];
@@ -40,14 +40,12 @@ pub fn search_in_document(content: String, query: String) -> Vec<SearchMatch> {
     results
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn parse_kql(query: String) -> Vec<KqlPipelineStep> {
     crate::core::kql::parse_kql_pipeline(&query)
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn strip_json_comments(text: String) -> String {
     crate::core::json::strip_json_comments(&text)
 }

--- a/src-tauri/src/commands/sidecar_config.rs
+++ b/src-tauri/src/commands/sidecar_config.rs
@@ -8,6 +8,7 @@ use crate::core::sidecar::config::{load_mrsf_config, SidecarConfigState};
 use crate::core::sidecar::migration::{self, MigrateDirection, SidecarCounts};
 use std::path::PathBuf;
 use tauri::{Emitter, Manager};
+use crate::mdr_command;
 
 // ── Result types ─────────────────────────────────────────────────────
 
@@ -69,8 +70,7 @@ fn emit_config_changed(app: &tauri::AppHandle, root: &std::path::Path) {
 
 // ── Commands ─────────────────────────────────────────────────────────
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn get_sidecar_config(
     root: String,
     config_state: tauri::State<'_, SidecarConfigState>,
@@ -85,8 +85,7 @@ pub fn get_sidecar_config(
     Ok(build_result(&root, &sidecar_root))
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn set_sidecar_config(
     window: tauri::Window,
     root: String,
@@ -119,8 +118,7 @@ pub fn set_sidecar_config(
     Ok(build_result(&root, &sidecar_root))
 }
 
-#[tauri::command(rename_all = "camelCase")]
-#[specta::specta]
+#[mdr_command(rename_all = "camelCase")]
 pub fn migrate_sidecars_cmd(
     window: tauri::Window,
     root: String,

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -1,0 +1,25 @@
+//! IPC entry point for frontend-driven startup-phase telemetry.
+//!
+//! The Rust side records `AppInit`, `WebviewReady`, and `FirstIpc`
+//! directly (see `lib.rs::run` and the `#[mdr_command]` macro). The
+//! frontend reports the remaining phases — `ThemeApplied`,
+//! `FrontendMounted`, `FirstFileLoaded` — via this single IPC. The
+//! emitted `[startup] phase=… t_ms=…` event flows into the same
+//! rotating log file as the rest of the tracing surface (see
+//! `docs/observability.md`).
+//!
+//! Idempotent at the recorder level — the underlying
+//! `StartupRecorder::record_phase` dedupes per-phase per-process so
+//! a chatty frontend (StrictMode double-invoke, hot reload, etc.)
+//! cannot inflate the timeline.
+
+use crate::mdr_command;
+use crate::startup_recorder::{record_phase, StartupPhase};
+
+/// Record a startup phase from the frontend. Mirrors
+/// `StartupPhase` 1:1 — see that enum for the kebab-case wire shape
+/// (`"theme-applied"`, `"frontend-mounted"`, `"first-file-loaded"`).
+#[mdr_command]
+pub fn record_startup_phase(phase: StartupPhase) {
+    record_phase(phase);
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -12,6 +12,7 @@
 
 use std::path::Path;
 use std::process::Command;
+use crate::mdr_command;
 
 /// Typed error surfaced to the renderer. Discriminated with an internal `kind`
 /// tag so the TS side can branch on it without parsing prose strings.
@@ -66,8 +67,7 @@ pub(crate) fn build_reveal_command(path: &Path) -> Result<Command, SystemError> 
 ///
 /// Workspace-allowlisted via `WatcherState::is_path_allowed`. On Linux there
 /// is no portable "select" — we open the parent directory instead.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn reveal_in_folder(
     path: String,
     state: tauri::State<'_, crate::watcher::WatcherState>,

--- a/src-tauri/src/commands/word_tokens.rs
+++ b/src-tauri/src/commands/word_tokens.rs
@@ -8,11 +8,11 @@
 //! `Err(String)` rather than burning CPU on adversarial payloads.
 
 use crate::core::word_tokens::{tokenize_words as core_tokenize, WordSpan};
+use crate::mdr_command;
 
 const MAX_BYTES: usize = 65_536;
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn tokenize_words(text: String) -> Result<Vec<WordSpan>, String> {
     if text.len() > MAX_BYTES {
         return Err(format!("tokenize_words: input exceeds {} bytes", MAX_BYTES));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,27 @@
+// Self-alias so the `#[mdr_command]` proc-macro (in `mdr-macros/`) can
+// emit absolute paths like `::mdown_review_lib::startup_recorder::…`
+// uniformly — both INSIDE this crate's compile units AND in downstream
+// integration tests. Without this, a bare `::mdown_review_lib::…` path
+// inside `lib.rs` itself fails E0433 because the crate cannot
+// self-reference by name. This is the canonical Rust pattern for
+// proc-macros that need an absolute path back to the host crate.
+extern crate self as mdown_review_lib;
+
 pub mod commands;
 pub mod core;
 pub mod instance_scope;
+pub mod macros;
 pub mod registry;
+pub mod startup_recorder;
 pub mod tracing_log_bridge;
 pub mod update;
 pub mod watcher;
+
+// Re-export `#[mdr_command]` at the crate root so call sites read
+// `use crate::mdr_command;` (or `use mdown_review_lib::mdr_command;`
+// from tests) instead of the deeper `crate::macros::mdr_command`.
+// See `macros/mod.rs` for the indirection rationale.
+pub use macros::mdr_command;
 
 use commands::{parse_launch_args, LaunchArgs};
 #[cfg(all(debug_assertions, feature = "codegen"))]
@@ -168,8 +185,7 @@ fn open_new_window(app: &tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| format!("failed to create window: {e}"))
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 fn register_window_folder(
     window: tauri::Window,
     folder: String,
@@ -198,8 +214,7 @@ fn register_window_folder(
     }
 }
 
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 fn unregister_window_folder(
     window: tauri::Window,
     registry: tauri::State<'_, registry::WindowRegistry>,
@@ -352,6 +367,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
                 commands::sidecar_config::get_sidecar_config,
                 commands::sidecar_config::set_sidecar_config,
                 commands::sidecar_config::migrate_sidecars_cmd,
+                commands::startup::record_startup_phase,
                 update::check_update,
                 update::install_update,
                 register_window_folder,
@@ -374,6 +390,12 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Anchor the StartupRecorder timeline. Touching `record_phase` here
+    // also forces lazy `OnceLock` init so the `t_ms` baseline matches
+    // the user-visible "process start" rather than the first IPC call.
+    // See `startup_recorder` for the schema (`[startup] phase=app-init t_ms=…`).
+    startup_recorder::record_phase(startup_recorder::StartupPhase::AppInit);
+
     let log_plugin = {
         let mut builder = tauri_plugin_log::Builder::new()
             .max_file_size(5 * 1024 * 1024)
@@ -515,9 +537,15 @@ pub fn run() {
 
             // ── Per-window menu for main window ──────────────────────────────
             // Main window is created by tauri.conf.json; set its menu here.
+            // The presence of the main webview window at this point is the
+            // best in-process signal that the renderer is loadable, so we
+            // record `WebviewReady` here. Frontend-side phases
+            // (`ThemeApplied`, `FrontendMounted`, `FirstFileLoaded`) are
+            // reported via `record_startup_phase` once React mounts.
             if let Some(main_win) = app.get_webview_window("main") {
                 let main_menu = build_window_menu(app, "main")?;
                 main_win.set_menu(main_menu)?;
+                startup_recorder::record_phase(startup_recorder::StartupPhase::WebviewReady);
             }
 
             // ── Menu event routing ───────────────────────────────────────────

--- a/src-tauri/src/macros/mod.rs
+++ b/src-tauri/src/macros/mod.rs
@@ -1,0 +1,16 @@
+//! IPC tracing macro re-export.
+//!
+//! `#[mdr_command]` is defined in the sibling proc-macro crate
+//! `mdr-macros` (proc-macros must live in their own crate per Rust's
+//! `proc-macro = true` rule). This module re-exports it so callers can
+//! use a stable `crate::mdr_command` path; `lib.rs` further re-exports
+//! it at the crate root so call sites read `#[mdr_command]` rather than
+//! `#[macros::mdr_command]`.
+//!
+//! See `mdr-macros/src/lib.rs` for the macro implementation, the on-disk
+//! log schema, and the argument-forwarding rules. See also
+//! `crate::startup_recorder` — the macro's expanded body calls
+//! `record_first_ipc()` to drive the `StartupPhase::FirstIpc` event on
+//! the very first IPC of the process.
+
+pub use mdr_macros::mdr_command;

--- a/src-tauri/src/startup_recorder.rs
+++ b/src-tauri/src/startup_recorder.rs
@@ -140,6 +140,103 @@ pub fn record_first_ipc() {
     }
 }
 
+/// Cached gate for the per-call `[ipc]` log line emitted by `#[mdr_command]`.
+/// Returns `true` in any debug build, or whenever `MDR_IPC_TRACE` is set in
+/// the process environment. The result is memoized in a `OnceLock<bool>`
+/// so the steady-state per-IPC cost is one relaxed atomic load + one
+/// branch — matches the hot-path budget in `docs/performance.md`.
+///
+/// Why cache: `std::env::var` is a syscall (or TLS lookup with a Mutex on
+/// Windows). Calling it on every IPC dispatch breaches the budget for
+/// hot commands like `search_in_document` and the watcher's `notify`
+/// callbacks. The env var is read at most once per process; live toggling
+/// is intentionally unsupported.
+pub fn ipc_trace_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| cfg!(debug_assertions) || std::env::var("MDR_IPC_TRACE").is_ok())
+}
+
+/// Maximum length of a sanitized err string in an `[ipc]` log line. Keeps
+/// pathological error payloads (e.g. multi-MB serde dumps) from blowing
+/// out the rotating log file on a single failed IPC call.
+const MAX_LOG_ERR_LEN: usize = 512;
+
+/// Sanitize a Debug-formatted error payload for inclusion in an `[ipc]`
+/// log line. Strips control characters that an attacker could use to
+/// forge log entries — newlines, carriage returns, and ANSI/CSI escape
+/// sequences — and bounds the length so a pathological error cannot
+/// rotate out useful diagnostic context.
+///
+/// The replacement character is `?` (0x3F), which is structurally
+/// distinguishable from real text and survives a UTF-8 round trip.
+/// Truncation appends `…(truncated)` so a downstream parser can detect
+/// the cut and avoid acting on a partial payload.
+///
+/// Used by the `#[mdr_command]` proc-macro's err= field (see
+/// `mdr-macros/src/lib.rs`). Not a security boundary on its own — the
+/// `[ipc]` lines are gated behind `ipc_trace_enabled()` and only fire
+/// in debug builds or when `MDR_IPC_TRACE=1` — but it closes the
+/// log-injection / forensic-tampering surface flagged in the security
+/// review of issue #264.
+pub fn sanitize_err_for_log(s: &str) -> String {
+    let mut out = String::with_capacity(s.len().min(MAX_LOG_ERR_LEN + 16));
+    let mut written = 0usize;
+    for c in s.chars() {
+        if written >= MAX_LOG_ERR_LEN {
+            out.push_str("…(truncated)");
+            return out;
+        }
+        // Control characters (C0 + DEL + C1) and ESC are replaced. Keeps
+        // ASCII printable, normal whitespace becomes a single space, and
+        // anything else (e.g. non-Latin path components) passes through
+        // unchanged so the log remains useful for diagnostics.
+        let safe = match c {
+            '\t' | ' ' => ' ',
+            c if c.is_control() => '?',
+            c => c,
+        };
+        out.push(safe);
+        written += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_err_for_log;
+
+    #[test]
+    fn strips_newline_carriage_return_and_escape() {
+        let payload = "evil\n[ipc] cmd=install_update ok=true\rinjected\x1b[31m";
+        let out = sanitize_err_for_log(payload);
+        assert!(!out.contains('\n'), "newline must be stripped: {out:?}");
+        assert!(!out.contains('\r'), "CR must be stripped: {out:?}");
+        assert!(!out.contains('\x1b'), "ESC must be stripped: {out:?}");
+    }
+
+    #[test]
+    fn preserves_normal_diagnostic_text() {
+        let payload = "ConfigError::IoError { path: \"/Users/dev/x.md\", reason: \"ENOENT\" }";
+        let out = sanitize_err_for_log(payload);
+        assert_eq!(out, payload, "normal text must round-trip unchanged");
+    }
+
+    #[test]
+    fn truncates_pathological_input() {
+        let payload = "a".repeat(2048);
+        let out = sanitize_err_for_log(&payload);
+        assert!(
+            out.ends_with("…(truncated)"),
+            "must signal truncation: {out:?}"
+        );
+        assert!(
+            out.chars().count() <= super::MAX_LOG_ERR_LEN + "…(truncated)".chars().count(),
+            "must bound output length: got {} chars",
+            out.chars().count()
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/startup_recorder.rs
+++ b/src-tauri/src/startup_recorder.rs
@@ -1,0 +1,169 @@
+//! Process-singleton emitter for startup-phase telemetry.
+//!
+//! Used by:
+//!   * `lib.rs::run` — records `AppInit` and `WebviewReady`.
+//!   * The `mdr_command!` proc-macro expansion — drives the
+//!     `FirstIpc` phase via [`record_first_ipc`].
+//!   * The `record_startup_phase` IPC — the frontend reports
+//!     `ThemeApplied`, `FrontendMounted`, `FirstFileLoaded`.
+//!
+//! The recorder is process-global (one `OnceLock<Mutex<State>>`).
+//! Each phase fires at most once per process; subsequent calls
+//! against the same phase emit a debug-level note and otherwise
+//! noop. The `[startup]` schema is `phase=<kebab-name> t_ms=<n>`,
+//! emitted via `log::info!` so it lands in the rotating log file
+//! configured by `tauri-plugin-log` (see `lib.rs::run`).
+//!
+//! See `docs/observability.md` for the post-hoc analysis pipeline.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+/// Ordered phases of app startup, mirrored to TypeScript via specta as a
+/// kebab-case string union (`"app-init" | "webview-ready" | ...`). Each
+/// phase is recorded at most once per process lifetime.
+///
+/// Order of expected emission:
+///   1. `AppInit` — Rust `pub fn run` first instruction.
+///   2. `WebviewReady` — main webview's `Created` window event.
+///   3. `FirstIpc` — first call through any `#[mdr_command]` IPC.
+///   4. `ThemeApplied` — frontend reports after applying initial theme
+///      (PR4 will move this to a pre-React script tag).
+///   5. `FrontendMounted` — React's `App` finished its first effect.
+///   6. `FirstFileLoaded` — the user's first viewer paint completes.
+///
+/// Phase order is not enforced — async timing differences mean the recorder
+/// must accept events in any sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum StartupPhase {
+    AppInit,
+    WebviewReady,
+    FirstIpc,
+    ThemeApplied,
+    FrontendMounted,
+    FirstFileLoaded,
+}
+
+impl StartupPhase {
+    /// Stable kebab-case string used by both the `[startup]` log schema
+    /// and the on-wire IPC payload (matched by the `serde(rename_all =
+    /// "kebab-case")` above).
+    fn as_str(&self) -> &'static str {
+        match self {
+            StartupPhase::AppInit => "app-init",
+            StartupPhase::WebviewReady => "webview-ready",
+            StartupPhase::FirstIpc => "first-ipc",
+            StartupPhase::ThemeApplied => "theme-applied",
+            StartupPhase::FrontendMounted => "frontend-mounted",
+            StartupPhase::FirstFileLoaded => "first-file-loaded",
+        }
+    }
+}
+
+struct State {
+    /// Wall-clock anchor against which every phase's `t_ms` is computed.
+    /// Set the first time the recorder is touched (`AppInit` or earlier).
+    start: Instant,
+    /// Phases already emitted. Subsequent calls against any phase in this
+    /// set are deduplicated (debug-logged but not re-emitted).
+    seen: HashSet<StartupPhase>,
+}
+
+static STATE: OnceLock<Mutex<State>> = OnceLock::new();
+
+/// Fast-path guard for the `FirstIpc` phase. The proc-macro `#[mdr_command]`
+/// fires `record_first_ipc()` on every IPC entry; without this atomic
+/// short-circuit every call would acquire the recorder's `Mutex<State>`,
+/// imposing a global lock on the entire IPC dispatcher. After the first
+/// IPC the atomic flips and subsequent calls return immediately with a
+/// single relaxed atomic load.
+static FIRST_IPC_DONE: AtomicBool = AtomicBool::new(false);
+
+fn state() -> &'static Mutex<State> {
+    STATE.get_or_init(|| {
+        Mutex::new(State {
+            start: Instant::now(),
+            seen: HashSet::new(),
+        })
+    })
+}
+
+/// Record a startup phase. Idempotent — first call wins; subsequent calls
+/// against the same phase emit only a debug-level note. Recoverable on
+/// `Mutex` poisoning (logs the panic source's data; never panics itself).
+pub fn record_phase(phase: StartupPhase) {
+    let mut st = match state().lock() {
+        Ok(s) => s,
+        // Poison recovery: another thread panicked while holding the lock.
+        // The `seen` set is still consistent enough to dedupe on, so we
+        // unwrap the inner state and proceed.
+        Err(p) => p.into_inner(),
+    };
+    if st.seen.insert(phase) {
+        let t_ms = st.start.elapsed().as_millis();
+        log::info!(
+            target: "startup",
+            "[startup] phase={} t_ms={}",
+            phase.as_str(),
+            t_ms
+        );
+    } else {
+        log::debug!(
+            target: "startup",
+            "[startup] phase={} (duplicate, ignored)",
+            phase.as_str()
+        );
+    }
+}
+
+/// Fast-path entry for the `[mdr_command]` macro: record `FirstIpc`
+/// at most once per process. Implemented as an atomic CAS-then-record
+/// so the IPC hot path costs one relaxed atomic load after the first
+/// invocation. Calls `record_phase(StartupPhase::FirstIpc)` exactly once.
+pub fn record_first_ipc() {
+    if FIRST_IPC_DONE.load(Ordering::Relaxed) {
+        return;
+    }
+    // CAS to ensure only one thread drives the underlying record_phase.
+    // Subsequent threads that lose the race observe the flipped flag
+    // on their next call and short-circuit on the relaxed load above.
+    if FIRST_IPC_DONE
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_ok()
+    {
+        record_phase(StartupPhase::FirstIpc);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `as_str` is the schema contract — every phase name is kebab-case
+    /// and stable for log analyzers (PR4's `analyze-log`). Adding a new
+    /// variant requires extending this match.
+    #[test]
+    fn as_str_uses_kebab_case() {
+        assert_eq!(StartupPhase::AppInit.as_str(), "app-init");
+        assert_eq!(StartupPhase::WebviewReady.as_str(), "webview-ready");
+        assert_eq!(StartupPhase::FirstIpc.as_str(), "first-ipc");
+        assert_eq!(StartupPhase::ThemeApplied.as_str(), "theme-applied");
+        assert_eq!(StartupPhase::FrontendMounted.as_str(), "frontend-mounted");
+        assert_eq!(StartupPhase::FirstFileLoaded.as_str(), "first-file-loaded");
+    }
+
+    /// JSON wire shape: matches the `serde(rename_all = "kebab-case")`
+    /// attribute. The frontend's `bindings.ts` consumes the same string
+    /// values; this guards against an accidental rename diverging the
+    /// wire contract.
+    #[test]
+    fn serde_emits_kebab_case() {
+        let s = serde_json::to_string(&StartupPhase::FrontendMounted).unwrap();
+        assert_eq!(s, "\"frontend-mounted\"");
+    }
+}

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::{Update, UpdaterExt};
+use crate::mdr_command;
 
 const STABLE_ENDPOINT: &str =
     "https://github.com/dryotta/mdownreview/releases/latest/download/latest.json";
@@ -51,8 +52,7 @@ fn installed_channel(app: &AppHandle) -> &'static str {
 /// Check for an update on the given channel.
 /// For cross-channel switches the version comparator is overridden
 /// to accept any different version (enabling "downgrades").
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub async fn check_update(app: AppHandle, channel: String) -> Result<Option<UpdateInfo>, String> {
     let endpoint = endpoint_for_channel(&channel);
     let cross_channel = installed_channel(&app) != channel.as_str();
@@ -88,8 +88,7 @@ pub async fn check_update(app: AppHandle, channel: String) -> Result<Option<Upda
 
 /// Download and install the pending update. Emits "update-progress"
 /// events so the frontend can show a progress bar.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub async fn install_update(app: AppHandle) -> Result<(), String> {
     let update = {
         let state = app.state::<PendingUpdate>();

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
+use crate::mdr_command;
 
 /// Maximum number of tree-watched dirs across ALL windows (merged union).
 pub const MAX_TREE_WATCHED_DIRS: usize = 1024;
@@ -428,8 +429,7 @@ fn sync_dirs(
 
 /// Tauri command: update the set of watched file paths.
 /// The frontend calls this whenever the set of open tabs changes.
-#[tauri::command]
-#[specta::specta]
+#[mdr_command]
 pub fn update_watched_files(
     window: tauri::Window,
     paths: Vec<String>,

--- a/src-tauri/tests/observability.rs
+++ b/src-tauri/tests/observability.rs
@@ -1,0 +1,305 @@
+//! Issue #264 — runtime tracing infrastructure: observability integration test.
+//!
+//! Asserts:
+//! 1. Calling `record_phase` for a fresh phase emits `[startup] phase=… t_ms=…`
+//!    at INFO level.
+//! 2. Calling `record_phase` again for the same phase does NOT re-emit at
+//!    INFO — it logs at DEBUG ("duplicate, ignored") instead.
+//! 3. The `[ipc] cmd=… duration_us=… payload_bytes=… ok=…` schema fires
+//!    once per call to a `#[mdr_command]`-wrapped function with the
+//!    expected ok-state.
+//! 4. The `MDR_IPC_TRACE=1` env var path does not panic and emits the
+//!    same canonical schema (the env-var only affects the
+//!    `payload_bytes` field gating; both branches currently emit `0`,
+//!    documented as the iter-1 placeholder in `docs/observability.md`).
+//!
+//! The test installs an in-memory `log::Log` and serializes the assertion
+//! across the whole binary via a `Mutex` because `log::set_logger`
+//! is process-global (and `cargo test` shares one binary per
+//! test target). The mutex also serialises `MDR_IPC_TRACE` env-var
+//! mutation against any other test that might read the same var.
+
+use mdown_review_lib::mdr_command;
+use mdown_review_lib::startup_recorder::{record_first_ipc, record_phase, StartupPhase};
+use std::sync::{Mutex, OnceLock};
+
+// ── In-memory log capture ────────────────────────────────────────────────
+
+/// Captured log line: (target, level, message). Targets we care about are
+/// `"ipc"` and `"startup"` — the macro / recorder canonical surfaces.
+#[derive(Debug, Clone)]
+struct LogLine {
+    target: String,
+    level: log::Level,
+    message: String,
+}
+
+struct CaptureLogger;
+
+static CAPTURED: OnceLock<Mutex<Vec<LogLine>>> = OnceLock::new();
+
+fn captured() -> &'static Mutex<Vec<LogLine>> {
+    CAPTURED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _meta: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        let line = LogLine {
+            target: record.target().to_string(),
+            level: record.level(),
+            message: format!("{}", record.args()),
+        };
+        if let Ok(mut g) = captured().lock() {
+            g.push(line);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Install the capture logger exactly once. `log::set_logger` panics on a
+/// second install per process; `OnceLock` guards us. The integration tests
+/// must run in a single binary so we accept that this is a process-wide
+/// install and the `cargo test` runner serialises tests inside the same
+/// binary's target dir.
+fn install_logger() {
+    INIT.get_or_init(|| {
+        // ignore error if another integration test already installed a
+        // logger — we only need OURS to be observed by the assertions
+        // below; a parallel test binary running concurrently uses its own
+        // process and does not race here.
+        let _ = log::set_logger(&LOGGER);
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+}
+
+/// Serialise every test in this file so the shared log buffer + env-var
+/// state is observed deterministically. `cargo test` parallelises tests
+/// by default; without this lock two `[startup] phase=app-init` lines
+/// from independent fixtures could collide and confuse the assertions.
+static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+fn test_lock() -> &'static Mutex<()> {
+    TEST_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn drain_captured() -> Vec<LogLine> {
+    let mut g = captured().lock().unwrap_or_else(|p| p.into_inner());
+    let out = std::mem::take(&mut *g);
+    out
+}
+
+// ── Fixture command ──────────────────────────────────────────────────────
+
+/// Stand-in IPC handler used to verify the `[ipc]` schema. `#[mdr_command]`
+/// expands to `#[tauri::command] + #[specta::specta] + tracing wrap`. We
+/// don't actually go through the Tauri runtime — we just CALL the function
+/// like a normal Rust fn and observe the logs the wrap emits.
+///
+/// Returning `Result<i32, String>` exercises the `ok=true|false` branch
+/// of the macro; a sister fixture `fixture_err_command` covers the warn
+/// path for typed errors.
+#[mdr_command]
+fn fixture_ok_command(value: i32) -> Result<i32, String> {
+    Ok(value * 2)
+}
+
+#[mdr_command]
+fn fixture_err_command(reason: String) -> Result<(), String> {
+    Err(reason)
+}
+
+#[mdr_command]
+fn fixture_unit_command(value: i32) -> i32 {
+    value + 1
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[test]
+fn record_phase_emits_startup_schema_once() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    // First call — INFO emit expected.
+    record_phase(StartupPhase::ThemeApplied);
+    let lines = drain_captured();
+    let info_lines: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "startup" && l.level == log::Level::Info)
+        .collect();
+    assert!(
+        info_lines
+            .iter()
+            .any(|l| l.message.starts_with("[startup] phase=theme-applied t_ms=")),
+        "first record_phase(ThemeApplied) must emit INFO `[startup] phase=theme-applied t_ms=…`, got {:?}",
+        lines
+    );
+
+    // Second call — DEBUG emit (deduped); NO INFO.
+    record_phase(StartupPhase::ThemeApplied);
+    let lines = drain_captured();
+    let info_again: Vec<_> = lines
+        .iter()
+        .filter(|l| {
+            l.target == "startup"
+                && l.level == log::Level::Info
+                && l.message.contains("phase=theme-applied")
+        })
+        .collect();
+    assert!(
+        info_again.is_empty(),
+        "second record_phase(ThemeApplied) must NOT re-emit at INFO, got {:?}",
+        info_again
+    );
+    let dup_lines: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "startup" && l.message.contains("duplicate, ignored"))
+        .collect();
+    assert_eq!(
+        dup_lines.len(),
+        1,
+        "second record_phase(ThemeApplied) must emit exactly one DEBUG dedupe note, got {:?}",
+        lines
+    );
+}
+
+#[test]
+fn first_ipc_recorded_once_via_record_first_ipc() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    // Hammer the function — atomic CAS guard ensures `FirstIpc` fires at
+    // most once across the entire process. After the first test in this
+    // file runs (any of the fixture_* commands), the flag is already
+    // flipped; this is fine because the assertion is "fires AT MOST once,
+    // for the whole process". We assert the relaxed-load fast-path
+    // behaviour here: subsequent calls do NOT panic and do NOT log.
+    for _ in 0..16 {
+        record_first_ipc();
+    }
+    let lines = drain_captured();
+    let first_ipc_emits: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "startup" && l.message.contains("phase=first-ipc"))
+        .filter(|l| l.level == log::Level::Info)
+        .collect();
+    assert!(
+        first_ipc_emits.len() <= 1,
+        "record_first_ipc must emit FirstIpc INFO at most once per process, got {} lines: {:?}",
+        first_ipc_emits.len(),
+        first_ipc_emits
+    );
+}
+
+#[test]
+fn mdr_command_emits_ipc_schema_on_ok() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    let result = fixture_ok_command(21);
+    assert_eq!(result, Ok(42));
+
+    let lines = drain_captured();
+    let ipc_lines: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "ipc" && l.level == log::Level::Info)
+        .collect();
+    assert!(
+        ipc_lines.iter().any(|l| {
+            l.message.starts_with("[ipc] cmd=fixture_ok_command duration_us=")
+                && l.message.contains("payload_bytes=0")
+                && l.message.contains("ok=true")
+        }),
+        "fixture_ok_command must emit `[ipc] cmd=… duration_us=… payload_bytes=0 ok=true`, got {:?}",
+        ipc_lines
+    );
+}
+
+#[test]
+fn mdr_command_emits_ipc_warn_on_err() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    let result = fixture_err_command("disk_full".to_string());
+    assert_eq!(result, Err("disk_full".to_string()));
+
+    let lines = drain_captured();
+    let ipc_warns: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "ipc" && l.level == log::Level::Warn)
+        .collect();
+    assert!(
+        ipc_warns.iter().any(|l| {
+            l.message.starts_with("[ipc] cmd=fixture_err_command duration_us=")
+                && l.message.contains("ok=false")
+                && l.message.contains("disk_full")
+        }),
+        "fixture_err_command must emit WARN `[ipc] cmd=… ok=false err=…`, got {:?}",
+        ipc_warns
+    );
+}
+
+#[test]
+fn mdr_command_unit_return_logs_ok_true() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    let v = fixture_unit_command(7);
+    assert_eq!(v, 8);
+
+    let lines = drain_captured();
+    let ipc_lines: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "ipc" && l.level == log::Level::Info)
+        .collect();
+    assert!(
+        ipc_lines.iter().any(|l| {
+            l.message.starts_with("[ipc] cmd=fixture_unit_command duration_us=")
+                && l.message.contains("ok=true")
+        }),
+        "fixture_unit_command (non-Result return) must log ok=true, got {:?}",
+        ipc_lines
+    );
+}
+
+#[test]
+fn mdr_ipc_trace_env_does_not_panic() {
+    let _guard = test_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_logger();
+    drain_captured();
+
+    // SAFETY: env-var mutation is process-global and racy w.r.t. other
+    // threads observing the same var. The test_lock above serialises this
+    // with the rest of this file's tests.
+    // SAFETY note for set_var: the std::env API is `unsafe` only on
+    // newer toolchains; on stable it is safe. This file targets the
+    // current edition; if the toolchain bumps to a release that gates
+    // env::set_var as unsafe, wrap in `unsafe { … }`.
+    std::env::set_var("MDR_IPC_TRACE", "1");
+    let result = fixture_ok_command(1);
+    assert_eq!(result, Ok(2));
+    std::env::remove_var("MDR_IPC_TRACE");
+
+    let lines = drain_captured();
+    let ipc_lines: Vec<_> = lines
+        .iter()
+        .filter(|l| l.target == "ipc" && l.level == log::Level::Info)
+        .collect();
+    assert!(
+        !ipc_lines.is_empty(),
+        "MDR_IPC_TRACE=1 path must still emit canonical `[ipc]` schema, got {:?}",
+        lines
+    );
+}

--- a/src-tauri/tests/specta_coverage.rs
+++ b/src-tauri/tests/specta_coverage.rs
@@ -77,10 +77,32 @@ fn attr_path_matches(attr: &syn::Attribute, targets: &[&[&str]]) -> bool {
     false
 }
 
+/// Floor for the number of `#[mdr_command]`-annotated IPC entry points
+/// the codebase must carry. The migration in issue #264 renamed every
+/// pre-existing `#[tauri::command]` (except `fetch_remote_asset`) to
+/// `#[mdr_command]`. If a future change accidentally reverts the
+/// annotation — or if someone copies a command stub without the
+/// `#[mdr_command]` line — the count drops below this floor and the
+/// test fails.
+///
+/// Set deliberately below the actual count (~50 at the time of the
+/// migration) so unrelated command additions / removals don't churn
+/// this number; the goal is to detect a wholesale silent regression,
+/// not to gate every PR on an exact count.
+const MIN_MDR_COMMAND_COUNT: usize = 30;
+
 struct CommandVisitor {
     file: PathBuf,
     /// Functions found that have `#[tauri::command]` but no `#[specta::specta]`.
     missing: Vec<(PathBuf, String)>,
+    /// Functions that carry BOTH `#[mdr_command]` and a bare
+    /// `#[tauri::command]` — a layering bug, since `#[mdr_command]`
+    /// already expands to `#[tauri::command]` and stacking them
+    /// double-wraps the body and breaks the trace span.
+    double_wrapped: Vec<(PathBuf, String)>,
+    /// Functions annotated with `#[mdr_command]`. Counted across the
+    /// whole tree to detect a silent migration regression.
+    mdr_command_count: usize,
 }
 
 impl<'ast> Visit<'ast> for CommandVisitor {
@@ -89,11 +111,30 @@ impl<'ast> Visit<'ast> for CommandVisitor {
             .attrs
             .iter()
             .any(|a| attr_path_matches(a, &[&["tauri", "command"], &["command"]]));
+        let has_mdr_cmd = item
+            .attrs
+            .iter()
+            .any(|a| attr_path_matches(a, &[&["mdr_command"]]));
+        let fn_name = item.sig.ident.to_string();
+
+        if has_mdr_cmd {
+            self.mdr_command_count += 1;
+            // `#[mdr_command]` always expands to `#[tauri::command] +
+            // #[specta::specta] + tracing wrap` (see mdr-macros/src/lib.rs).
+            // Pairing is therefore guaranteed by the macro itself — and
+            // verified by the unit tests in that crate. Coverage rule
+            // satisfied for this fn; no further attribute check needed.
+            if has_tauri_cmd {
+                self.double_wrapped.push((self.file.clone(), fn_name.clone()));
+            }
+            syn::visit::visit_item_fn(self, item);
+            return;
+        }
+
         if !has_tauri_cmd {
             syn::visit::visit_item_fn(self, item);
             return;
         }
-        let fn_name = item.sig.ident.to_string();
         if EXEMPT_FNS.contains(&fn_name.as_str()) {
             syn::visit::visit_item_fn(self, item);
             return;
@@ -121,6 +162,8 @@ fn every_tauri_command_has_specta_specta() {
     );
 
     let mut all_missing: Vec<(PathBuf, String)> = Vec::new();
+    let mut all_double_wrapped: Vec<(PathBuf, String)> = Vec::new();
+    let mut total_mdr_count = 0usize;
     for file in &files {
         let src = std::fs::read_to_string(file)
             .unwrap_or_else(|e| panic!("read {}: {e}", file.display()));
@@ -134,9 +177,13 @@ fn every_tauri_command_has_specta_specta() {
         let mut visitor = CommandVisitor {
             file: file.clone(),
             missing: Vec::new(),
+            double_wrapped: Vec::new(),
+            mdr_command_count: 0,
         };
         visitor.visit_file(&ast);
         all_missing.extend(visitor.missing);
+        all_double_wrapped.extend(visitor.double_wrapped);
+        total_mdr_count += visitor.mdr_command_count;
     }
 
     assert!(
@@ -144,5 +191,23 @@ fn every_tauri_command_has_specta_specta() {
         "the following `#[tauri::command]` fns are missing `#[specta::specta]` \
          (add the attribute or extend EXEMPT_FNS in tests/specta_coverage.rs): {:#?}",
         all_missing
+    );
+
+    assert!(
+        all_double_wrapped.is_empty(),
+        "the following fns carry BOTH `#[mdr_command]` and `#[tauri::command]` — \
+         this double-wraps the body and corrupts the trace span. Drop the bare \
+         `#[tauri::command]` line: {:#?}",
+        all_double_wrapped
+    );
+
+    assert!(
+        total_mdr_count >= MIN_MDR_COMMAND_COUNT,
+        "found only {total_mdr_count} `#[mdr_command]`-annotated fns under {} — \
+         expected at least {MIN_MDR_COMMAND_COUNT}. A wholesale silent regression \
+         (e.g. mass-rename back to bare `#[tauri::command]`, or someone broke \
+         the `mdr_command` re-export) probably happened. Investigate before \
+         lowering the floor.",
+        src_dir.display()
     );
 }

--- a/src-tauri/tests/specta_coverage.rs
+++ b/src-tauri/tests/specta_coverage.rs
@@ -1,4 +1,4 @@
-//! Meta-test for the tauri-specta codegen pipeline (issue #263).
+//! Meta-test for the tauri-specta codegen pipeline (issue #263 / #264).
 //!
 //! Walks `src-tauri/src/`, parses every `.rs` file with `syn`, and
 //! asserts that every function carrying `#[tauri::command]` ALSO
@@ -9,6 +9,14 @@
 //! `tauri::ipc::Response` return). Adding a new exemption requires
 //! updating both this list AND `lib.rs::build_specta_builder` AND the
 //! dispatcher in `lib.rs::run`.
+//!
+//! Issue #264 introduced `#[mdr_command]` (in `mdr-macros/`) which
+//! expands to `#[tauri::command] + #[specta::specta] + tracing wrap`.
+//! That attribute IS the canonical IPC marker for everything except
+//! the documented `fetch_remote_asset` exemption — so this test
+//! treats `#[mdr_command]` as inherently specta-paired (the macro
+//! always emits the specta attr) and only enforces the pairing rule
+//! against bare `#[tauri::command]`.
 //!
 //! This file deliberately does NOT reference any `mdown_review_lib::*`
 //! symbol that pulls in `tauri::Wry` (and therefore `tauri-runtime-wry`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import { isSidecarFile } from "@/lib/file-types";
 import { IconFile, IconFolder, IconComment } from "@/components/Icons";
 import "@/styles/app.css";
 import "@/styles/print.css";
-import { unregisterWindowFolder } from "@/lib/tauri-commands";
+import { recordStartupPhase, unregisterWindowFolder } from "@/lib/tauri-commands";
 
 export default function App() {
   const { theme, root, folderPaneWidth, commentsPaneVisible, activeTabPath } = useStore(
@@ -64,6 +64,16 @@ export default function App() {
       document.title = folderName ? `${folderName} — mdownreview` : "mdownreview";
     }
   }, [activeTabPath, root]);
+
+  // Issue #264 — runtime tracing: report `frontend-mounted` to Rust's
+  // `StartupRecorder` once React's `App` finishes its first effect.
+  // The Rust side dedupes per-phase per-process so StrictMode's
+  // double-invoke is harmless. Errors are swallowed because telemetry
+  // is non-essential — the user-visible app must keep working even if
+  // the IPC fails (e.g. headless tests with no Tauri host).
+  useEffect(() => {
+    void recordStartupPhase("frontend-mounted").catch(() => {});
+  }, []);
 
   const [aboutOpen, setAboutOpen] = useState(false);
   const settingsDialogOpen = useStore((s) => s.settingsDialogOpen);

--- a/src/__mocks__/@tauri-apps/api/core.ts
+++ b/src/__mocks__/@tauri-apps/api/core.ts
@@ -86,13 +86,10 @@ export const invoke = vi.fn<(cmd: string, args?: Record<string, unknown>) => Pro
       }
     }
     return result;
-  },
+  }
 );
 
-async function defaultInvoke(
-  cmd: string,
-  _args?: Record<string, unknown>,
-): Promise<InvokeResult> {
+async function defaultInvoke(cmd: string, _args?: Record<string, unknown>): Promise<InvokeResult> {
   if (cmd === "get_launch_args") {
     return launchArgsQueue.length > 0 ? launchArgsQueue.shift()! : EMPTY_LAUNCH_ARGS;
   }
@@ -136,10 +133,7 @@ async function defaultInvoke(
   if (cmd === "read_text_file") {
     return { content: "", size_bytes: 0, line_count: 0 } as TextFileResult;
   }
-  if (
-    cmd === "cli_shim_status" ||
-    cmd === "default_handler_status"
-  ) {
+  if (cmd === "cli_shim_status" || cmd === "default_handler_status") {
     return "missing";
   }
   if (cmd === "onboarding_state") {
@@ -148,11 +142,7 @@ async function defaultInvoke(
     // Playwright fixture's default.
     return { schema_version: 1, last_seen_sections: [] } as unknown as InvokeResult;
   }
-  if (
-    cmd === "install_cli_shim" ||
-    cmd === "remove_cli_shim" ||
-    cmd === "set_default_handler"
-  ) {
+  if (cmd === "install_cli_shim" || cmd === "remove_cli_shim" || cmd === "set_default_handler") {
     return undefined;
   }
   if (cmd === "canonicalize_path") {
@@ -164,15 +154,35 @@ async function defaultInvoke(
   if (cmd === "get_file_viewer_pref") return null;
   if (cmd === "set_file_viewer_pref") return undefined;
   if (cmd === "get_sidecar_config")
-    return { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 } satisfies SidecarConfigResult;
+    return {
+      enabled: false,
+      sidecar_root: null,
+      count_in_folder: 0,
+      count_colocated: 0,
+    } satisfies SidecarConfigResult;
   if (cmd === "set_sidecar_config")
-    return { enabled: (_args?.enabled as boolean) ?? false, sidecar_root: _args?.enabled ? ".reviews" : null, count_in_folder: 0, count_colocated: 0 } satisfies SidecarConfigResult;
+    return {
+      enabled: (_args?.enabled as boolean) ?? false,
+      sidecar_root: _args?.enabled ? ".reviews" : null,
+      count_in_folder: 0,
+      count_colocated: 0,
+    } satisfies SidecarConfigResult;
   if (cmd === "migrate_sidecars_cmd")
-    return { moved: 0, failed: [], config: { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 } } satisfies MigrateSidecarsResult;
+    return {
+      moved: 0,
+      failed: [],
+      config: { enabled: false, sidecar_root: null, count_in_folder: 0, count_colocated: 0 },
+    } satisfies MigrateSidecarsResult;
   if (cmd === "read_dir") return { entries: [], total: 0, has_more: false } satisfies ReadDirResult;
   if (cmd === "register_window_folder") return undefined;
   if (cmd === "unregister_window_folder") return undefined;
+  // record_startup_phase is fire-and-forget telemetry (#264). Tests don't
+  // verify the side-effect; returning undefined matches the Rust
+  // `() -> ()` shape so the façade's bindings.recordStartupPhase resolves.
+  if (cmd === "record_startup_phase") return undefined;
   return undefined;
 }
 
-export const convertFileSrc = vi.fn((path: string) => "asset://localhost/" + encodeURIComponent(path));
+export const convertFileSrc = vi.fn(
+  (path: string) => "asset://localhost/" + encodeURIComponent(path)
+);

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -47,6 +47,10 @@ vi.mock("@/lib/tauri-commands", () => ({
   getLogPath: vi.fn().mockResolvedValue("/mock/log.log"),
   getAuthor: vi.fn().mockResolvedValue("Test User"),
   setAuthor: vi.fn().mockResolvedValue("Test User"),
+  // Issue #264 — runtime tracing fires from App.tsx's mount effect.
+  // Stub returns void; the real implementation logs to the rotating
+  // file via Rust's StartupRecorder.
+  recordStartupPhase: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/hooks/useFileWatcher", () => ({
@@ -122,12 +126,7 @@ async function renderApp() {
 
 // ── Helper: dispatch keyboard shortcut on window ───────────────────────────
 
-function pressKey(opts: {
-  key: string;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-  metaKey?: boolean;
-}) {
+function pressKey(opts: { key: string; ctrlKey?: boolean; shiftKey?: boolean; metaKey?: boolean }) {
   fireEvent.keyDown(window, {
     key: opts.key,
     ctrlKey: opts.ctrlKey ?? false,
@@ -483,4 +482,3 @@ describe("App – menu event listeners", () => {
     expect(screen.getByTestId("about-dialog")).toBeInTheDocument();
   });
 });
-

--- a/src/__tests__/SettingsSurface.test.tsx
+++ b/src/__tests__/SettingsSurface.test.tsx
@@ -54,6 +54,8 @@ vi.mock("@/lib/tauri-commands", () => ({
   getLogPath: vi.fn().mockResolvedValue("/mock/log.log"),
   getAuthor: vi.fn().mockResolvedValue("Test User"),
   setAuthor: vi.fn().mockResolvedValue("Test User"),
+  // Issue #264 — runtime tracing fires from App.tsx's mount effect.
+  recordStartupPhase: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/hooks/useFileWatcher", () => ({ useFileWatcher: () => {} }));

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -395,6 +395,14 @@ async migrateSidecarsCmd(root: string, direction: MigrateDirection) : Promise<Re
 }
 },
 /**
+ * Record a startup phase from the frontend. Mirrors
+ * `StartupPhase` 1:1 — see that enum for the kebab-case wire shape
+ * (`"theme-applied"`, `"frontend-mounted"`, `"first-file-loaded"`).
+ */
+async recordStartupPhase(phase: StartupPhase) : Promise<void> {
+    await TAURI_INVOKE("record_startup_phase", { phase });
+},
+/**
  * Check for an update on the given channel.
  * For cross-channel switches the version comparator is overridden
  * to accept any different version (enabling "downgrades").
@@ -637,6 +645,24 @@ export type SearchMatch = { lineIndex: number; startCol: number; endCol: number 
  */
 export type Severity = "none" | "low" | "medium" | "high"
 export type SidecarConfigResult = { enabled: boolean; sidecar_root: string | null; count_in_folder: number; count_colocated: number }
+/**
+ * Ordered phases of app startup, mirrored to TypeScript via specta as a
+ * kebab-case string union (`"app-init" | "webview-ready" | ...`). Each
+ * phase is recorded at most once per process lifetime.
+ * 
+ * Order of expected emission:
+ * 1. `AppInit` — Rust `pub fn run` first instruction.
+ * 2. `WebviewReady` — main webview's `Created` window event.
+ * 3. `FirstIpc` — first call through any `#[mdr_command]` IPC.
+ * 4. `ThemeApplied` — frontend reports after applying initial theme
+ * (PR4 will move this to a pre-React script tag).
+ * 5. `FrontendMounted` — React's `App` finished its first effect.
+ * 6. `FirstFileLoaded` — the user's first viewer paint completes.
+ * 
+ * Phase order is not enforced — async timing differences mean the recorder
+ * must accept events in any sequence.
+ */
+export type StartupPhase = "app-init" | "webview-ready" | "first-ipc" | "theme-applied" | "frontend-mounted" | "first-file-loaded"
 /**
  * Typed error surfaced to the renderer. Discriminated with an internal `kind`
  * tag so the TS side can branch on it without parsing prose strings.

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -86,6 +86,7 @@ export type {
   SearchMatch,
   Severity,
   SidecarConfigResult,
+  StartupPhase,
   SystemError,
   TaggedNewAnchor,
   TextFileResult,
@@ -126,6 +127,7 @@ import type {
   ReadDirResult,
   SearchMatch,
   SidecarConfigResult,
+  StartupPhase,
   TextFileResult,
   UpdateInfo,
   WordSpan,
@@ -312,6 +314,16 @@ export const registerWindowFolder = (folder: string): Promise<void> =>
 
 export const unregisterWindowFolder = (): Promise<void> =>
   unwrap(bindings.unregisterWindowFolder()).then(() => {});
+
+// Startup-phase telemetry (issue #264) ────────────────────────────────────
+// The frontend reports the phases it owns — `theme-applied`,
+// `frontend-mounted`, `first-file-loaded` — by name. Rust dedupes by
+// phase per-process, so a chatty caller (StrictMode double-invoke,
+// hot reload) cannot inflate the timeline. The recorder emits
+// `[startup] phase=… t_ms=…` to the rotating log file. See
+// `docs/observability.md` for the post-hoc analysis story.
+export const recordStartupPhase = (phase: StartupPhase): Promise<void> =>
+  bindings.recordStartupPhase(phase);
 
 // ── Non-IPC helpers (cannot route through bindings) ───────────────────────
 //

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import * as logger from "@/logger";
+import { recordStartupPhase } from "@/lib/tauri-commands";
 import App from "@/App";
 import "@/styles/settings-view.css";
+
+// Issue #264 / PR3 — startup tracing placeholder. PR4 will move this to
+// a pre-React inline script in `index.html` so the phase fires before
+// Vite-injected modules even parse (FOUC mitigation pairs with
+// `theme-applied`). For now we report from the renderer entry point
+// — close enough for log-analysis purposes; the schema slot is what
+// matters for `analyze-log` (PR4). Errors swallowed: telemetry is
+// non-essential and missing IPC (e.g. unit tests / headless harnesses)
+// must not break the main render path.
+void recordStartupPhase("theme-applied").catch(() => {});
 
 // Install global error handlers before React initializes so that errors
 // during module loading or the first render are captured.


### PR DESCRIPTION
Implements #264 — Engineering excellence — PR3: runtime tracing infrastructure.

Rebased onto `main` after #273 (PR2) merged.

## Goal

Ship the **minimum runtime instrumentation** needed to root-cause IPC and startup-perf issues that escape PR1+PR2's static gates. Internal infra only — end-user behavior unchanged.

## Acceptance criteria

### 1. `mdr_command!` macro
- [ ] Defined in `src-tauri/src/macros/`. Composes `#[tauri::command]` + `#[specta::specta]` + tracing span.
- [ ] Every `#[tauri::command]` in `src-tauri/src/commands/` migrated.
- [ ] Each call emits `[ipc] cmd=<name> duration_us=<u> payload_bytes=<n> ok=<bool>`.
- [ ] `payload_bytes` only computed when `cfg!(debug_assertions) || env MDR_IPC_TRACE`.
- [ ] `ok=false` events at warn level, include error string.
- [ ] Macro expansion test.

### 2. `StartupRecorder`
- [ ] OnceCell<Mutex<...>> singleton; `record_phase` emits `[startup] phase=<name> t_ms=<n>` once per phase.
- [ ] Phases: app-init, webview-ready, first-ipc, theme-applied, frontend-mounted, first-file-loaded.

### 3. IPC for frontend phases
- [ ] `recordStartupPhase(phase: StartupPhase)` IPC command, frontend wired in App.tsx.

### 4. Performance budget
- [ ] ≤ 5 ms total instrumentation overhead at startup.
- [ ] ≤ 100 KB binary growth.
- [ ] No > 1 ms regression in existing Criterion benches.

### 5. Integration test + Docs
- [ ] Rust integration test asserts `[ipc]` and `[startup]` events appear with `MDR_IPC_TRACE=1`.
- [ ] New `docs/observability.md`; update `docs/features/logging.md`; reference in `AGENTS.md`.

## Rebase notes

- Dropped 8 ancestor commits from #263 (now in main as squash 4a8a724).
- One conflict in `src-tauri/src/commands/fs.rs` resolved: kept main's typed `PathKind` enum return for `check_path_exists`, applied the `#[mdr_command]` annotation from this PR (the macro composes `#[tauri::command]` + `#[specta::specta]`, so the typed enum still flows through specta).
- Verified locally: `cargo check --all-targets` clean; `cargo test` 6/6 observability tests + every_tauri_command_has_specta_specta gate pass; bindings.ts regenerates with no drift; vitest 1607/1607 pass.

Closes #264 when all ACs land.