### PR TITLE
chore: add macOS platform best practices and update expert agents

### DIFF
--- a/.claude/agents/architect-expert.md
+++ b/.claude/agents/architect-expert.md
@@ -10,6 +10,7 @@ description: Reviews component boundaries, IPC contract, store design, and layer
 **Knowledge files:**
 - `docs/architecture.md` — layer boundaries, MVVM seam, IPC/logger chokepoints, state stratification, file-size budgets, MRSF schema, re-anchoring.
 - `docs/best-practices-common/tauri/v2-patterns.md` — `ipc-*`, `events-*`, `caps-*`, `windows-*`, `plugins-*` rule families.
+- `docs/best-practices-common/tauri/macos-platform.md` — `mac-menu-*`, `mac-lifecycle-*`, `mac-keys-*`, `mac-webview-*`, `mac-chrome-*` rule families.
 - `docs/best-practices-common/react/state-management.md` — slice boundaries, derived-state, single-writer.
 
 **Out of scope (handoff):**

--- a/.claude/agents/product-expert.md
+++ b/.claude/agents/product-expert.md
@@ -11,12 +11,14 @@ description: Reviews features against user needs (developers reviewing AI agent 
 - `docs/principles.md` — pillars + Non-Goals (canonical scope).
 - `docs/features/` — current capability surface (read the relevant area files for the diff).
 - `docs/best-practices-common/general/accessibility.md` — keyboard, focus, contrast.
+- `docs/best-practices-common/tauri/macos-platform.md` — macOS UX conventions (menu, lifecycle, keyboard).
 
 **Always check:**
 - Does the change expand toward a Non-Goal? BLOCK and cite.
 - Does it add user-visible affordance without a discoverable path (menu, shortcut, label)?
 - Friction: extra clicks, modal stack, broken keyboard path.
 - High-value gaps still missing for the reviewer use case.
+- **Platform parity:** Does the change work natively on BOTH macOS and Windows? A feature that only feels right on one platform is a product regression on the other.
 
 **Out of scope (handoff):**
 - Implementation correctness → `bug-expert` / `react-tauri-expert`.

--- a/.claude/agents/react-tauri-expert.md
+++ b/.claude/agents/react-tauri-expert.md
@@ -12,6 +12,7 @@ description: Reviews React 19 and Tauri v2 API usage — finds misused hooks, ou
 - `docs/best-practices-common/react/hooks-and-effects.md` — hook rules, effect lifecycle, refs, transitions.
 - `docs/best-practices-common/react/state-management.md` — derived state, lift-vs-collocate.
 - `docs/best-practices-common/tauri/v2-patterns.md` — IPC, events, capabilities, plugins, windows, fs.
+- `docs/best-practices-common/tauri/macos-platform.md` — macOS-specific: app menu, window lifecycle, WKWebView, distribution, keyboard.
 
 **Out of scope (handoff):**
 - Security implications → `security-expert`.

--- a/docs/best-practices-common/tauri/macos-platform.md
+++ b/docs/best-practices-common/tauri/macos-platform.md
@@ -1,0 +1,249 @@
+# Tauri v2 — macOS Platform Patterns
+
+Project-agnostic macOS-specific patterns for Tauri v2 apps. Cite a rule as `violates rule <rule-id> in docs/best-practices-common/tauri/macos-platform.md`.
+
+> **Scope:** macOS-specific guidance for Tauri v2. Windows-specific rules will live in a future `windows-platform.md`. Cross-platform rules live in [`v2-patterns.md`](v2-patterns.md).
+
+---
+
+## Menu Bar — `mac-menu-*`
+
+### `mac-menu-app-submenu-first`
+
+The **first submenu** in the menu bar MUST be the macOS "application menu" (the one to the right of the Apple logo, titled with the app name). On macOS, the OS **always** interprets the first submenu as the app menu regardless of the `text` label you provide.
+
+If you skip this and start with "File", macOS places your "File" items under the app-name menu, shifting everything else. The result looks broken.
+
+**Pattern (Rust):**
+```rust
+#[cfg(target_os = "macos")]
+{
+    let app_menu = SubmenuBuilder::new(handle, "mdownreview")
+        .about(None)           // PredefinedMenuItem::About
+        .separator()
+        .services()            // PredefinedMenuItem::Services
+        .separator()
+        .hide()                // PredefinedMenuItem::Hide
+        .hide_others()         // PredefinedMenuItem::HideOthers
+        .show_all()            // PredefinedMenuItem::ShowAll
+        .separator()
+        .quit()                // PredefinedMenuItem::Quit
+        .build()?;
+    menu_builder = menu_builder.item(&app_menu);
+}
+```
+
+**On Windows:** Do NOT include this submenu — Windows has no app-name menu concept. Use `#[cfg(target_os = "macos")]` or runtime detection.
+
+### `mac-menu-edit-submenu`
+
+macOS requires an "Edit" menu with standard text-editing items (Undo, Redo, Cut, Copy, Paste, Select All) for **clipboard and text input to work correctly in webview input fields**. Without this, Cmd+C/Cmd+V may not function in `<input>` / `<textarea>` elements.
+
+**Pattern:**
+```rust
+let edit_menu = SubmenuBuilder::new(handle, "Edit")
+    .undo()
+    .redo()
+    .separator()
+    .cut()
+    .copy()
+    .paste()
+    .select_all()
+    .build()?;
+```
+
+Include this on macOS unconditionally. On Windows, WebView2 handles clipboard shortcuts natively without a menu, but including the Edit menu is still recommended for discoverability.
+
+### `mac-menu-no-quit-in-file`
+
+On macOS, "Quit" belongs in the **app menu** (first submenu), not in "File". Users expect Cmd+Q to originate from the app-name menu. Having a duplicate "Quit" in the File menu is non-native and confusing.
+
+On Windows, "Exit" or "Quit" at the bottom of the File menu is standard. Use conditional compilation:
+```rust
+#[cfg(not(target_os = "macos"))]
+file_menu_builder = file_menu_builder.separator().quit();
+```
+
+### `mac-menu-settings-placement`
+
+On macOS, "Settings…" (or "Preferences…") belongs in the **app menu** with the accelerator Cmd+Comma. On Windows, "Settings…" lives in the File menu (or a dedicated Tools menu). The accelerator `CmdOrCtrl+,` works cross-platform, but placement must differ:
+
+```rust
+#[cfg(target_os = "macos")]
+// Add settings item to the app submenu
+app_menu_builder = app_menu_builder.item(&settings_item);
+
+#[cfg(not(target_os = "macos"))]
+// Add settings item to the File submenu
+file_menu_builder = file_menu_builder.separator().item(&settings_item);
+```
+
+### `mac-menu-window-submenu`
+
+macOS expects a "Window" menu with at minimum: Minimize, Zoom (or Fullscreen toggle), separator, Bring All to Front. The OS appends a dynamic window list below your items automatically when the submenu is titled "Window".
+
+---
+
+## Window Lifecycle — `mac-lifecycle-*`
+
+### `mac-lifecycle-close-hides`
+
+On macOS, closing the **last window** MUST NOT quit the app. The standard Mac convention is: the app stays running (Dock icon remains), and clicking the Dock icon or Cmd+Tab reopening shows the window again. Only Cmd+Q (or Menu → Quit) exits.
+
+**Implementation:** Handle `RunEvent::WindowEvent { event: WindowEvent::CloseRequested { api, .. }, .. }` in the `.run()` callback:
+```rust
+#[cfg(target_os = "macos")]
+{
+    api.prevent_close();
+    window.hide().unwrap();
+}
+```
+
+On Windows, closing the last window quits the app (the standard convention). No special handling needed.
+
+### `mac-lifecycle-reopen-on-activate`
+
+When the user clicks the Dock icon while the app is running but has no visible windows, macOS emits `RunEvent::Reopen { has_visible_windows: false, .. }`. The app MUST handle this by showing or recreating the main window.
+
+```rust
+tauri::RunEvent::Reopen { has_visible_windows, .. } => {
+    if !has_visible_windows {
+        if let Some(win) = app_handle.get_webview_window("main") {
+            win.show().unwrap();
+            win.set_focus().unwrap();
+        }
+    }
+}
+```
+
+### `mac-lifecycle-quit-explicit`
+
+The macOS app should only fully exit when:
+1. User selects Quit from the app menu (Cmd+Q)
+2. `PredefinedMenuItem::quit()` triggers the exit
+3. Code calls `app.exit(0)` explicitly
+
+Do NOT tie app exit to the last window closing on macOS.
+
+---
+
+## Keyboard & Accelerators — `mac-keys-*`
+
+### `mac-keys-cmd-not-ctrl`
+
+Always use `CmdOrCtrl` in Tauri accelerator strings for cross-platform shortcuts. This maps to ⌘ on macOS and Ctrl on Windows. Never hardcode `Cmd+` or `Ctrl+`.
+
+### `mac-keys-platform-conventions`
+
+Some keyboard conventions differ by platform. Common macOS expectations:
+- **Cmd+Q** → Quit (via app menu, not File)
+- **Cmd+,** → Settings/Preferences (via app menu)
+- **Cmd+H** → Hide app (system-level, via app menu PredefinedMenuItem)
+- **Cmd+W** → Close window/tab
+- **Cmd+M** → Minimize
+- **Cmd+`** → Cycle windows (system-level, no code needed)
+- **Ctrl+Tab** / **Ctrl+Shift+Tab** → Next/Previous tab (differs from Windows Ctrl+Tab)
+
+### `mac-keys-function-keys`
+
+Function keys (F1–F12) on macOS require holding Fn by default (they trigger media/brightness otherwise). If you bind F12 to an action (e.g., DevTools), document that users may need Fn+F12 unless they change system settings.
+
+---
+
+## Webview (WKWebView) — `mac-webview-*`
+
+### `mac-webview-clipboard-requires-edit-menu`
+
+WKWebView on macOS requires a native "Edit" menu with Copy/Paste/Cut/SelectAll predefined items for clipboard keyboard shortcuts to reach webview text inputs. Without the Edit menu, Cmd+C/V/X may be swallowed by the native menu system and never reach the web content.
+
+This is the most common "clipboard doesn't work on Mac" bug in Tauri apps.
+
+### `mac-webview-focus-quirks`
+
+WKWebView may lose focus more easily than WebView2 (Windows). Known scenarios:
+- After a native dialog closes (file picker, alert)
+- During drag-and-drop operations
+- After menu interaction
+
+Mitigation: After any native dialog completes, explicitly call `window.set_focus()` from Rust or dispatch a refocus event to the frontend.
+
+### `mac-webview-drag-drop`
+
+File drag-and-drop in WKWebView may not propagate `drop` events to JS listeners as reliably as WebView2. If drag-and-drop is critical:
+- Test on macOS specifically
+- Consider handling drops on the native (Rust) side and forwarding file paths via IPC
+- Ensure `preventDefault()` is called on `dragover` events
+
+---
+
+## Distribution — `mac-dist-*`
+
+### `mac-dist-universal-binary`
+
+Ship a universal binary (`--target universal-apple-darwin`) to support both Apple Silicon (aarch64) and Intel (x86_64) Macs from a single `.app` bundle. Build with:
+```bash
+cargo tauri build --target universal-apple-darwin
+```
+
+### `mac-dist-code-signing`
+
+All macOS distributions MUST be code-signed. For development/ad-hoc: use `signingIdentity: "-"` in `tauri.conf.json`. For distribution: use a Developer ID Application certificate.
+
+Unsigned/ad-hoc-signed apps trigger Gatekeeper warnings and cannot be notarized.
+
+### `mac-dist-notarization`
+
+For public distribution (outside the App Store), the `.app` and `.dmg` MUST be notarized with Apple. This involves:
+1. Code signing with a Developer ID certificate
+2. Submitting to Apple's notary service (`xcrun notarytool submit`)
+3. Stapling the ticket (`xcrun stapler staple`)
+
+Without notarization, macOS Sequoia+ will refuse to open the app without manual security override.
+
+### `mac-dist-entitlements`
+
+Tauri apps using WKWebView need at minimum:
+- `com.apple.security.cs.allow-jit` — required for WebKit JIT
+- Network entitlements only if the app makes network requests (updater, etc.)
+
+Do NOT include `com.apple.security.cs.disable-library-validation` unless absolutely required.
+
+### `mac-dist-dmg-conventions`
+
+macOS DMGs should include:
+- A symbolic link to `/Applications` for drag-install
+- A background image showing the install gesture
+- The `.app` bundle (not a bare binary)
+- Optionally a `README.txt`
+
+---
+
+## Titlebar & Chrome — `mac-chrome-*`
+
+### `mac-chrome-decorations-true`
+
+Use `decorations: true` (the default) for standard macOS traffic-light buttons and title bar. Custom titlebars (`decorations: false`) break:
+- Native fullscreen (green button)
+- Traffic light positioning on notched displays
+- OS-level window snapping (macOS Sequoia+)
+
+Only disable decorations if you have a compelling UX reason AND test on all Mac hardware variants.
+
+### `mac-chrome-title-vs-filename`
+
+macOS shows the window title in the title bar and in Mission Control / Cmd+Tab. Keep it short and informative (app name + current context). Avoid long paths — use the folder/file display name, not the full canonical path.
+
+---
+
+## Testing — `mac-test-*`
+
+### `mac-test-arm-and-intel`
+
+CI should test on both `macos-latest` (ARM) and `macos-13` (Intel) GitHub Actions runners, or use a universal binary to cover both architectures.
+
+### `mac-test-menu-integration`
+
+Menu-driven features (open file, close tab, toggle pane) cannot be tested through Playwright alone — Playwright controls the webview, not the native menu bar. Use:
+- Keyboard shortcuts (which Playwright can send) as a proxy
+- Tauri's `emit` to simulate menu events in browser-mode tests
+- Native E2E tests (WebDriver/CDP on a real binary) for full menu coverage

--- a/docs/best-practices-common/tauri/v2-patterns.md
+++ b/docs/best-practices-common/tauri/v2-patterns.md
@@ -184,3 +184,11 @@ Window creation (`WebviewWindowBuilder::build()`) runs on the main thread and ma
 - Do NOT acquire locks that IPC handlers also need
 - Do NOT perform I/O (file scanning, canonicalization) synchronously before or after `build()`
 - Move any post-creation setup (arg pushing, event emission) to be as fast as possible
+
+## Platform-Specific Cross-References
+
+| Platform | Document |
+|----------|----------|
+| macOS | [`macos-platform.md`](macos-platform.md) — app menu structure, window lifecycle (close-hides), WKWebView quirks, distribution, keyboard conventions |
+
+Menu construction, window close behavior, and clipboard handling differ significantly between macOS and Windows. Always use `#[cfg(target_os = "...")]` or runtime detection to branch platform-specific logic. Never assume Windows behavior is universal.


### PR DESCRIPTION
## Summary

Adds comprehensive macOS-specific Tauri v2 best practices documentation and updates expert agents to include the new knowledge file in their review dispatch.

## Background

Investigation revealed that the app's menu system doesn't work correctly on macOS because `build_window_menu` starts with "File" as the first submenu. On macOS, the OS always hijacks the first submenu as the app-name menu — so our "File" items end up under the app name, and everything shifts.

## Changes

### New: `docs/best-practices-common/tauri/macos-platform.md`
25 rules across 6 areas:
- **Menu Bar** (`mac-menu-*`) — app submenu must be first; Edit menu required for clipboard; platform-conditional Quit/Settings placement
- **Window Lifecycle** (`mac-lifecycle-*`) — close-hides convention; Reopen/Activate for Dock clicks
- **Keyboard** (`mac-keys-*`) — CmdOrCtrl; platform conventions; Fn key for function keys
- **WKWebView** (`mac-webview-*`) — clipboard requires Edit menu; focus quirks; drag-drop differences
- **Distribution** (`mac-dist-*`) — universal binary; code signing; notarization; entitlements; DMG
- **Chrome/Titlebar** (`mac-chrome-*`) — keep decorations:true; short window titles

### Updated
- `v2-patterns.md` — added platform cross-reference section
- `react-tauri-expert.md` — added macOS platform file to knowledge dispatch
- `architect-expert.md` — added macOS platform file to knowledge dispatch
- `product-expert.md` — added macOS platform file + "platform parity" check

## Next Steps (separate PRs)
- Fix `build_window_menu` in `lib.rs` to prepend macOS app submenu and add Edit menu
- Handle `RunEvent::Reopen` for Dock click window restoration
- Implement close-hides behavior on macOS