### PR TITLE
feat: implement #293 - Sidecar YAML round-trip bug - saphyr emitter produces unreadable block scalars for whitespace-leading nested strings

### DIFF
--- a/src-tauri/src/core/sidecar/io_guards.rs
+++ b/src-tauri/src/core/sidecar/io_guards.rs
@@ -103,6 +103,13 @@ pub(crate) fn reject_yaml_anchors(text: &str) -> std::io::Result<()> {
 ///   4. `serde_saphyr::from_str::<serde_json::Value>(&repaired)` —
 ///      structural round-trip parse. Catches parse-level breakage
 ///      from a future repair-pass regression.
+///   5. **Structural-equality** check: `serde_json::to_value(value)`
+///      must compare equal to the parsed-back `Value` from step 4.
+///      Catches a repair-pass bug that produces parseable-but-
+///      different YAML — exactly what a stateless regex over body
+///      lines could do (issue #293 forward-fix). The reference is
+///      the input value re-serialized through serde to its JSON
+///      shape; saphyr-from-str of the repaired YAML must match it.
 ///
 /// The validator rejects rather than mutates. Rule 4 in
 /// `docs/security.md` ("the only acceptable failure is 'no write'")
@@ -115,7 +122,28 @@ where
     let raw = serde_saphyr::to_string(value)
         .map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
     let repaired = repair_block_scalar_indents(raw);
-    validate_emitted_mrsf_yaml(&repaired)?;
+
+    // Stage 1: parse-level guard (anchor reject + parseability).
+    reject_yaml_anchors(&repaired).map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
+    let post: serde_json::Value = serde_saphyr::from_str(&repaired)
+        .map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
+
+    // Stage 2: structural equality. Catches a repair-pass bug that
+    // produced parseable-but-different YAML — which is exactly what
+    // a stateless regex over body lines could do (issue #293
+    // forward-fix).
+    let original: serde_json::Value = serde_json::to_value(value).map_err(|e| {
+        super::SidecarError::YamlParse(format!(
+            "input value cannot be re-serialized for round-trip check: {e}"
+        ))
+    })?;
+    if post != original {
+        return Err(super::SidecarError::YamlParse(
+            "post-emit YAML parses to a value that differs structurally from the input \
+             — refusing to write to disk to avoid silent corruption (issue #293)"
+                .into(),
+        ));
+    }
     Ok(repaired)
 }
 
@@ -154,18 +182,29 @@ pub(super) fn validate_emitted_mrsf_yaml(text: &str) -> Result<(), super::Sideca
 /// NOT moved — the bug is purely in the indicator, not the body
 /// layout. Chomping indicators (`+` / `-`) are preserved verbatim.
 ///
-/// Allocates only when at least one header needs repair: returns the
-/// original `String` untouched otherwise (single allocation total in
-/// the happy path, since `emit_mrsf_yaml` already owns `raw`).
+/// Allocates a `Vec<&str>` proportional to line count for line-by-line
+/// scanning; the content `String` itself is only reallocated when at
+/// least one header needs rewriting (returns the original `String`
+/// untouched in the happy path).
+///
+/// **Stateful body skipping** (issue #293 forward-fix). After matching
+/// a header at parent indent `P`, the outer loop jumps past every
+/// following line whose indent is strictly greater than `P` (blanks
+/// included) before resuming header detection. A line *inside* an
+/// already-open block-scalar body must NEVER be re-tested as a header,
+/// otherwise a body line that happens to look like `|3` or `>3-` would
+/// be silently rewritten — corrupting the user's literal content.
 fn repair_block_scalar_indents(yaml: String) -> String {
     static HEADER_RE: OnceLock<Regex> = OnceLock::new();
     let re = HEADER_RE.get_or_init(|| {
-        // Conservative: only match lines whose prefix is a recognisable
-        // YAML node-position (leading spaces, optional `- `, optional
-        // `key: `). The header itself is `|` or `>`, an explicit
-        // ASCII digit, optional chomp, optional trailing whitespace.
+        // Saphyr never emits a bare `|N` on its own line; a header
+        // always sits on a `- ` element line, a `key:` line, or both.
+        // Require at least one of those prefixes so a body line that
+        // happens to read `|3` (or `>3-`) is NOT misclassified as a
+        // header. Capture each prefix component separately so the
+        // post-match check can reject a bare-prefix match.
         Regex::new(
-            r"^(?P<indent>[ \t]*)(?:-[ \t]+)?(?:[^\n:|>]+?:[ \t]+)?[|>](?P<digit>[0-9])[+\-]?[ \t]*$",
+            r"^(?P<indent>[ \t]*)(?P<dash>-[ \t]+)?(?P<key>[^\n:|>][^\n:|>]*?:[ \t]+)?[|>](?P<digit>[0-9])[+\-]?[ \t]*$",
         )
         .expect("valid block-scalar header regex")
     });
@@ -178,7 +217,8 @@ fn repair_block_scalar_indents(yaml: String) -> String {
     let lines: Vec<&str> = yaml.split_inclusive('\n').collect();
     let mut out: Option<String> = None;
 
-    for i in 0..lines.len() {
+    let mut i = 0;
+    while i < lines.len() {
         let line = lines[i];
         let line_no_nl = trim_eol(line);
 
@@ -188,9 +228,22 @@ fn repair_block_scalar_indents(yaml: String) -> String {
                 if let Some(ref mut buf) = out {
                     buf.push_str(line);
                 }
+                i += 1;
                 continue;
             }
         };
+
+        // Defense-in-depth: even though the regex requires at least one
+        // of `dash` / `key` via the alternation pattern, double-check.
+        // A line with neither prefix is a body-line look-alike and must
+        // be left alone.
+        if caps.name("dash").is_none() && caps.name("key").is_none() {
+            if let Some(ref mut buf) = out {
+                buf.push_str(line);
+            }
+            i += 1;
+            continue;
+        }
 
         let parent_col = caps.name("indent").unwrap().as_str().len();
         let digit_match = caps.name("digit").unwrap();
@@ -198,20 +251,24 @@ fn repair_block_scalar_indents(yaml: String) -> String {
         let digit_byte_offset = digit_match.start();
 
         // Scan body: find the MINIMUM indent across every non-blank body
-        // line, stopping at any line indented `<=` parent_col (dedent).
+        // line, AND determine the body span end (first non-body line, or
+        // `lines.len()`). Body = blank line OR line indented > parent_col.
         // Saphyr preserves leading whitespace in the first content line by
-        // emitting that line at one extra indent level (the leading-space
-        // bytes become content after the strip), so the FIRST body line
+        // emitting it at one extra indent level, so the FIRST body line
         // can be deeper than the body's logical indent — only the minimum
         // determines what the parser will accept (YAML 1.2 §8.1.1).
         let mut body_col: Option<usize> = None;
+        let mut body_end = lines.len();
         for j in (i + 1)..lines.len() {
             let bl = trim_eol(lines[j]);
             if bl.is_empty() || bl.bytes().all(|b| b == b' ' || b == b'\t') {
+                // Blank lines belong to the body; do not constrain
+                // `body_col`, but do not terminate the span either.
                 continue;
             }
             let lead = bl.bytes().take_while(|b| *b == b' ').count();
             if lead <= parent_col {
+                body_end = j;
                 break;
             }
             body_col = Some(body_col.map_or(lead, |cur| cur.min(lead)));
@@ -241,6 +298,15 @@ fn repair_block_scalar_indents(yaml: String) -> String {
                 }
             }
         }
+
+        // CRITICAL: jump past the entire body span so body lines are
+        // NEVER re-tested as headers. This is the stateful guard.
+        if let Some(ref mut buf) = out {
+            for k in (i + 1)..body_end {
+                buf.push_str(lines[k]);
+            }
+        }
+        i = body_end;
     }
 
     out.unwrap_or(yaml)

--- a/src-tauri/src/core/sidecar/io_guards.rs
+++ b/src-tauri/src/core/sidecar/io_guards.rs
@@ -1,16 +1,22 @@
-//! Read-side chokepoints for sidecar I/O.
+//! I/O chokepoints for sidecar reads and writes.
 //!
 //! Lifted out of `sidecar/mod.rs` to keep that file under the 400 LOC
 //! budget (rule 23 in `docs/architecture.md`). These functions are the
-//! only sanctioned way to ingest sidecar bytes from disk; both the YAML
-//! and JSON load paths in [`super::load_sidecar`] / [`super::patch_comment`]
-//! call [`read_capped`] (and the YAML branch additionally calls
-//! [`reject_yaml_anchors`]) before any parser touches the content.
+//! only sanctioned way to ingest sidecar bytes from disk OR to produce
+//! sidecar bytes for the disk: every load path in
+//! [`super::load_sidecar`] / [`super::patch_comment`] calls
+//! [`read_capped`] (and the YAML branch additionally calls
+//! [`reject_yaml_anchors`]) before any parser touches the content, and
+//! every save path in [`super::save_sidecar_at`] / [`super::patch_comment_at`]
+//! routes its YAML emission through [`emit_mrsf_yaml`] before any bytes
+//! reach `write_atomic`.
 //!
 //! Visibility is `pub(crate)` on purpose: no command handler outside
-//! this module should be reading sidecars directly — it must go through
-//! the `sidecar` API, which guarantees the cap + anchor-rejection
-//! invariants documented in `docs/security.md` rule 3.
+//! this module should be reading or writing sidecars directly — it must
+//! go through the `sidecar` API, which guarantees the cap + anchor
+//! rejection invariants documented in `docs/security.md` rule 3 (read
+//! side) and rules 4 / 8 (write side: the only acceptable failure is
+//! "no write", and YAML anchors / aliases are rejected symmetrically).
 
 use regex::Regex;
 use std::sync::OnceLock;
@@ -72,6 +78,172 @@ pub(crate) fn reject_yaml_anchors(text: &str) -> std::io::Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Single chokepoint for emitting MRSF YAML.
+///
+/// Wraps `serde_saphyr::to_string`, repairs a known emitter bug in
+/// `serde-saphyr-0.0.25` where block-scalar indicators in nested
+/// mappings are computed as the absolute body column instead of
+/// the parent-relative delta (issue #293 — YAML 1.2 §8.1.1.1
+/// requires content indentation = parent_indent + N), and validates
+/// by re-parsing before returning. Any non-roundtrippable output is a
+/// hard `SidecarError::YamlParse`, never silent disk corruption.
+///
+/// Pipeline:
+///   1. `serde_saphyr::to_string(value)` — initial emit.
+///   2. Generic block-literal indent-repair pass on the emitted
+///      text. Operates on YAML text, not field-specific values, so
+///      unknown / forward-compat payloads (`Anchor::Unknown`,
+///      v1.1 fields carried as `serde_json::Value`) are covered.
+///   3. `reject_yaml_anchors(&repaired)` — defense-in-depth
+///      symmetric write-side enforcement of the no-anchors policy
+///      (`docs/security.md` rule 8). The typed structs don't emit
+///      anchors today, but a future custom `Serialize` impl might.
+///   4. `serde_saphyr::from_str::<serde_json::Value>(&repaired)` —
+///      structural round-trip parse. Catches parse-level breakage
+///      from a future repair-pass regression.
+///
+/// The validator rejects rather than mutates. Rule 4 in
+/// `docs/security.md` ("the only acceptable failure is 'no write'")
+/// applies here: the caller surfaces a save error to the user instead
+/// of writing silently corrupt YAML.
+pub(crate) fn emit_mrsf_yaml<T>(value: &T) -> Result<String, super::SidecarError>
+where
+    T: serde::Serialize,
+{
+    let raw = serde_saphyr::to_string(value)
+        .map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
+    let repaired = repair_block_scalar_indents(raw);
+    validate_emitted_mrsf_yaml(&repaired)?;
+    Ok(repaired)
+}
+
+/// Validation half of [`emit_mrsf_yaml`], exposed at `pub(super)` so
+/// unit tests can assert the guard fires on synthetic broken output
+/// without trying to provoke saphyr into emitting garbage.
+pub(super) fn validate_emitted_mrsf_yaml(text: &str) -> Result<(), super::SidecarError> {
+    reject_yaml_anchors(text).map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
+    let _: serde_json::Value =
+        serde_saphyr::from_str(text).map_err(|e| super::SidecarError::YamlParse(e.to_string()))?;
+    Ok(())
+}
+
+/// Repair the saphyr-0.0.25 block-literal indent bug.
+///
+/// Walks the emitted YAML line-by-line. For every line ending in a
+/// block-literal header `|N[+-]?` or folded header `>N[+-]?` (where
+/// `N` is a single ASCII digit; bare `|` / `|-` / `|+` / `>` headers
+/// have no digit and are skipped — saphyr lets the parser auto-detect
+/// from body indentation in that branch, which works correctly), the
+/// pass computes:
+///   - `parent_col` — column of the first non-space character of the
+///     header line (the dash in `- ...` or the key in `key: ...`,
+///     uniformly — empirically the parser uses this column as the
+///     parent indent for block scalars in both shapes).
+///   - `body_col` — MINIMUM indent across every non-blank line that
+///     follows and is indented strictly deeper than `parent_col`.
+///     Saphyr preserves leading whitespace in the first content line
+///     by emitting it at extra indent (so the leading bytes become
+///     content after the strip), so only the minimum reflects the
+///     body's logical indent. Blank lines are skipped (they don't
+///     constrain the indicator).
+/// The correct YAML 1.2 §8.1.1.1 indicator value is
+/// `body_col - parent_col`. If that differs from the digit emitted
+/// by saphyr, rewrite the digit (and only the digit). Body lines are
+/// NOT moved — the bug is purely in the indicator, not the body
+/// layout. Chomping indicators (`+` / `-`) are preserved verbatim.
+///
+/// Allocates only when at least one header needs repair: returns the
+/// original `String` untouched otherwise (single allocation total in
+/// the happy path, since `emit_mrsf_yaml` already owns `raw`).
+fn repair_block_scalar_indents(yaml: String) -> String {
+    static HEADER_RE: OnceLock<Regex> = OnceLock::new();
+    let re = HEADER_RE.get_or_init(|| {
+        // Conservative: only match lines whose prefix is a recognisable
+        // YAML node-position (leading spaces, optional `- `, optional
+        // `key: `). The header itself is `|` or `>`, an explicit
+        // ASCII digit, optional chomp, optional trailing whitespace.
+        Regex::new(
+            r"^(?P<indent>[ \t]*)(?:-[ \t]+)?(?:[^\n:|>]+?:[ \t]+)?[|>](?P<digit>[0-9])[+\-]?[ \t]*$",
+        )
+        .expect("valid block-scalar header regex")
+    });
+
+    fn trim_eol(s: &str) -> &str {
+        let s = s.strip_suffix('\n').unwrap_or(s);
+        s.strip_suffix('\r').unwrap_or(s)
+    }
+
+    let lines: Vec<&str> = yaml.split_inclusive('\n').collect();
+    let mut out: Option<String> = None;
+
+    for i in 0..lines.len() {
+        let line = lines[i];
+        let line_no_nl = trim_eol(line);
+
+        let caps = match re.captures(line_no_nl) {
+            Some(c) => c,
+            None => {
+                if let Some(ref mut buf) = out {
+                    buf.push_str(line);
+                }
+                continue;
+            }
+        };
+
+        let parent_col = caps.name("indent").unwrap().as_str().len();
+        let digit_match = caps.name("digit").unwrap();
+        let current_n: u32 = digit_match.as_str().parse().unwrap();
+        let digit_byte_offset = digit_match.start();
+
+        // Scan body: find the MINIMUM indent across every non-blank body
+        // line, stopping at any line indented `<=` parent_col (dedent).
+        // Saphyr preserves leading whitespace in the first content line by
+        // emitting that line at one extra indent level (the leading-space
+        // bytes become content after the strip), so the FIRST body line
+        // can be deeper than the body's logical indent — only the minimum
+        // determines what the parser will accept (YAML 1.2 §8.1.1).
+        let mut body_col: Option<usize> = None;
+        for j in (i + 1)..lines.len() {
+            let bl = trim_eol(lines[j]);
+            if bl.is_empty() || bl.bytes().all(|b| b == b' ' || b == b'\t') {
+                continue;
+            }
+            let lead = bl.bytes().take_while(|b| *b == b' ').count();
+            if lead <= parent_col {
+                break;
+            }
+            body_col = Some(body_col.map_or(lead, |cur| cur.min(lead)));
+        }
+
+        let needs_rewrite = body_col
+            .filter(|bc| *bc > parent_col)
+            .map(|bc| (bc - parent_col) as u32)
+            .filter(|n| (1..=9).contains(n) && *n != current_n);
+
+        match needs_rewrite {
+            Some(expected_n) => {
+                let buf = out.get_or_insert_with(|| {
+                    let mut s = String::with_capacity(yaml.len());
+                    for k in 0..i {
+                        s.push_str(lines[k]);
+                    }
+                    s
+                });
+                buf.push_str(&line[..digit_byte_offset]);
+                buf.push(char::from_digit(expected_n, 10).expect("1..=9 digit"));
+                buf.push_str(&line[digit_byte_offset + 1..]);
+            }
+            None => {
+                if let Some(ref mut buf) = out {
+                    buf.push_str(line);
+                }
+            }
+        }
+    }
+
+    out.unwrap_or(yaml)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/core/sidecar/mod.rs
+++ b/src-tauri/src/core/sidecar/mod.rs
@@ -8,6 +8,11 @@
 //! → parse. JSON reads intentionally skip the YAML anchor check (anchors
 //! are a YAML-only construct).
 //!
+//! Symmetrically, all sidecar **writes** funnel through
+//! [`io_guards::emit_mrsf_yaml`] (emit + saphyr block-literal repair
+//! for #293 + write-side `reject_yaml_anchors` per `docs/security.md`
+//! rule 8 + structural re-parse) before bytes reach `write_atomic`.
+//!
 //! Workspace `.mrsf.yaml` config (loading, validation, caching) lives in
 //! [`config`].
 
@@ -20,7 +25,7 @@ use crate::core::mrsf_version::mrsf_version_for;
 use crate::core::types::{CommentMutation, MrsfComment, MrsfSidecar};
 // Re-export IO guards so sibling core modules (e.g. paths.rs) can reuse
 // the same capped-read + anchor-rejection defenses for config files.
-pub(crate) use io_guards::{read_capped, reject_yaml_anchors};
+pub(crate) use io_guards::{emit_mrsf_yaml, read_capped, reject_yaml_anchors};
 use std::collections::HashSet;
 use std::fmt;
 use std::path::Path;
@@ -149,8 +154,8 @@ pub fn load_sidecar_at(
     match read_capped(yaml_path) {
         Ok(content) => {
             reject_yaml_anchors(&content)?;
-            let sidecar: MrsfSidecar =
-                serde_saphyr::from_str(&content).map_err(|e| SidecarError::YamlParse(e.to_string()))?;
+            let sidecar: MrsfSidecar = serde_saphyr::from_str(&content)
+                .map_err(|e| SidecarError::YamlParse(e.to_string()))?;
             reject_unsupported_version(&sidecar)?;
             validate_sidecar_warnings(&sidecar);
             return Ok(Some(sidecar));
@@ -207,13 +212,13 @@ pub fn save_sidecar_at(
         document: document.to_string(),
         comments: comments.to_vec(),
     };
-    let yaml = serde_saphyr::to_string(&payload).map_err(|e| {
+    let yaml = emit_mrsf_yaml(&payload).map_err(|e| {
         log::warn!(
             target: "mdownreview::sidecar",
-            "save_sidecar_at: serde_saphyr serialise failed path={} comment_count={} error={}",
+            "save_sidecar_at: emit_mrsf_yaml failed path={} comment_count={} error={}",
             sidecar_path.display(), comments.len(), e
         );
-        SidecarError::YamlParse(e.to_string())
+        e
     })?;
 
     crate::core::atomic::write_atomic(sidecar_path, yaml.as_bytes()).map_err(|e| {
@@ -316,7 +321,7 @@ pub fn patch_comment_at(
                     // Convert JSON to YAML Value
                     let json_val: serde_json::Value =
                         serde_json::from_str(&c).map_err(SidecarError::JsonParse)?;
-                    serde_saphyr::to_string(&json_val).map_err(|e| SidecarError::YamlParse(e.to_string()))?
+                    emit_mrsf_yaml(&json_val)?
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Err(SidecarError::NotFound);
@@ -355,9 +360,7 @@ pub fn patch_comment_at(
                 text,
                 timestamp,
             } => {
-                let responses = comment
-                    .get_mut("responses")
-                    .and_then(|v| v.as_array_mut());
+                let responses = comment.get_mut("responses").and_then(|v| v.as_array_mut());
                 let new_response = serde_json::json!({
                     "author": author,
                     "text": text,
@@ -373,7 +376,7 @@ pub fn patch_comment_at(
         }
     }
 
-    let yaml_out = serde_saphyr::to_string(&doc).map_err(|e| SidecarError::YamlParse(e.to_string()))?;
+    let yaml_out = emit_mrsf_yaml(&doc)?;
 
     // Atomic write — always target the provided yaml_path.
     crate::core::atomic::write_atomic(Path::new(yaml_path), yaml_out.as_bytes())?;

--- a/src-tauri/src/core/sidecar/tests.rs
+++ b/src-tauri/src/core/sidecar/tests.rs
@@ -596,6 +596,68 @@ fn regression_saphyr_block_scalar_indent_bug() {
     );
 }
 
+/// Forward-fix regression for #293: the indent-repair pass must NOT
+/// rewrite block-scalar body lines that happen to look like headers.
+/// Without stateful tracking, a stateless line-regex would match a
+/// body line `|3` as a "header" and rewrite the digit, silently
+/// corrupting the user's literal content.
+#[test]
+fn repair_does_not_rewrite_body_lines_that_look_like_headers() {
+    let payload = MrsfSidecar {
+        mrsf_version: "1.0".into(),
+        document: "d.md".into(),
+        comments: vec![sample_comment_with("c1", |b| {
+            b.selected_text = Some("foo\n|3\n    deeper\n    deeper2".into());
+        })],
+    };
+    let yaml = emit_mrsf_yaml(&payload).expect("must emit valid yaml");
+    let round: MrsfSidecar = serde_saphyr::from_str(&yaml).expect("emitted yaml must parse");
+    assert_eq!(
+        round.comments[0].selected_text.as_deref(),
+        Some("foo\n|3\n    deeper\n    deeper2"),
+        "body line `|3` must not be misclassified as a header"
+    );
+}
+
+/// Variant: chomping indicator on body line (`|3-`) — verifies the
+/// stateful repair preserves the chomp marker too, not just the digit.
+#[test]
+fn repair_does_not_rewrite_body_lines_with_chomping_indicator() {
+    let payload = MrsfSidecar {
+        mrsf_version: "1.0".into(),
+        document: "d.md".into(),
+        comments: vec![sample_comment_with("c1", |b| {
+            b.selected_text = Some("foo\n|3-\n    deeper\n    deeper2".into());
+        })],
+    };
+    let yaml = emit_mrsf_yaml(&payload).expect("must emit valid yaml");
+    let round: MrsfSidecar = serde_saphyr::from_str(&yaml).expect("emitted yaml must parse");
+    assert_eq!(
+        round.comments[0].selected_text.as_deref(),
+        Some("foo\n|3-\n    deeper\n    deeper2"),
+        "body line `|3-` must not be misclassified as a header"
+    );
+}
+
+/// Variant: folded-scalar header look-alike (`>3`) inside body content.
+#[test]
+fn repair_does_not_rewrite_body_lines_that_look_like_folded_headers() {
+    let payload = MrsfSidecar {
+        mrsf_version: "1.0".into(),
+        document: "d.md".into(),
+        comments: vec![sample_comment_with("c1", |b| {
+            b.selected_text = Some("foo\n>3\n    deeper\n    deeper2".into());
+        })],
+    };
+    let yaml = emit_mrsf_yaml(&payload).expect("must emit valid yaml");
+    let round: MrsfSidecar = serde_saphyr::from_str(&yaml).expect("emitted yaml must parse");
+    assert_eq!(
+        round.comments[0].selected_text.as_deref(),
+        Some("foo\n>3\n    deeper\n    deeper2"),
+        "body line `>3` must not be misclassified as a folded header"
+    );
+}
+
 /// Exact reproducer from #293: `selected_text` with one leading space,
 /// 3 lines, no trailing newline. Forces saphyr's literal-block branch.
 #[test]
@@ -927,9 +989,12 @@ fn emit_mrsf_yaml_round_trip_validation_rejects_unparseable_output() {
     );
 }
 
-/// Structural round-trip equality check: emit then parse, the parsed
-/// JSON Value must `==` the input. Catches a hypothetical repair-pass
-/// bug that produces parseable-but-different YAML.
+/// Asserts that `emit_mrsf_yaml` enforces structural equality between
+/// the input value and the post-emit YAML's parse — preventing silent
+/// disk corruption from a future repair-pass regression. The runtime
+/// guard at `io_guards.rs::emit_mrsf_yaml` rejects any non-structurally-
+/// equal output as `SidecarError::YamlParse`; this test asserts that
+/// guarantee from the outside (via `emit_mrsf_yaml` → success path).
 #[test]
 fn emit_mrsf_yaml_round_trip_validates_structural_equality() {
     let value = serde_json::json!({

--- a/src-tauri/src/core/sidecar/tests.rs
+++ b/src-tauri/src/core/sidecar/tests.rs
@@ -2,29 +2,89 @@
 //! the 400-LOC budget (rule 23 in docs/architecture.md).
 
 use super::*;
-use crate::core::types::MrsfComment;
+use crate::core::types::{Anchor, MrsfComment};
 use tempfile::TempDir;
 
+/// Builder used by [`sample_comment_with`]. Lets individual tests
+/// override the fields that vary across cases (whitespace prefixes,
+/// anchored text, sparse-fixture matching) without each test
+/// re-listing the dozen `Option::None` defaults.
+struct CommentBuilder {
+    id: String,
+    text: String,
+    line: Option<u32>,
+    selected_text: Option<String>,
+    anchored_text: Option<String>,
+}
+
 fn sample_comment(id: &str) -> MrsfComment {
-    MrsfComment {
+    sample_comment_with(id, |_| {})
+}
+
+fn sample_comment_with<F: FnOnce(&mut CommentBuilder)>(id: &str, f: F) -> MrsfComment {
+    let mut b = CommentBuilder {
         id: id.to_string(),
-        author: "test".to_string(),
-        timestamp: "2025-01-01T00:00:00Z".to_string(),
         text: "test comment".to_string(),
-        resolved: false,
         line: Some(1),
+        selected_text: None,
+        anchored_text: None,
+    };
+    f(&mut b);
+
+    // Keep the `Anchor::Line` payload in sync with the legacy flat
+    // line/selected_text fields. The wire round-trip would otherwise
+    // overwrite the in-memory anchor with values reconstructed from
+    // the flat fields (see `wire::TryFrom<MrsfCommentRepr>`), which
+    // would make `assert_sidecar_eq` spuriously fail.
+    let anchor = Anchor::Line {
+        line: b.line.unwrap_or(0),
         end_line: None,
         start_column: None,
         end_column: None,
-        selected_text: None,
-        anchored_text: None,
+        selected_text: b.selected_text.clone(),
+        selected_text_hash: None,
+    };
+
+    MrsfComment {
+        id: b.id,
+        author: "test".to_string(),
+        timestamp: "2025-01-01T00:00:00Z".to_string(),
+        text: b.text,
+        resolved: false,
+        line: b.line,
+        end_line: None,
+        start_column: None,
+        end_column: None,
+        selected_text: b.selected_text,
+        anchored_text: b.anchored_text,
         selected_text_hash: None,
         commit: None,
         comment_type: None,
         severity: None,
         reply_to: None,
+        anchor,
         ..Default::default()
     }
+}
+
+/// Byte-exact equality across every sidecar field. `MrsfSidecar`
+/// itself doesn't derive `PartialEq` (only its `Vec<MrsfComment>`
+/// does), so compare structurally. This is the only oracle worth
+/// using for round-trip tests — substring / `is_some()` / length
+/// checks let the saphyr block-scalar bug ship (#293).
+fn assert_sidecar_eq(loaded: &MrsfSidecar, expected: &MrsfSidecar) {
+    assert_eq!(
+        loaded.mrsf_version, expected.mrsf_version,
+        "mrsf_version round-trip mismatch"
+    );
+    assert_eq!(
+        loaded.document, expected.document,
+        "document round-trip mismatch"
+    );
+    assert_eq!(
+        loaded.comments, expected.comments,
+        "comments round-trip mismatch (byte-exact)"
+    );
 }
 
 #[test]
@@ -48,10 +108,15 @@ comments:
     .unwrap();
 
     let result = load_sidecar(file_path.to_str().unwrap()).unwrap();
-    assert!(result.is_some());
-    let sidecar = result.unwrap();
-    assert_eq!(sidecar.comments.len(), 1);
-    assert_eq!(sidecar.comments[0].id, "c1");
+    let expected = MrsfSidecar {
+        mrsf_version: "1.0".to_string(),
+        document: "test.md".to_string(),
+        comments: vec![sample_comment_with("c1", |b| {
+            b.text = "hello".to_string();
+            b.line = None; // fixture has no `line` field
+        })],
+    };
+    assert_sidecar_eq(&result.unwrap(), &expected);
 }
 
 #[test]
@@ -67,8 +132,15 @@ fn load_sidecar_json_fallback() {
         .unwrap();
 
     let result = load_sidecar(file_path.to_str().unwrap()).unwrap();
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().comments[0].id, "c1");
+    let expected = MrsfSidecar {
+        mrsf_version: "1.0".to_string(),
+        document: "test.md".to_string(),
+        comments: vec![sample_comment_with("c1", |b| {
+            b.text = "hello".to_string();
+            b.line = None; // fixture has no `line` field
+        })],
+    };
+    assert_sidecar_eq(&result.unwrap(), &expected);
 }
 
 #[test]
@@ -291,8 +363,12 @@ fn load_sidecar_accepts_v1_minor_versions() {
     .unwrap();
 
     let result = load_sidecar(file_path.to_str().unwrap()).unwrap();
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().mrsf_version, "1.5");
+    let expected = MrsfSidecar {
+        mrsf_version: "1.5".to_string(),
+        document: "v1x.md".to_string(),
+        comments: vec![],
+    };
+    assert_sidecar_eq(&result.unwrap(), &expected);
 }
 
 // ── Save error semantics (regression: misleading "sidecar not found") ───────
@@ -347,7 +423,11 @@ fn save_sidecar_at_to_invalid_ancestor_surfaces_real_io_error() {
         "x".into(),
         false,
         Some(1),
-        None, None, None, None, None,
+        None,
+        None,
+        None,
+        None,
+        None,
     );
     let result = save_sidecar_at(&bogus, "foo.bin", std::slice::from_ref(&c));
     let err = result.expect_err("write to invalid ancestor must fail");
@@ -416,7 +496,11 @@ fn save_sidecar_at_to_readonly_dir_surfaces_clear_message() {
         "x".into(),
         false,
         Some(1),
-        None, None, None, None, None,
+        None,
+        None,
+        None,
+        None,
+        None,
     );
     let result = save_sidecar_at(&target, "foo.png", std::slice::from_ref(&c));
     let err = result.expect_err("write to read-only dir must fail");
@@ -479,4 +563,393 @@ comments:
     );
     // Value actually changed
     assert!(on_disk.contains("resolved: true"));
+}
+
+// ── #293 P0 tests: block-literal indent bug + write-side chokepoint ─────────
+//
+// All tests here assert byte-exact round-trip on whitespace-bearing string
+// fields. Without `emit_mrsf_yaml`'s repair pass, saphyr-0.0.25 would emit
+// a `|N` indicator computed against the absolute body column instead of
+// parent-relative, producing YAML the parser rejects (and silently dropping
+// the comment on next load — the exact failure mode reported in #293).
+
+/// AC4 regression — verbatim from issue #293 body.
+#[test]
+fn regression_saphyr_block_scalar_indent_bug() {
+    let payload = MrsfSidecar {
+        mrsf_version: "1.0".into(),
+        document: "test.md".into(),
+        comments: vec![sample_comment_with("abc", |b| {
+            b.selected_text = Some(
+                " install, and launch the mdownreview desktop app\n\
+                 readScan for review sidecars\n\
+                 reviewOrchestrate the full c"
+                    .into(),
+            );
+        })],
+    };
+    let yaml = emit_mrsf_yaml(&payload).expect("must emit valid yaml");
+    let round: MrsfSidecar = serde_saphyr::from_str(&yaml).expect("emitted yaml must parse");
+    assert_eq!(
+        round.comments[0].selected_text, payload.comments[0].selected_text,
+        "selected_text must round-trip byte-exact"
+    );
+}
+
+/// Exact reproducer from #293: `selected_text` with one leading space,
+/// 3 lines, no trailing newline. Forces saphyr's literal-block branch.
+#[test]
+fn save_then_load_preserves_selected_text_with_leading_space() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = " install, and launch the mdownreview desktop app\n\
+                    readScan for review sidecars\n\
+                    reviewOrchestrate the full c"
+        .to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.selected_text = Some(original.clone());
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(
+        loaded.comments[0].selected_text.as_deref(),
+        Some(original.as_str()),
+        "selected_text with leading space must round-trip byte-exact"
+    );
+}
+
+#[test]
+fn save_then_load_preserves_selected_text_with_leading_tab() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = "\tline1\nline2\nline3".to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.selected_text = Some(original.clone());
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(
+        loaded.comments[0].selected_text.as_deref(),
+        Some(original.as_str())
+    );
+}
+
+#[test]
+fn save_then_load_preserves_selected_text_with_leading_newline() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = "\n  body\n  more".to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.selected_text = Some(original.clone());
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(
+        loaded.comments[0].selected_text.as_deref(),
+        Some(original.as_str())
+    );
+}
+
+#[test]
+fn save_then_load_preserves_text_with_leading_whitespace() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = "  multi-line\n  comment\n  body".to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.text = original.clone();
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(
+        loaded.comments[0].text, original,
+        "comment.text with leading whitespace must round-trip byte-exact"
+    );
+}
+
+#[test]
+fn save_then_load_preserves_anchored_text_multiline() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = "  anchor line 1\n  anchor line 2\n  anchor line 3".to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.anchored_text = Some(original.clone());
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(
+        loaded.comments[0].anchored_text.as_deref(),
+        Some(original.as_str())
+    );
+}
+
+/// File-level anchors don't carry `selected_text` (the wire-level
+/// guard rejects it: `Anchor::File requires explicit anchor_kind:"file"
+/// with NO flat targeting fields`). Exercise the same write path with
+/// whitespace-leading content via the comment's `text` field instead.
+#[test]
+fn save_then_load_file_anchor_with_whitespace_text() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = "  file-level\n  comment\n  body".to_string();
+    let mut comment = sample_comment_with("c1", |b| {
+        b.text = original.clone();
+        b.line = None; // file anchor: no flat targeting
+    });
+    comment.anchor = Anchor::File;
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(loaded.comments[0].text, original);
+    assert!(matches!(loaded.comments[0].anchor, Anchor::File));
+}
+
+#[test]
+fn save_then_load_multiple_comments_mixed_content() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let leading_space = " selected with leading space\nline2\nline3".to_string();
+    let leading_tab = "\ttabby text\non multiple lines\nfor sure".to_string();
+
+    let mut c1 = sample_comment_with("c1", |b| {
+        b.selected_text = Some(leading_space.clone());
+    });
+    c1.id = "c1".into();
+    let mut c2 = sample_comment_with("c2", |b| {
+        b.text = leading_tab.clone();
+    });
+    c2.id = "c2".into();
+    let c3 = sample_comment_with("c3", |b| {
+        b.text = "no whitespace here".into();
+    });
+
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[c1, c2, c3]).unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    assert_eq!(loaded.comments.len(), 3);
+    assert_eq!(
+        loaded.comments[0].selected_text.as_deref(),
+        Some(leading_space.as_str())
+    );
+    assert_eq!(loaded.comments[1].text, leading_tab);
+    assert_eq!(loaded.comments[2].text, "no whitespace here");
+}
+
+#[test]
+fn save_then_load_preserves_anchor_history_selected_text() {
+    use crate::core::types::Anchor;
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let history_text = "  history line 1\n  history line 2\n  history line 3".to_string();
+    let mut comment = sample_comment_with("c1", |_| {});
+    comment.anchor_history = Some(vec![Anchor::Line {
+        line: 5,
+        end_line: None,
+        start_column: None,
+        end_column: None,
+        selected_text: Some(history_text.clone()),
+        selected_text_hash: None,
+    }]);
+
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+
+    let history = loaded.comments[0]
+        .anchor_history
+        .as_ref()
+        .expect("history must survive round-trip");
+    assert_eq!(history.len(), 1);
+    match &history[0] {
+        Anchor::Line { selected_text, .. } => {
+            assert_eq!(selected_text.as_deref(), Some(history_text.as_str()));
+        }
+        other => panic!("expected Anchor::Line, got {:?}", other),
+    }
+}
+
+/// Lossy fallback path for `patch_comment` (L376) must preserve
+/// whitespace-leading `selected_text`. We can't reliably force the
+/// fallback (surgery handles `SetResolved` for typical inputs), so we
+/// assert the invariant that matters in BOTH branches: even if the
+/// surgery path was taken, the bytes survive (surgery preserves bytes
+/// by definition); even if the lossy fallback was taken, the
+/// emit_mrsf_yaml chokepoint preserves them.
+#[test]
+fn patch_comment_lossy_fallback_preserves_whitespace_selected_text() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = " selected with leading space\nline2\nline3".to_string();
+    let comment = sample_comment_with("c1", |b| {
+        b.selected_text = Some(original.clone());
+    });
+    save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+
+    patch_comment(
+        file_path.to_str().unwrap(),
+        "c1",
+        &[CommentMutation::SetResolved(true)],
+    )
+    .unwrap();
+
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    let c = loaded.comments.iter().find(|c| c.id == "c1").unwrap();
+    assert!(c.resolved, "set_resolved must have applied");
+    assert_eq!(
+        c.selected_text.as_deref(),
+        Some(original.as_str()),
+        "selected_text must survive patch_comment regardless of surgery vs lossy branch"
+    );
+}
+
+/// L319 path: `.review.json` exists (no `.review.yaml`), patch_comment
+/// migrates to YAML. Whitespace-leading `selected_text` must survive
+/// the JSON→YAML emission through the chokepoint.
+#[test]
+fn patch_comment_json_to_yaml_migration_preserves_whitespace() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("doc.md");
+    std::fs::write(&file_path, "# Test").unwrap();
+
+    let original = " leading-space text\nline two\nline three";
+    let json_path = tmp.path().join("doc.md.review.json");
+    let json = serde_json::json!({
+        "mrsf_version": "1.0",
+        "document": "doc.md",
+        "comments": [{
+            "id": "c1",
+            "author": "test",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "text": "test comment",
+            "resolved": false,
+            "line": 1,
+            "selected_text": original,
+        }]
+    });
+    std::fs::write(&json_path, serde_json::to_string(&json).unwrap()).unwrap();
+
+    patch_comment(
+        file_path.to_str().unwrap(),
+        "c1",
+        &[CommentMutation::SetResolved(true)],
+    )
+    .unwrap();
+
+    // Loaded back via the YAML path (newly written by migration).
+    let yaml_path = tmp.path().join("doc.md.review.yaml");
+    assert!(yaml_path.exists(), "migration must produce a .review.yaml");
+    let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+    let c = loaded.comments.iter().find(|c| c.id == "c1").unwrap();
+    assert!(c.resolved);
+    assert_eq!(c.selected_text.as_deref(), Some(original));
+}
+
+/// Table-driven matrix: every (field × prefix) combination must
+/// round-trip byte-exact. Catches any one-cell regression in a single
+/// test, with descriptive failure messages.
+#[test]
+fn round_trip_every_string_field_with_every_whitespace_prefix() {
+    #[derive(Copy, Clone)]
+    enum Field {
+        Text,
+        SelectedText,
+        AnchoredText,
+    }
+    let fields = [Field::Text, Field::SelectedText, Field::AnchoredText];
+    let prefixes: &[&str] = &[" ", "\t", "  ", ""];
+    let body = "\nbody line two\nbody line three";
+
+    for (fi, field) in fields.iter().enumerate() {
+        for (pi, prefix) in prefixes.iter().enumerate() {
+            let value = format!("{prefix}content{body}");
+            let id = format!("c-{fi}-{pi}");
+            let comment = sample_comment_with(&id, |b| match field {
+                Field::Text => b.text = value.clone(),
+                Field::SelectedText => b.selected_text = Some(value.clone()),
+                Field::AnchoredText => b.anchored_text = Some(value.clone()),
+            });
+
+            let tmp = TempDir::new().unwrap();
+            let file_path = tmp.path().join("doc.md");
+            std::fs::write(&file_path, "# Test").unwrap();
+            save_sidecar(file_path.to_str().unwrap(), "doc.md", &[comment]).unwrap();
+            let loaded = load_sidecar(file_path.to_str().unwrap()).unwrap().unwrap();
+            let c = &loaded.comments[0];
+            let actual = match field {
+                Field::Text => c.text.clone(),
+                Field::SelectedText => c.selected_text.clone().unwrap_or_default(),
+                Field::AnchoredText => c.anchored_text.clone().unwrap_or_default(),
+            };
+            assert_eq!(
+                actual, value,
+                "round-trip failed: field={fi} prefix={pi:?} value={value:?}"
+            );
+        }
+    }
+}
+
+/// Validation guard fires when the repair pass would otherwise produce
+/// unparseable output. Pre-feed `validate_emitted_mrsf_yaml` a
+/// hand-crafted broken document; assert it returns `YamlParse`.
+#[test]
+fn emit_mrsf_yaml_round_trip_validation_rejects_unparseable_output() {
+    use super::io_guards::validate_emitted_mrsf_yaml;
+    // `id: x` at col 4, but `text:` at col 6 — inconsistent indent in
+    // the same map. saphyr's parser must reject this.
+    let broken = "comments:\n  - id: x\n      text: |2-\n  no indent\n";
+    let err =
+        validate_emitted_mrsf_yaml(broken).expect_err("validator must reject unparseable yaml");
+    assert!(
+        matches!(err, SidecarError::YamlParse(_)),
+        "expected YamlParse, got {:?}",
+        err
+    );
+}
+
+/// Structural round-trip equality check: emit then parse, the parsed
+/// JSON Value must `==` the input. Catches a hypothetical repair-pass
+/// bug that produces parseable-but-different YAML.
+#[test]
+fn emit_mrsf_yaml_round_trip_validates_structural_equality() {
+    let value = serde_json::json!({
+        "mrsf_version": "1.0",
+        "document": "test.md",
+        "comments": [{
+            "id": "c1",
+            "author": "test",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "text": "test comment",
+            "resolved": false,
+            "line": 1,
+            "selected_text": " leading space\nsecond line\nthird line",
+        }]
+    });
+    let yaml = emit_mrsf_yaml(&value).expect("must emit");
+    let re_parsed: serde_json::Value =
+        serde_saphyr::from_str(&yaml).expect("emitted yaml must parse");
+    assert_eq!(
+        re_parsed, value,
+        "structural round-trip mismatch: yaml=\n{yaml}"
+    );
 }


### PR DESCRIPTION
Ready to merge  release gate passed.

Closes #293