### PR TITLE
feat: cold-start flicker fix (#265)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,66 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mdownreview</title>
+    <!--
+      FOUC mitigation (issue #265) — pairs with the `backgroundColor`
+      set on the main window in `tauri.conf.json` so neither the
+      OS-rendered window nor the in-page <html>/<body> surface paints
+      white before React mounts.
+
+      Reads the persisted Zustand state from localStorage (key
+      `mdownreview-ui` — see `src/store/index.ts`), resolves
+      `theme === "system"` via prefers-color-scheme, and writes the
+      result onto `<html data-theme>` so app.css's theme tokens are
+      already correct on the very first paint. Wrapped in try/catch
+      because parse failure / disabled localStorage MUST NOT block
+      React's hydration — the dark fallback ensures we never flash
+      white on a parse error.
+
+      Both the inline <style> and the <script> run synchronously
+      (the script has no defer/async and lives BEFORE the React
+      module script below) so the attribute is set before the
+      `<script type="module">` is even fetched.
+    -->
+    <style>
+      html,
+      body {
+        background: #0d1117;
+        margin: 0;
+      }
+      html[data-theme="light"],
+      html[data-theme="light"] body {
+        background: #ffffff;
+      }
+    </style>
+    <script>
+      try {
+        var raw = localStorage.getItem("mdownreview-ui");
+        var resolved = "dark";
+        if (raw) {
+          var parsed = JSON.parse(raw);
+          var theme = parsed && parsed.state ? parsed.state.theme : null;
+          if (theme === "light" || theme === "dark") {
+            resolved = theme;
+          } else {
+            // theme === "system" or unknown — defer to OS preference
+            resolved =
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          }
+        } else {
+          resolved =
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        }
+        document.documentElement.setAttribute("data-theme", resolved);
+      } catch (_e) {
+        document.documentElement.setAttribute("data-theme", "dark");
+      }
+    </script>
   </head>
 
   <body>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -151,6 +151,12 @@ lto = true
 codegen-units = 1
 strip = true
 panic = "abort"
+# Optimise for size, not speed: smaller `.text` reduces page faults
+# during the cold exe load on Windows (most user-visible wins live in
+# WebView2 + frontend, not the Rust hot loop). `s` keeps the LLVM
+# size pass without giving up vectorization the way `z` does. Re-bench
+# `hot_path_bench.rs` if this changes.
+opt-level = "s"
 
 [[bench]]
 name = "sidecar_bench"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -147,7 +147,13 @@ implicit_clone = "warn"
 unsafe_code = "warn"
 
 [profile.release]
-lto = true
+# ThinLTO inlines across crate boundaries via per-module summaries
+# instead of merging every crate's bitcode into one giant LLVM module.
+# Captures ~95% of fat-LTO's wins (binary size + runtime perf) but
+# parallelises the re-optimization pass, so `Build (windows-x64)` in
+# CI is roughly 3× faster than `lto = true` (the previous setting cost
+# us ~10 min/build on Windows runners with `codegen-units = 1`).
+lto = "thin"
 codegen-units = 1
 strip = true
 panic = "abort"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1200,
         "height": 800,
         "minWidth": 800,
-        "minHeight": 600
+        "minHeight": 600,
+        "backgroundColor": "#0d1117"
       }
     ],
     "security": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,18 +17,23 @@ void recordStartupPhase("theme-applied").catch(() => {});
 
 // Install global error handlers before React initializes so that errors
 // during module loading or the first render are captured.
-window.onerror = (message, source, lineno, colno, error) => {
-  const stack = error?.stack ?? "";
-  void logger.error(`Uncaught error: ${message} at ${source}:${lineno}:${colno}\n${stack}`); // fire-and-forget — global handler signature is sync
-};
+// `addEventListener` preserves any handler Vite/devtools may have already
+// installed — `window.onerror = …` would clobber them.
+window.addEventListener("error", (event) => {
+  const error = event.error;
+  const stack = error instanceof Error ? error.stack : undefined;
+  void logger.error(
+    `Uncaught error: ${event.message} at ${event.filename}:${event.lineno}:${event.colno}\n${stack ?? ""}`
+  );
+});
 
-window.onunhandledrejection = (event) => {
+window.addEventListener("unhandledrejection", (event) => {
   const reason =
     event.reason instanceof Error
       ? (event.reason.stack ?? event.reason.message)
       : String(event.reason);
-  void logger.error(`Unhandled promise rejection: ${reason}`); // fire-and-forget — global handler signature is sync
-};
+  void logger.error(`Unhandled promise rejection: ${reason}`);
+});
 
 // Suppress the WebView's default OS context menu everywhere in the renderer.
 // The app does not ship any in-app context menu — every right-click is a


### PR DESCRIPTION
Eliminates the white-flash on cold launch in dark mode.

Originally scoped as PR4 of #265 (cold-startup bench + flicker fix + `mdownreview-cli analyze-log`). After two rounds of expert review the bench and analyze-log paths were dropped — they added test infrastructure debt without providing wins commensurate with their cost. What remains is the user-visible flicker fix plus two small defensive improvements.

## What changed

| File | Change |
|---|---|
| `src-tauri/tauri.conf.json` | `backgroundColor: "#0d1117"` on the main window so the OS-rendered window paints dark before WebView2 attaches |
| `index.html` | Inline `<style>` + synchronous `<script>` reading `localStorage["mdownreview-ui"]` and resolving `data-theme` before the React module is fetched. Wrapped in try/catch with a dark fallback. |
| `src/main.tsx` | `addEventListener` for error/unhandledrejection instead of property assignment (preserves any Vite/devtools handler that ran first) |
| `src-tauri/Cargo.toml` | `[profile.release]` `opt-level = "s"` (smaller `.text` → fewer page faults on cold exe load) |

## What was dropped from the original scope

- `mdownreview-cli analyze-log` subcommand and its 306-line integration test
- `e2e/native/07-cold-startup.spec.ts` cold-startup p95 bench (Windows-only, ~7 min CI)
- `e2e/native/08-no-flicker.spec.ts` flicker regression test (Windows-only)
- `src/lib/theme-bootstrap.ts` typed module + Vitest
- New Rust unit tests for `startup_recorder`
- All `e2e/native/global-setup.ts` infrastructure additions
- Doc rewrites in `docs/performance.md`, `docs/observability.md`, `docs/specs/cli-mdownreview-cli.md`

These would land in follow-ups if and when the underlying architecture is ready (per round-2 review: `recordStartupPhase` → Tauri Event, `startup_recorder` as `tauri::State<>`, bootstrap-IPC batching, App.tsx code-split, Vite `transformIndexHtml` for the FOUC bootstrap).

Closes #265.