### PR TITLE
feat: --trace[=on|off] launch flag for IPC tracing gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Every rule is numbered and citable as "violates rule N in `docs/X.md`". Each doc
 | [`docs/security.md`](docs/security.md) | File-read bounds, path canonicalization, sidecar atomicity, CSP, capability ACL, markdown XSS posture |
 | [`docs/design-patterns.md`](docs/design-patterns.md) | React 19 + Tauri v2 idioms, hook composition, error capture, cross-hook communication |
 | [`docs/test-strategy.md`](docs/test-strategy.md) | Three-layer pyramid, coverage floors, IPC mock hygiene, console-spy contract |
-| [`docs/observability.md`](docs/observability.md) | `[ipc]` + `[startup]` log schemas, `#[mdr_command]` macro contract, `StartupRecorder` phases, `MDR_IPC_TRACE` gating |
+| [`docs/observability.md`](docs/observability.md) | `[ipc]` + `[startup]` log schemas, `#[mdr_command]` macro contract, `StartupRecorder` phases, `--trace` launch flag + `MDR_IPC_TRACE` gating |
 | [`docs/best-practices-common/`](docs/best-practices-common/) | **Project-agnostic, stack-specific** patterns (composition, rerender, JS perf, bundle hygiene, Tauri v2). Distilled from external sources with attribution. Project-specific docs above always override. |
 | [`docs/best-practices-project/`](docs/best-practices-project/) | **mdownreview-specific** knowledge files: hot-paths, bug categories, test patterns. Single-area files for use by review agents under the per-knowledge-file dispatch protocol. |
 

--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -51,7 +51,7 @@ flowchart LR
 
 ## Runtime tracing schemas
 
-Two stable line schemas share this rotating file (issue #264 / PR3). The canonical home for the field reference, env-var gating, and the post-hoc `analyze-log` story is [`docs/observability.md`](../observability.md):
+Two stable line schemas share this rotating file (issue #264 / PR3). The canonical home for the field reference, gating model, and the post-hoc `analyze-log` story is [`docs/observability.md`](../observability.md):
 
-* **`[ipc] cmd=<name> duration_us=<u> payload_bytes=<n> ok=<bool>`** — emitted by every `#[mdr_command]`-wrapped Tauri command, target `"ipc"`. Errors land at `warn` level with `err=<debug>`.
-* **`[startup] phase=<kebab-name> t_ms=<n>`** — emitted at most once per phase per process by `StartupRecorder`, target `"startup"`. Phases: `app-init`, `webview-ready`, `first-ipc`, `theme-applied`, `frontend-mounted`, `first-file-loaded`.
+* **`[ipc] cmd=<name> duration_us=<u> payload_bytes=<n> ok=<bool>`** — emitted by every `#[mdr_command]`-wrapped Tauri command, target `"ipc"`. Errors land at `warn` level with `err=<sanitized>` and are **always-on**. Successful info-level lines are gated by the `--trace` launch flag (or `MDR_IPC_TRACE` env-var fallback) so the IPC hot path stays within the budget in [`docs/performance.md`](../performance.md).
+* **`[startup] phase=<kebab-name> t_ms=<n>`** — emitted at most once per phase per process by `StartupRecorder`, target `"startup"`. Phases: `app-init`, `webview-ready`, `first-ipc`, `theme-applied`, `frontend-mounted`, `first-file-loaded`. Always-on regardless of `--trace`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,9 +23,9 @@ On error:
 | Level | Lines | When emitted |
 |---|---|---|
 | `warn` | `ok=false err=…` (the error variant) | **Always.** IPC errors are rare and high-value diagnostics; the format + plugin-write cost is negligible on a path that fires only on failure. The err= field is sanitized (control-char strip + 512-char bound) so log-injection / forensic-tampering is blocked. |
-| `info` | `ok=true` (every successful call) | Only when `cfg!(debug_assertions) || env::var("MDR_IPC_TRACE").is_ok()`. The success path is the IPC hot path — `search_in_document`, watcher callbacks, etc. fire thousands of times per session. The flag is read once per process and cached in a `OnceLock<bool>`; steady-state cost in a release build with the env var unset is one relaxed atomic load + one branch, well under the hot-path budget in [`docs/performance.md`](performance.md). |
+| `info` | `ok=true` (every successful call) | Only when the `--trace` launch flag (or `MDR_IPC_TRACE` env var fallback) opens the gate, or in debug builds. The success path is the IPC hot path — `search_in_document`, watcher callbacks, etc. fire thousands of times per session. The gate lives in a static `AtomicBool` set once at boot; steady-state cost when closed is one relaxed atomic load + one branch, well under the hot-path budget in [`docs/performance.md`](performance.md). |
 
-To enable per-success tracing in a release build, set `MDR_IPC_TRACE=1` before launch (see "Enabling extra trace detail" below). Errors and warnings always reach the rotating log file regardless of the env var or build profile.
+To enable per-success tracing in a release build, launch with `mdownreview --trace` (see "Enabling extra trace detail" below for all forms). Errors and warnings always reach the rotating log file regardless of the flag, env var, or build profile.
 
 Field reference:
 
@@ -75,19 +75,39 @@ Every existing IPC handler in `src-tauri/src/commands/`, `src-tauri/src/lib.rs`,
 
 ## Enabling extra trace detail
 
-Set the `MDR_IPC_TRACE` environment variable to any value (e.g. `1`, `true`) before launching the app to enable the per-success `[ipc] … ok=true` info-level lines in a release build. Debug builds (`cargo build` without `--release`) enable the path implicitly via `cfg!(debug_assertions)`.
+The per-success `[ipc] … ok=true` info-level lines are gated by the **`--trace` launch flag**:
 
 ```bash
+# Enable for this launch (any of these)
+mdownreview --trace
+mdownreview --trace=on        # explicit on (also: true, 1, yes)
+
+# Disable for this launch — overrides the debug-build default
+mdownreview --trace=off       # explicit off (also: false, 0, no)
+
+# Combine freely with file / folder args
+mdownreview --trace ./README.md /path/to/folder
+```
+
+Boot-time precedence (highest wins):
+
+1. **`--trace[=on|off]`** launch flag — explicit user intent for this launch (parsed by `commands::launch::parse_trace_flag`).
+2. **`MDR_IPC_TRACE`** env var (any value) — legacy escape hatch for shell aliases / launcher scripts.
+3. **`cfg!(debug_assertions)`** — debug builds default ON, release builds default OFF.
+
+The resolved value is stored in `startup_recorder::IPC_TRACE_ENABLED` (a static `AtomicBool`) and read by `ipc_trace_enabled()` on every IPC dispatch — one relaxed atomic load + one branch per call. See [`docs/specs/cli-file-open.md` § Process-global flags](specs/cli-file-open.md#process-global-flags) for the formal spec.
+
+```bash
+# Env-var fallback (still works)
 # macOS / Linux
 MDR_IPC_TRACE=1 mdownreview
-
 # Windows (PowerShell)
 $env:MDR_IPC_TRACE=1; mdownreview
 ```
 
-`MDR_IPC_TRACE` is **dev-time only** — there is no UI affordance to toggle it (Non-Goal: no in-app log viewer). The variable is read once at first IPC dispatch and cached for the rest of the process; live toggling is intentionally unsupported.
+**Per-launch only.** The flag is read at boot and applied **before** the Tauri runtime starts dispatching IPCs. There is no UI toggle (Non-Goal: no in-app log viewer / no developer settings panel) and no live-toggle IPC. A second-instance launch with `--trace` does **not** modify the running app's gate state — the file/folder args are still forwarded normally, but the running process keeps the gate state set at its own boot. To switch tracing on/off for an already-running app, quit and relaunch.
 
-The env var **only** controls the success-path info lines. Errors (`[ipc] … ok=false err=…`) and `[startup]` phase events are always-on regardless of build profile or env var.
+The flag **only** controls the success-path info lines. Errors (`[ipc] … ok=false err=…`) and `[startup]` phase events are always-on regardless of the flag, env var, or build profile.
 
 ## Log location
 

--- a/docs/specs/cli-file-open.md
+++ b/docs/specs/cli-file-open.md
@@ -19,7 +19,7 @@
 The parser accepts (case-insensitive on Windows path comparisons):
 
 ```
-mdownreview [--folder <dir>]... [--file <path>]... [<positional>...]
+mdownreview [--trace[=on|off]] [--folder <dir>]... [--file <path>]... [<positional>...]
 ```
 
 - `--folder` and `--file` may appear in any order, before or after positional
@@ -28,6 +28,10 @@ mdownreview [--folder <dir>]... [--file <path>]... [<positional>...]
   list.
 - A positional that resolves to a directory becomes a folder; one that
   resolves to a file becomes a file.
+- `--trace[=…]` is a **process-global** flag parsed by `parse_trace_flag`
+  (separate from `parse_launch_args`). It is silently ignored by the
+  file/folder parser and never appears in the resulting `LaunchArgs`.
+  See [Process-global flags](#process-global-flags) below.
 
 ## Path-resolution rules
 
@@ -76,6 +80,84 @@ The GUI calls into `core::paths::resolve_path` exactly as the CLI does:
 - **Given** `core::paths::resolve_path` is the canonical resolver.
 - **Then** `parse_launch_args` calls it for every path it produces — no
   ad-hoc joining elsewhere in `lib.rs` or the `launch` commands.
+
+## Process-global flags
+
+These flags configure the **whole process** at boot, not a particular
+window. They are parsed by `commands::launch::parse_trace_flag` (and
+peers, if added) before the Tauri builder spins up. They never appear
+in `LaunchArgs` and are silently ignored by `parse_launch_args`.
+
+### `--trace` — verbose IPC tracing
+
+Controls whether the per-call `[ipc] cmd=… ok=true` info-level lines
+are emitted by `#[mdr_command]` (see
+[`docs/observability.md`](../observability.md)). Always-on warn-level
+err lines and `[startup]` events are unaffected — those fire
+regardless of this flag.
+
+Accepted forms (first match wins):
+
+| Form | Result |
+|---|---|
+| `--trace` | `Some(true)` (presence implies on) |
+| `--trace=on`, `--trace=true`, `--trace=1`, `--trace=yes` | `Some(true)` |
+| `--trace=off`, `--trace=false`, `--trace=0`, `--trace=no` | `Some(false)` |
+| `--trace=<unrecognised>` | `None` (fall through to env / cfg) |
+| (flag absent) | `None` (fall through to env / cfg) |
+
+Boot-time precedence (highest wins):
+
+1. `--trace[=…]` flag — explicit user intent for *this* launch.
+2. `MDR_IPC_TRACE` env var (any value) — preserves the existing
+   escape hatch for shell aliases / launcher scripts.
+3. `cfg!(debug_assertions)` — debug builds default ON, release
+   builds default OFF.
+
+The resolved value is stored in
+`startup_recorder::IPC_TRACE_ENABLED` (a static `AtomicBool`) and
+read by `ipc_trace_enabled()` on every IPC call.
+
+### Scenario: `--trace` enables verbose IPC info lines for this launch
+
+- **Given** a release build with no `MDR_IPC_TRACE` env var set.
+- **When** `mdownreview --trace` is launched.
+- **Then** `startup_recorder::ipc_trace_enabled()` returns `true` and
+  every `#[mdr_command]` success arm emits `[ipc] … ok=true` to the
+  rotating log file.
+- **Coverage:** `commands/launch.rs` `parse_trace_flag` tests +
+  `tests/observability.rs` integration.
+
+### Scenario: `--trace=off` force-disables tracing in a debug build
+
+- **Given** a debug build (which would default to `on` via
+  `cfg!(debug_assertions)`).
+- **When** `mdownreview --trace=off` is launched.
+- **Then** the gate is `false`; no `[ipc] … ok=true` info lines fire.
+
+### Scenario: `--trace` is silently ignored by `parse_launch_args`
+
+- **Given** `mdownreview --trace=on foo.md`.
+- **When** the parser splits responsibilities (`parse_trace_flag` for
+  the flag; `parse_launch_args` for the paths).
+- **Then** `LaunchArgs.files == [foo.md]`, `LaunchArgs.folders == []`,
+  and the trace gate is set to `true`. The flag never reaches the
+  per-window IPC payload.
+- **Coverage:** `commands/launch.rs` `launch_args_ignore_trace_flag`.
+
+### Scenario: second-instance `--trace` is **not** applied to the running app
+
+- **Given** a running instance launched without `--trace`.
+- **When** the user double-clicks a `.md` file via a launcher that
+  passes `--trace=on`, and the OS routes it through the
+  `tauri-plugin-single-instance` forwarder.
+- **Then** the file is forwarded and opened in a new tab; the running
+  process's trace gate is **not** modified. Per-launch semantics: the
+  flag describes how the *first* launch boots, not "switch the
+  running app." If a user wants verbose tracing, they quit and
+  relaunch with `--trace`.
+- **Coverage:** `lib.rs::run` single-instance handler does not call
+  `parse_trace_flag`.
 
 ## Multi-file launches & single-instance forwarding
 

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -8,6 +8,48 @@ use crate::core::types::LaunchArgs;
 use std::path::Path;
 use tauri::Manager;
 
+/// Parse the process-global `--trace` flag out of the raw argv.
+///
+/// Recognized forms (the **only** flag this function inspects — every other
+/// argument is ignored, since they are owned by the per-window
+/// [`parse_launch_args`] parser):
+///
+/// * `--trace`        → `Some(true)` (presence implies on)
+/// * `--trace=on`     → `Some(true)`   |  `--trace=off`   → `Some(false)`
+/// * `--trace=true`   → `Some(true)`   |  `--trace=false` → `Some(false)`
+/// * `--trace=1`      → `Some(true)`   |  `--trace=0`     → `Some(false)`
+///
+/// Returns `None` when the flag is absent. Caller applies the precedence
+/// chain (CLI > env > cfg) — see `lib.rs::run`.
+///
+/// Per-launch only: a second-instance forward does **not** call this — the
+/// running process keeps the gate state set at its own boot. This matches
+/// the user mental model that `--trace` configures *how this launch boots*,
+/// not "switch the running app's tracing." If live toggling is ever needed,
+/// add a setter IPC backed by [`crate::startup_recorder::set_ipc_trace_enabled`].
+///
+/// Trace is process-global, so it intentionally does **not** live on
+/// [`LaunchArgs`] (which is per-window).
+pub fn parse_trace_flag(args: &[String]) -> Option<bool> {
+    for arg in args {
+        if arg == "--trace" {
+            return Some(true);
+        }
+        if let Some(value) = arg.strip_prefix("--trace=") {
+            return match value.to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" | "yes" => Some(true),
+                "off" | "false" | "0" | "no" => Some(false),
+                // Unknown value: treat as if the flag were absent so we
+                // fall through to the env / cfg precedence rather than
+                // silently picking the wrong default. A warning would
+                // be ideal but we have no logger yet at this call site.
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
 /// Parse CLI-style launch arguments into a `LaunchArgs` struct.
 ///
 /// Supports `--folder <path>`, `--file <path>`, and positional auto-detect
@@ -18,7 +60,9 @@ use tauri::Manager;
 ///      base and are canonicalized as-is.
 ///
 /// Non-existent paths are silently dropped (canonicalize fails). Unknown flags
-/// (anything starting with `-` other than `--folder`/`--file`) are ignored.
+/// (anything starting with `-` other than `--folder`/`--file`) are ignored —
+/// in particular, the process-global `--trace[=…]` flag (parsed by
+/// [`parse_trace_flag`]) is silently skipped here.
 pub fn parse_launch_args(args: &[String], cwd: &Path) -> LaunchArgs {
     let mut folders: Vec<String> = Vec::new();
     let mut files: Vec<String> = Vec::new();
@@ -298,6 +342,81 @@ mod tests {
             .into_owned();
 
         assert_eq!(out.files, vec![expected_canon]);
+    }
+
+    // ── parse_trace_flag tests ────────────────────────────────────────────
+
+    #[test]
+    fn trace_flag_absent_returns_none() {
+        assert_eq!(parse_trace_flag(&[]), None);
+        assert_eq!(parse_trace_flag(&[s("--folder"), s("/tmp")]), None);
+        assert_eq!(parse_trace_flag(&[s("foo.md"), s("bar.md")]), None);
+    }
+
+    #[test]
+    fn trace_flag_bare_implies_on() {
+        assert_eq!(parse_trace_flag(&[s("--trace")]), Some(true));
+        // Mixed with file / folder args, regardless of order.
+        assert_eq!(
+            parse_trace_flag(&[s("--folder"), s("/tmp"), s("--trace"), s("a.md")]),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn trace_flag_kv_on_variants_are_true() {
+        for v in ["on", "true", "1", "yes", "ON", "True", "YES"] {
+            let arg = format!("--trace={v}");
+            assert_eq!(parse_trace_flag(&[arg.clone()]), Some(true), "arg={arg}");
+        }
+    }
+
+    #[test]
+    fn trace_flag_kv_off_variants_are_false() {
+        for v in ["off", "false", "0", "no", "OFF", "False", "NO"] {
+            let arg = format!("--trace={v}");
+            assert_eq!(parse_trace_flag(&[arg.clone()]), Some(false), "arg={arg}");
+        }
+    }
+
+    /// An unrecognized value falls back to `None` so the caller's
+    /// precedence chain (env / cfg) kicks in — better than guessing.
+    #[test]
+    fn trace_flag_unknown_value_returns_none() {
+        assert_eq!(parse_trace_flag(&[s("--trace=maybe")]), None);
+        assert_eq!(parse_trace_flag(&[s("--trace=")]), None);
+    }
+
+    /// First `--trace` wins. Catches accidental duplication in a wrapper
+    /// script; the user's first-stated intent is kept.
+    #[test]
+    fn trace_flag_first_match_wins() {
+        assert_eq!(
+            parse_trace_flag(&[s("--trace=on"), s("--trace=off")]),
+            Some(true)
+        );
+        assert_eq!(
+            parse_trace_flag(&[s("--trace=off"), s("--trace=on")]),
+            Some(false)
+        );
+    }
+
+    /// `parse_launch_args` must continue to treat `--trace[=...]` as an
+    /// unknown flag (silently skipped). Regression guard for the
+    /// "trace flag pollutes file/folder parsing" failure mode.
+    #[test]
+    fn launch_args_ignore_trace_flag() {
+        let cwd = tempdir().unwrap();
+        fs::write(cwd.path().join("foo.md"), "x").unwrap();
+
+        let with_trace = parse_launch_args(
+            &[s("--trace=on"), s("foo.md"), s("--trace")],
+            cwd.path(),
+        );
+        let without_trace = parse_launch_args(&[s("foo.md")], cwd.path());
+
+        assert_eq!(with_trace.files, without_trace.files);
+        assert_eq!(with_trace.folders, without_trace.folders);
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use html::{compute_fold_regions, resolve_html_assets, FoldRegion};
 #[cfg(debug_assertions)]
 pub use launch::set_root_via_test;
 pub use launch::{
-    get_launch_args, get_log_path, parse_launch_args,
+    get_launch_args, get_log_path, parse_launch_args, parse_trace_flag,
     scan_review_files,
 };
 pub use remote_asset::fetch_remote_asset;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -396,6 +396,23 @@ pub fn run() {
     // See `startup_recorder` for the schema (`[startup] phase=app-init t_ms=…`).
     startup_recorder::record_phase(startup_recorder::StartupPhase::AppInit);
 
+    // Apply the IPC trace gate precedence chain BEFORE the Tauri builder
+    // spins up the runtime (no IPC dispatches before `Builder::build()`
+    // returns, so the gate is set before any `#[mdr_command]` call reads
+    // it via `ipc_trace_enabled()`):
+    //
+    //   1. `--trace[=on|off]` launch flag  (highest)
+    //   2. `MDR_IPC_TRACE` env var         (existing escape hatch)
+    //   3. `cfg!(debug_assertions)`        (debug-on by default)
+    //
+    // See `docs/observability.md` for the user-facing description and
+    // `commands::launch::parse_trace_flag` for accepted flag forms.
+    let early_argv: Vec<String> = std::env::args().skip(1).collect();
+    let trace_enabled = commands::launch::parse_trace_flag(&early_argv)
+        .or_else(|| std::env::var("MDR_IPC_TRACE").ok().map(|_| true))
+        .unwrap_or(cfg!(debug_assertions));
+    startup_recorder::set_ipc_trace_enabled(trace_enabled);
+
     let log_plugin = {
         let mut builder = tauri_plugin_log::Builder::new()
             .max_file_size(5 * 1024 * 1024)

--- a/src-tauri/src/startup_recorder.rs
+++ b/src-tauri/src/startup_recorder.rs
@@ -140,20 +140,47 @@ pub fn record_first_ipc() {
     }
 }
 
-/// Cached gate for the per-call `[ipc]` log line emitted by `#[mdr_command]`.
-/// Returns `true` in any debug build, or whenever `MDR_IPC_TRACE` is set in
-/// the process environment. The result is memoized in a `OnceLock<bool>`
-/// so the steady-state per-IPC cost is one relaxed atomic load + one
-/// branch — matches the hot-path budget in `docs/performance.md`.
+/// Process-global gate for the per-call `[ipc]` info line emitted by
+/// `#[mdr_command]`. Read by every IPC call (success arm); set once at
+/// boot from the precedence chain (`--trace` flag > `MDR_IPC_TRACE` env
+/// var > `cfg!(debug_assertions)`) — see `lib.rs::run`.
 ///
-/// Why cache: `std::env::var` is a syscall (or TLS lookup with a Mutex on
-/// Windows). Calling it on every IPC dispatch breaches the budget for
-/// hot commands like `search_in_document` and the watcher's `notify`
-/// callbacks. The env var is read at most once per process; live toggling
-/// is intentionally unsupported.
+/// Initial value is `cfg!(debug_assertions)` so that:
+///   * debug builds (incl. `cargo test`) light up tracing without
+///     explicit setup — the macro's behavior is identical to a
+///     production build that passed `--trace` on the command line;
+///   * release builds default OFF and only flip ON if `lib.rs::run`'s
+///     precedence chain says so. There is a brief window between
+///     `static` init and the first `set_ipc_trace_enabled` call when
+///     this default is observable, but no IPC fires before
+///     `tauri::Builder::build()` returns, and the boot sets the gate
+///     before the runtime starts dispatching commands.
+///
+/// The hot-path read is one `Ordering::Relaxed` atomic load — well under
+/// the budget in `docs/performance.md` for keystroke-rate commands.
+static IPC_TRACE_ENABLED: AtomicBool = AtomicBool::new(cfg!(debug_assertions));
+
+/// Returns whether the per-call `[ipc] … ok=true` info line should be
+/// emitted on this IPC dispatch. Always-on warn-level err lines and
+/// `[startup]` events are unaffected.
+///
+/// The flag is set once at boot via [`set_ipc_trace_enabled`]; subsequent
+/// calls just observe the atomic. If you want to live-toggle from a
+/// running app (e.g. via a Settings IPC), call [`set_ipc_trace_enabled`]
+/// from that command — every IPC dispatched after the store sees the new
+/// value via the relaxed-acquire ordering used here, which is sufficient
+/// because the gate is purely advisory (incorrect for at most a handful
+/// of in-flight IPCs while the store propagates).
 pub fn ipc_trace_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| cfg!(debug_assertions) || std::env::var("MDR_IPC_TRACE").is_ok())
+    IPC_TRACE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Set the [`ipc_trace_enabled`] gate. Called from `lib.rs::run` after
+/// applying the `--trace` / `MDR_IPC_TRACE` / `cfg!(debug_assertions)`
+/// precedence chain. Safe to call from any thread; uses relaxed ordering
+/// (the gate is advisory — see [`ipc_trace_enabled`]).
+pub fn set_ipc_trace_enabled(on: bool) {
+    IPC_TRACE_ENABLED.store(on, Ordering::Relaxed);
 }
 
 /// Maximum length of a sanitized err string in an `[ipc]` log line. Keeps


### PR DESCRIPTION
Per-launch CLI flag for the IPC info-line trace gate introduced in #264 / PR #285.

## What ships

\`\`\`bash
mdownreview --trace            # on (presence implies enabled)
mdownreview --trace=on         # on (also: true, 1, yes — case-insensitive)
mdownreview --trace=off        # off (also: false, 0, no)
mdownreview                    # default policy
\`\`\`

Boot-time precedence (highest wins):
1. \`--trace[=…]\` launch flag
2. \`MDR_IPC_TRACE\` env var (existing escape hatch, preserved)
3. \`cfg!(debug_assertions)\` (debug ON, release OFF)

## Why this shape

- **Per-launch only** — no persistence to leak / leave on accidentally bloating the rotating log file.
- **Bug-report ergonomics** — "Quit, relaunch with \`--trace\`, reproduce, attach the log."
- **Charter Lean** — no UI surface for a developer-only diagnostic (no Settings entry, no menu item).
- **Reuses existing launch-arg parsing** — sibling to \`--folder\` / \`--file\`.

Errors and warnings remain always-on under every combination of flag / env var / build profile.

## Files

\`\`\`
AGENTS.md                         |   2 +-
docs/features/logging.md          |   6 +-
docs/observability.md             |  32 ++++++++--
docs/specs/cli-file-open.md       |  84 +++++++++++++++++++++++++-
src-tauri/src/commands/launch.rs  | 121 +++++++++++++++++++++++++++++++++++++-
src-tauri/src/commands/mod.rs     |   2 +-
src-tauri/src/lib.rs              |  17 ++++++
src-tauri/src/startup_recorder.rs |  51 ++++++++++++----
\`\`\`

## Test plan

- [x] \`cargo test --tests\` — 472 lib + 29 + 65 + 10 + 9 + 6 + 5 + 1, all green (7 new \`parse_trace_flag\` tests).
- [x] \`npm run test\` — 1607/1607 passing.
- [x] \`cargo clippy --all-targets\` — no errors.
- [x] Bindings regen — no drift (no IPC schema change).
- [ ] CI: cross-platform builds + native E2E (Windows).
- [ ] Smoke test: launch \`mdownreview --trace=on\` in release build, verify \`[ipc] cmd=… ok=true\` lines appear in the rotating log file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)