### PR TITLE
chore(skills): merge-pr-loop now rebases stale PRs onto origin/main

### DIFF
--- a/.claude/skills/iterate-one-issue/SKILL.md
+++ b/.claude/skills/iterate-one-issue/SKILL.md
@@ -17,7 +17,7 @@ Let `ARG` = trimmed string after skill name. First match wins:
 
 | Pattern | Result |
 |---|---|
-| `^--resume-pr\s+(\S+)$` | `MODE=resume-pr`, `PR_REF=$1` (number, `#N`, or PR URL). Skips 0c–0h and Phase 1; jumps to [Phase R — release-gate forward-fix](#phase-r--release-gate-forward-fix-mode-resume-pr). Caller pre-conditions: clean tree on `main` · the referenced PR carries the `iterate-pr` label · the PR's most recent `release-gate.yml` run failed (or the caller wants this skill to inspect it). Used by `merge-pr-loop` to drive forward-fixes. |
+| `^--resume-pr\s+(\S+)$` | `MODE=resume-pr`, `PR_REF=$1` (number, `#N`, or PR URL). Skips 0c–0h and Phase 1; jumps to [Phase R — release-gate forward-fix](#phase-r--release-gate-forward-fix-mode-resume-pr). Caller pre-conditions: clean tree on `main` · the referenced PR carries the `iterate-pr` label · **either** the PR's most recent `release-gate.yml` run failed (forward-fix sub-mode) **or** the PR branch is behind `origin/main` (rebase-only sub-mode). Used by `merge-pr-loop` to drive forward-fixes (Step 4) and rebase-conflict resolution (Step 3.5). |
 | `^\d+$` | `MODE=issue`, `ISSUE_NUMBER=ARG` |
 | `^#(\d+)$` | `MODE=issue`, group 1 |
 | `^[Ii]ssue-(\d+)$` | `MODE=issue`, group 1 |
@@ -619,7 +619,20 @@ Append to Step 8 comment (link local path, not blob URL — retro is uncommitted
 
 ## Phase R — Release-gate forward-fix mode (`--resume-pr`)
 
-Entered from Phase 0a when `MODE=resume-pr`. Skips Phase 0c–0h (no spec, no new branch, no PR creation) and Phase 1 (no goal-assessor loop). Performs **one** forward-fix pass against the latest failed `release-gate.yml` run on the referenced PR's branch, commits + pushes, and exits with `Done-ForwardFixed` for the caller (`merge-pr-loop`) to re-dispatch the gate.
+Entered from Phase 0a when `MODE=resume-pr`. Skips Phase 0c–0h (no spec, no new branch, no PR creation) and Phase 1 (no goal-assessor loop).
+
+Phase R has **two sub-modes**, auto-selected at R3 based on what's wrong with the PR:
+
+| Sub-mode | Trigger (R3) | What runs | Exit |
+|---|---|---|---|
+| **forward-fix** | Latest `release-gate.yml` run on the branch is `failure` | R3 → R4 (logs) → R5 (rebase if behind) → R6 (`exe-task-implementer` consumes failed-job logs) → R7 (commit + push) → R8 | `Done-ForwardFixed` |
+| **rebase-only** | No failed gate run **and** branch is behind `origin/main` | R3 → R5 (rebase + per-file conflict resolver) → R7 (push only, no commit) → R8 | `Done-ForwardFixed` |
+
+In both sub-modes the skill writes a `<!-- iterate-forward-fix-attempt -->` marker and the caller (`merge-pr-loop`) re-dispatches the gate. Both sub-modes share the same 5/PR attempt budget.
+
+**Phase R always rebases against the freshest `origin/main`** at the time R5 runs — not whatever snapshot the caller saw. If `origin/main` advanced again between the caller's behind-check and R5, that's fine: rebasing onto the newer main is exactly what we want.
+
+**Phase R does not increment the `.claude/iterate-recursion-depth` marker** (Phase 0b's hygiene step ages out stale markers but Phase R is single-pass, not recursive). The caller (`merge-pr-loop` Step 3.5 or Step 4.3) drives all retries.
 
 ### R0 — Pre-flight
 
@@ -651,29 +664,59 @@ fi
 
 If at cap: post a Done-Blocked PR comment (reason `release-gate forward-fix budget exhausted (5 attempts)`), emit `ITERATE_OUTCOME: Done-Blocked issue=n/a branch=$BRANCH pr=$PR_URL`, exit. (No `blocked` label on the source issue from this mode — merge-pr-loop owns that decision.)
 
-### R2 — Check out branch
+### R2 — Check out branch (stateless, remote-authoritative)
+
+Always reset the local branch to `origin/$BRANCH` so a stale local tracking ref or earlier interrupted run cannot poison this pass:
 
 ```bash
 git fetch origin "$BRANCH"
-git checkout "$BRANCH"
-git pull --ff-only
+git checkout -B "$BRANCH" "origin/$BRANCH"
 git config rerere.enabled true
 git config rerere.autoupdate true
+OLD_REMOTE_SHA=$(git rev-parse "origin/$BRANCH")   # captured for SHA-bound --force-with-lease in R7
 ```
 
-If the branch is gone or `pull --ff-only` fails (force-push from another session): emit `ITERATE_OUTCOME: Done-Blocked issue=n/a branch=$BRANCH pr=$PR_URL` (reason `branch missing or diverged`), exit.
+If the remote branch is gone (`git fetch` fails for it): emit `ITERATE_OUTCOME: Done-Blocked issue=n/a branch=$BRANCH pr=$PR_URL` (reason `branch missing or diverged`), exit.
 
-### R3 — Locate the failing release-gate run
+### R3 — Locate the failing release-gate run (or detect rebase-only trigger)
+
+Filter on the **current HEAD SHA** so an older failed run (from a prior commit on this branch that has since been forward-fixed) does not falsely re-trigger forward-fix mode and apply stale logs to the current tree:
 
 ```bash
-RG_RUN_ID=$(gh run list --workflow=release-gate.yml --branch "$BRANCH" --limit 5 \
+CURRENT_SHA=$(git rev-parse HEAD)
+RG_RUN_ID=$(gh run list --workflow=release-gate.yml --branch "$BRANCH" --limit 10 \
   --json databaseId,status,conclusion,headSha,createdAt \
-  --jq '[.[] | select(.status == "completed" and .conclusion == "failure")] | sort_by(.createdAt) | reverse | .[0].databaseId // empty')
+  --jq "[.[] | select(.status == \"completed\" and .conclusion == \"failure\" and .headSha == \"$CURRENT_SHA\")] | sort_by(.createdAt) | reverse | .[0].databaseId // empty")
 ```
 
-If empty: nothing to fix here. Emit `ITERATE_OUTCOME: Done-Blocked issue=n/a branch=$BRANCH pr=$PR_URL` (reason `no failed release-gate run found for branch`), exit. merge-pr-loop should re-dispatch and re-call.
+Sub-mode dispatch:
 
-### R4 — Pull failed-job logs
+```bash
+if [ -n "$RG_RUN_ID" ]; then
+  REBASE_ONLY=false
+  # Forward-fix sub-mode — fall through to R4.
+else
+  # No failed gate at the current HEAD. Maybe merge-pr-loop's Step 3.5 invoked us because the branch is behind main.
+  git fetch origin main
+  BEHIND=$(git rev-list --count "HEAD..origin/main")
+  if [ "$BEHIND" -gt 0 ]; then
+    REBASE_ONLY=true
+    FAIL_LOGS=""
+    FAILED_JOBS="rebase-only ($BEHIND commits behind origin/main)"
+    # Skip R4 and R6; jump to R5.
+  else
+    # Nothing for us to do — emit Done-Blocked.
+    # ITERATE_OUTCOME: Done-Blocked issue=n/a branch=$BRANCH pr=$PR_URL
+    # reason: `no failed release-gate run found for current HEAD and branch is up to date with origin/main`
+    # See done-handlers.md.
+    exit
+  fi
+fi
+```
+
+### R4 — Pull failed-job logs *(forward-fix sub-mode only)*
+
+Skip entirely when `REBASE_ONLY=true` (no logs to pull).
 
 ```bash
 FAIL_LOGS=$(gh run view "$RG_RUN_ID" --log-failed | tail -n 200)
@@ -684,14 +727,23 @@ FAILED_JOBS=$(gh run view "$RG_RUN_ID" --json jobs --jq '[.jobs[] | select(.conc
 
 ```bash
 git fetch origin main
+REBASE_HAPPENED=false
 if ! git merge-base --is-ancestor origin/main HEAD; then
   git rebase --strategy=recursive --strategy-option=diff3 origin/main
-  # On conflict: reuse Step 1's conflict-resolver loop. If unresolvable, emit
-  # ITERATE_OUTCOME: Done-Blocked reason=`forward-fix rebase against origin/main failed`.
+  REBASE_HAPPENED=true
+  # On conflict: reuse Step 1's conflict-resolver loop (per-file `exe-task-implementer` dispatch,
+  # `attempt < max_attempts_per_commit=3` per file, `commits_replayed < max_total_commits=20`,
+  # `architect-expert` escalation once at max). If still unresolvable:
+  #   git rebase --abort
+  #   ITERATE_OUTCOME: Done-Blocked reason=`forward-fix rebase against origin/main failed`.
 fi
 ```
 
-### R6 — Forward-fix
+In **rebase-only** sub-mode, R5 is the work — the rebase + conflict resolver is the entire job for this pass.
+
+### R6 — Forward-fix *(forward-fix sub-mode only)*
+
+Skip entirely when `REBASE_ONLY=true` (no failed-job logs to act on; the rebase itself was the fix).
 
 Spawn `exe-task-implementer`:
 ```
@@ -708,22 +760,46 @@ If the implementer reports no-op (nothing to fix in the failing logs): emit `ITE
 
 ### R7 — Commit + push
 
+`OLD_REMOTE_SHA` was captured at R2 — use it for an explicit SHA-bound `--force-with-lease` so a concurrent `git fetch` in this repo cannot relax the safety check:
+
 ```bash
 git add -A
-git commit -m "fix(iter-release): <one-line implementer summary>
+if [ "$REBASE_ONLY" = "true" ]; then
+  # Rebase-only: nothing to commit, just push the rebased branch.
+  # SHA-bound lease — accept the push iff origin/$BRANCH still equals what we observed at R2.
+  git push --force-with-lease="$BRANCH:$OLD_REMOTE_SHA" origin "HEAD:refs/heads/$BRANCH"
+elif [ "$REBASE_HAPPENED" = "true" ]; then
+  # Forward-fix sub-mode after a rebase: commit the fix, then SHA-bound force-push (history was rewritten).
+  git commit -m "fix(iter-release): <one-line implementer summary>
 
 <body>
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-git push
+  git push --force-with-lease="$BRANCH:$OLD_REMOTE_SHA" origin "HEAD:refs/heads/$BRANCH"
+else
+  # Forward-fix sub-mode without rebase: regular fast-forward push.
+  git commit -m "fix(iter-release): <one-line implementer summary>
+
+<body>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+  git push
+fi
 NEW_HEAD=$(git rev-parse HEAD)
 ```
 
 ### R8 — Mark attempt + exit
 
+Marker text varies by sub-mode (caller parses by counting markers, not by reading text — text is for humans):
+
 ```bash
-gh pr comment "$PR_NUMBER" --body "<!-- iterate-forward-fix-attempt -->
+if [ "$REBASE_ONLY" = "true" ]; then
+  gh pr comment "$PR_NUMBER" --body "<!-- iterate-forward-fix-attempt -->
+🔧 Release-gate forward-fix attempt $((ATTEMPTS + 1))/5 on commit \`$(git rev-parse --short HEAD)\` (rebase-only — was $BEHIND commit(s) behind origin/main). merge-pr-loop will re-dispatch the gate."
+else
+  gh pr comment "$PR_NUMBER" --body "<!-- iterate-forward-fix-attempt -->
 🔧 Release-gate forward-fix attempt $((ATTEMPTS + 1))/5 on commit \`$(git rev-parse --short HEAD)\` (failed run [<RG_RUN_ID>](https://github.com/dryotta/mdownreview/actions/runs/<RG_RUN_ID>)). merge-pr-loop will re-dispatch the gate."
+fi
 ```
 
 Emit:

--- a/.claude/skills/iterate-one-issue/references/done-handlers.md
+++ b/.claude/skills/iterate-one-issue/references/done-handlers.md
@@ -165,9 +165,12 @@ Then exit cleanly.
 
 ### Done-ForwardFixed
 
-Reached only from **Phase R** (`--resume-pr` mode). The forward-fix wave produced a new commit on the PR branch; merge-pr-loop should re-dispatch the release gate against `commit=<sha>`.
+Reached only from **Phase R** (`--resume-pr` mode), in either of two sub-modes:
 
-Phase R already wrote the `<!-- iterate-forward-fix-attempt -->` comment and pushed. No banner beyond the outcome marker. **Phase 2 is skipped** — single-pass forward-fixes lack signal density, and the eventual merge-pr-loop merge or its own Done-Blocked emits a retro.
+- **forward-fix sub-mode** — the forward-fix wave produced a new commit on the PR branch (gate logs informed an `exe-task-implementer` fix); merge-pr-loop should re-dispatch the release gate against `commit=<sha>`.
+- **rebase-only sub-mode** — no failed gate run was found but the branch was behind `origin/main`; Phase R rebased the branch (clean or via the per-file conflict resolver) and force-pushed. `commit=<sha>` is the rebased HEAD. merge-pr-loop should re-dispatch the gate on the rebased commit.
+
+In both cases Phase R already wrote the `<!-- iterate-forward-fix-attempt -->` comment and pushed. No banner beyond the outcome marker. **Phase 2 is skipped** — single-pass forward-fixes lack signal density, and the eventual merge-pr-loop merge or its own Done-Blocked emits a retro.
 
 ```
 ITERATE_OUTCOME: Done-ForwardFixed issue=n/a branch=<BRANCH> pr=<URL> commit=<NEW_HEAD>

--- a/.claude/skills/iterate-one-issue/references/halt-semantics.md
+++ b/.claude/skills/iterate-one-issue/references/halt-semantics.md
@@ -8,7 +8,7 @@
 
 **Halt (loop ends, Phase 2 skipped):**
 - Phase R (`--resume-pr`) success → `Done-ForwardFixed`
-- Phase R (`--resume-pr`) failure (no failed run, missing branch, no-op fix, attempt cap) → `Done-Blocked`
+- Phase R (`--resume-pr`) failure (no failed run AND branch up to date with origin/main, missing branch, no-op fix, attempt cap, unresolvable rebase conflict) → `Done-Blocked`
 
 **`DEGRADED` (continue):**
 - Validate/CI/experts fails to converge after 5 forward-fix waves (Step 6d — single merged loop)

--- a/.claude/skills/merge-pr-loop/SKILL.md
+++ b/.claude/skills/merge-pr-loop/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: merge-pr-loop
-description: Use when the user wants the agent to ship the iterate PR backlog autonomously — phrases like "merge the ready PRs", "ship the iterate PRs", "run the release gate on everything ready", or an empty `/merge-pr-loop`. Continuous (default) or single-pass (`--once`). Picks the next open ready-for-review PR labelled `iterate-pr`, dispatches the Release Gate, polls to completion, drives forward-fixes via `/iterate-one-issue --resume-pr <PR>` on failure (cap 5/PR), squash-merges on green. Never prompts. Never writes app source. Pair with `/iterate-loop` in another terminal — that loop produces the PRs this one ships.
+description: Use when the user wants the agent to ship the iterate PR backlog autonomously — phrases like "merge the ready PRs", "ship the iterate PRs", "run the release gate on everything ready", or an empty `/merge-pr-loop`. Continuous (default) or single-pass (`--once`). Picks the next open ready-for-review PR labelled `iterate-pr`, **rebases stale PR branches onto `origin/main` (clean rebases inline; conflicts delegate to `/iterate-one-issue --resume-pr`)**, dispatches the Release Gate, polls to completion, drives forward-fixes via `/iterate-one-issue --resume-pr <PR>` on failure (cap 5/PR), squash-merges on green. Never prompts. Never writes app source. Pair with `/iterate-loop` in another terminal — that loop produces the PRs this one ships.
 ---
 
-**RIGID. Fully autonomous — never calls `ask_user`.** Owns the **release-gate + merge** lifecycle for PRs opened by `iterate-one-issue`. Picks ready-for-review PRs labelled `iterate-pr`, validates each via the signed-installer Release Gate, drives forward-fixes when the gate fails, squash-merges on green.
+**RIGID. Fully autonomous — never calls `ask_user`.** Owns the **release-gate + merge** lifecycle for PRs opened by `iterate-one-issue`. Picks ready-for-review PRs labelled `iterate-pr`, rebases them onto `origin/main` if behind, validates each via the signed-installer Release Gate, drives forward-fixes when the gate fails, squash-merges on green.
 
-This skill never writes app source — every fix is delegated to `/iterate-one-issue --resume-pr <PR>`.
+This skill never writes app source — every code fix is delegated to `/iterate-one-issue --resume-pr <PR>`. The skill *does* perform `git rebase origin/main` + `git push --force-with-lease` on PR branches when they are behind main and the rebase is conflict-free; conflict resolution is also delegated to `/iterate-one-issue --resume-pr` (which has a per-file conflict-resolver loop). A clean rebase rewrites commit metadata only — it never modifies file contents.
 
 ---
 
@@ -104,12 +104,13 @@ gh pr edit $PICK --add-label "merge-pr-in-progress"
 
 If the label add fails (race with another agent or label removed mid-flight), log `[merge-pr-loop] failed to claim PR #$PICK — skipping this round` and loop back to Step 1.
 
-Capture PR metadata (used throughout the round):
+Capture PR metadata + per-PR counters (used throughout the round):
 ```bash
 gh pr view "$PICK" --json number,headRefName,headRefOid,url > /tmp/merge-pr-$PICK.json
 BRANCH=$(jq -r '.headRefName' /tmp/merge-pr-$PICK.json)
 PR_URL=$(jq -r '.url'         /tmp/merge-pr-$PICK.json)
 HEAD_SHA=$(jq -r '.headRefOid' /tmp/merge-pr-$PICK.json)
+MERGE_RACE_RETRIES=0   # cap=1; bumped each time we re-enter Step 3.5 from a Step 5 race-detect
 ```
 
 ### Step 3 — Pre-flight `main` (re-sync between rounds)
@@ -122,6 +123,56 @@ If pull fails (local main diverged from origin), STOP `[merge-pr-loop] main has 
 ```bash
 gh pr edit $PICK --remove-label "merge-pr-in-progress"
 ```
+
+### Step 3.5 — Rebase if behind (proactive)
+
+GitHub branch protection often requires `head branch is up to date with base` before merge. If main moved between PR creation and now, dispatching the gate on the unrebased SHA wastes a ~30 min run only to fail at Step 5. So rebase first, then dispatch on the rebased commit.
+
+```bash
+git fetch origin "$BRANCH" main
+PR_BEHIND=$(git rev-list --count "origin/$BRANCH..origin/main")
+```
+
+If `PR_BEHIND -eq 0`: skip to Step 4.
+
+If `PR_BEHIND -gt 0`: attempt a **clean** rebase inline (no conflict resolver — that's iterate-one-issue's job):
+
+```bash
+OLD_REMOTE_SHA=$(git rev-parse "origin/$BRANCH")     # used for SHA-bound --force-with-lease below
+git checkout -B "$BRANCH" "origin/$BRANCH"
+if git rebase origin/main; then
+  # Clean rebase. Push the rebased branch with an explicit SHA-bound lease so a concurrent fetch can't relax the safety check.
+  git push --force-with-lease="$BRANCH:$OLD_REMOTE_SHA" origin "HEAD:refs/heads/$BRANCH"
+  HEAD_SHA=$(git rev-parse HEAD)
+  git checkout main
+  gh pr comment "$PICK" --body "<!-- merge-pr-rebased -->
+🔄 Rebased onto main (was $PR_BEHIND commit(s) behind). New head: \`$(git rev-parse --short "$HEAD_SHA")\`. Dispatching release-gate."
+  # Continue to Step 4 with refreshed HEAD_SHA.
+else
+  # Conflict — abort and delegate to iterate-one-issue --resume-pr,
+  # which has a per-file conflict-resolver loop (subagents) and pushes the rebased branch on success.
+  git rebase --abort 2>/dev/null
+  git checkout main
+
+  # Per-PR forward-fix budget applies (same 5/PR cap as Step 4).
+  ATTEMPTS=$(gh pr view "$PICK" --json comments --jq '[.comments[].body | select(contains("<!-- iterate-forward-fix-attempt -->"))] | length')
+  if [ "$ATTEMPTS" -ge 5 ]; then
+    # Step 6 — block, reason `rebase conflict and forward-fix budget exhausted (5 attempts)`.
+  fi
+
+  # Spawn `iterate-one-issue --resume-pr "$PICK"` synchronously in the foreground.
+  # Detect path: iterate-one-issue's Phase R sees no failed gate at the current HEAD but a behind branch
+  # and runs in rebase-only mode — R5 rebase + conflict resolver, R7 SHA-bound force-push, R8 marker,
+  # exit Done-ForwardFixed. Phase R always rebases against the freshest origin/main visible at R5,
+  # so a race between this abort and R5 is benign.
+  # Routing mirrors Step 4.3:
+  # - Done-ForwardFixed commit=<sha>: refresh HEAD_SHA, PRS_FORWARD_FIXED += 1, continue to Step 4.
+  # - Done-Blocked: Step 6 — block (reason from inner skill, e.g. `forward-fix rebase against origin/main failed`).
+  # - Other / parse failure: Step 6 — block, reason `unrecognised outcome from iterate-one-issue --resume-pr (rebase-only)`.
+fi
+```
+
+Detailed routing of the inner-skill outcome marker is identical to Step 4.3 — see [references/release-gate.md](references/release-gate.md).
 
 ### Step 4 — Release-gate + forward-fix loop
 
@@ -141,6 +192,21 @@ Detailed flow: [references/release-gate.md](references/release-gate.md). High le
 
 When the release-gate run completes with `conclusion=success`:
 
+0. **Pre-merge race check** — main may have moved while the ~30 min gate was running. If the PR is now behind, the squash-merge will fail with `head branch is not up to date`:
+   ```bash
+   git fetch origin "$BRANCH" main
+   PR_BEHIND_NOW=$(git rev-list --count "origin/$BRANCH..origin/main")
+   ```
+   - `PR_BEHIND_NOW -eq 0`: branch is current, proceed to step 1 below.
+   - `PR_BEHIND_NOW -gt 0` and `MERGE_RACE_RETRIES -lt 1`:
+     ```bash
+     MERGE_RACE_RETRIES=$((MERGE_RACE_RETRIES + 1))
+     gh pr comment "$PICK" --body "<!-- merge-pr-race-retry -->
+     ⚠️ Main moved during the release-gate run. Rebasing + re-dispatching ($MERGE_RACE_RETRIES/1)."
+     ```
+     Loop back to **Step 3.5** (rebase + re-dispatch the gate on the rebased commit + re-poll). The rebase counter is independent of the forward-fix budget — race-retries don't write `<!-- iterate-forward-fix-attempt -->` markers unless a conflict triggers iterate-one-issue.
+   - `PR_BEHIND_NOW -gt 0` and `MERGE_RACE_RETRIES -ge 1`: halt this PR (Step 6 — block, reason `main moved during release-gate run; merge race retries exhausted (1)`).
+
 1. **Refresh PR body** — preserve `Closes #<N>` trailer; replace summary with `Ready to merge — release gate passed.`:
    ```bash
    gh pr edit "$PICK" --body "<refreshed body>"
@@ -153,8 +219,16 @@ When the release-gate run completes with `conclusion=success`:
 3. **Squash-merge**:
    ```bash
    gh pr merge "$PICK" --squash --delete-branch
+   MERGE_EXIT=$?
    ```
-   On non-zero exit (race, branch-protection regressed): log + halt this PR (Step 6 — block, reason `gh pr merge failed: <stderr first line>`). Do **not** retry mid-loop.
+   On non-zero exit:
+   - **If `MERGE_RACE_RETRIES -lt 1`**: a third-party race likely landed a commit on main between Step 5.0's check and `gh pr merge` (or branch-protection produced an "out of date" error Step 5.0 missed). Increment `MERGE_RACE_RETRIES`, comment, and **loop back to Step 3.5** — Step 5.0 on the retry will confirm the actual state.
+     ```bash
+     MERGE_RACE_RETRIES=$((MERGE_RACE_RETRIES + 1))
+     gh pr comment "$PICK" --body "<!-- merge-pr-race-retry -->
+     ⚠️ \`gh pr merge\` failed (third-party race after Step 5.0 check). Rebasing + re-dispatching ($MERGE_RACE_RETRIES/1)."
+     ```
+   - **If `MERGE_RACE_RETRIES -ge 1`**: log + halt this PR (Step 6 — block, reason `gh pr merge failed: <stderr first line>`). Do **not** retry mid-loop.
 4. **Cleanup labels** (defensive — branch deletion already cascaded most state):
    ```bash
    gh pr edit "$PICK" --remove-label "merge-pr-in-progress" 2>/dev/null || true
@@ -259,8 +333,11 @@ Retrospective: $RETRO_FILE
 
 **Per-PR soft skips / blocks (loop continues):**
 - Claim label add fails at Step 2 (race — log + skip).
+- Step 3.5 rebase conflict + forward-fix budget exhausted (5/5) → block this PR, continue.
+- Step 3.5 `iterate-one-issue --resume-pr` returns `Done-Blocked` (e.g. `forward-fix rebase against origin/main failed`) → block this PR with the inner reason, continue.
 - Release-gate dispatch fails (Step 4) → block this PR, continue.
 - Forward-fix budget exhausted (Step 4) → block this PR, continue.
+- Step 5 merge race retries exhausted (`MERGE_RACE_RETRIES >= 1`) → block this PR, continue.
 - `gh pr merge` fails (Step 5) → block this PR, continue.
 - Inner `iterate-one-issue --resume-pr` returns `Done-Blocked` → block this PR with the inner reason, continue.
 
@@ -289,7 +366,7 @@ Each loop re-syncs to `origin/main` between rounds. The full pipeline is: bug �
 
 ## Non-goals
 
-- This skill never opens issues, never opens PRs, and never modifies app source. Forward-fixes are delegated to `iterate-one-issue --resume-pr <PR>`.
+- This skill never opens issues, never opens PRs, and never modifies app source. Forward-fixes (including rebase-conflict resolution) are delegated to `iterate-one-issue --resume-pr <PR>`. Inline rebases (Step 3.5 clean path) rewrite commit metadata only — file contents are unchanged.
 - This skill never picks issues from the backlog (that's `iterate-loop`'s job).
 - This skill never enables GitHub's `--auto` merge queue (would require repo-level "Allow auto-merge" setting). It polls + merges directly so it works on any repo the agent can push to and merge on.
-- This skill never bypasses the release gate. Every merged PR was validated against the signed-installer build on the exact commit it merged.
+- This skill never bypasses the release gate. Every merged PR was validated against the signed-installer build on the exact commit it merged. (Step 5.0's race-retry re-dispatches the gate on the rebased commit — it does not skip validation.)

--- a/.claude/skills/merge-pr-loop/references/release-gate.md
+++ b/.claude/skills/merge-pr-loop/references/release-gate.md
@@ -128,6 +128,15 @@ Per-PR, all of these reset on Step 1's next pick:
 
 - `BRANCH` — captured at Step 2.
 - `PR_URL` — captured at Step 2.
-- `HEAD_SHA` — captured at Step 2; refreshed from the `commit=` field of every `Done-ForwardFixed` outcome.
+- `HEAD_SHA` — captured at Step 2; refreshed by Step 3.5 (clean rebase) and from the `commit=` field of every `Done-ForwardFixed` outcome.
+- `MERGE_RACE_RETRIES` — captured at Step 2 (init `0`); incremented by Step 5.0 when the branch is found behind right before merge; cap = `1`. Independent of the forward-fix budget.
 - `RG_RUN_ID` — assigned at every 4.1 dispatch.
 - Attempt count is **not** stored locally — re-read from PR comments at every loop iteration so a parallel run cannot bypass the cap.
+
+## Step 3.5's interaction with this document
+
+Step 3.5 in [`SKILL.md`](../SKILL.md) does an inline clean rebase before reaching this document's flow. On rebase **conflict** (not handled inline — clean rebases only), Step 3.5 invokes the same `iterate-one-issue --resume-pr "$PICK"` subagent described in §4.3 below. The inner skill detects "no failed gate but branch behind origin/main" and runs a **rebase-only** Phase R pass (R5 rebase + per-file conflict resolver, R7 push --force-with-lease, R8 marker, exit `Done-ForwardFixed`). Outcome routing is identical to §4.3:
+
+- `Done-ForwardFixed commit=<sha>` → refresh `HEAD_SHA = <sha>`, `PRS_FORWARD_FIXED += 1`, continue to §4.1 (dispatch the gate on the rebased commit).
+- `Done-Blocked` → SKILL.md Step 6 (block with inner reason).
+- Other / parse failure → SKILL.md Step 6 (block with `unrecognised outcome from iterate-one-issue --resume-pr (rebase-only)`).


### PR DESCRIPTION
## Summary

Update the autonomous PR-shipping skills so they handle PRs whose branches have fallen behind `origin/main` instead of blocking them at the merge step.

Without this, every PR opened against an older `main` was burning a ~2535 min release-gate run only to fail at `gh pr merge` with *"head branch is not up to date"*, forcing manual rebase + unblock. With this change the loop validates the merged state once and ships.

## What changes

### `merge-pr-loop`  new control-flow steps

| Step | What it does |
|---|---|
| **3.5 (new)** | Before dispatching the gate, fetch `origin`, count commits behind, and attempt a clean rebase inline. Push with SHA-bound `--force-with-lease=$BRANCH:$OLD_REMOTE_SHA`. On conflicts, delegate to `/iterate-one-issue --resume-pr <PR>` (cap = 5/PR forward-fix budget). |
| **5.0 (new)** | After gate PASS, re-fetch and re-check `behind`. If main moved during the ~30 min gate window, loop back to Step 3.5 (cap = 1 race retry per PR via `MERGE_RACE_RETRIES`). |
| **5.3 (modified)** | If `gh pr merge` itself fails (third-party race after the 5.0 check), fall back to Step 3.5 once using the same `MERGE_RACE_RETRIES` budget before blocking. |

Halt-conditions list and non-goals updated to reflect the new soft-block reasons. Inline rebases rewrite commit metadata only  file contents are unchanged, so the *"never modifies app source"* contract holds.

### `iterate-one-issue`  Phase R gains a rebase-only sub-mode

| Sub-mode | Trigger (R3) | What runs |
|---|---|---|
| **forward-fix** (existing) | Latest `release-gate.yml` run **at the current HEAD SHA** is `failure` | R3  R4  R5  R6 (`exe-task-implementer`)  R7  R8 |
| **rebase-only** (new) | No failed gate at HEAD **and** branch is behind `origin/main` | R3  R5 (rebase + per-file conflict resolver)  R7 (push-only, no commit)  R8 |

Both sub-modes share the same 5-attempt forward-fix budget (PR-comment markers).

Robustness fixes flagged by the rubber-duck pass:
- **R3 SHA filter**: failed-gate query now requires `headSha == HEAD`, so an older failed run on a prior commit can no longer falsely trigger forward-fix mode and apply stale logs to the current tree.
- **R2 stateless reset**: `git fetch origin "$BRANCH" ; git checkout -B "$BRANCH" "origin/$BRANCH"` instead of `pull --ff-only`  avoids false `Done-Blocked` when a prior run left local divergence.
- **R7 SHA-bound force-with-lease**: lease keyed off `OLD_REMOTE_SHA` captured at R2, not on the implicit local remote-tracking ref a concurrent fetch could refresh.

Phase R explicitly noted as **non-recursive** (does not increment `.claude/iterate-recursion-depth`) and as always rebasing onto the freshest `origin/main` visible at R5.

### Reference doc drift

- `merge-pr-loop/references/release-gate.md`  `MERGE_RACE_RETRIES` added to the per-PR state table; new section on Step 3.5  `iterate-one-issue --resume-pr` delegation.
- `iterate-one-issue/references/halt-semantics.md`  Phase R failure list now says *"no failed run **and** branch up to date with origin/main"*.
- `iterate-one-issue/references/done-handlers.md`  `Done-ForwardFixed` describes both sub-modes.

## Validation

- `npm run lint:skills`  passes (10 SKILL.md files OK).
- No source code touched. No CI workflow changes.
- Rubber-duck design critique consulted; 4/4 blocking concerns adopted.

## Out-of-scope (deliberately deferred)

- Extracting Step 1's conflict-resolver into a shared mini-spec  pre-existing cross-reference fragility.
- Replacing `/tmp/...` shell scratch with shell-var parsing  pre-existing portability issue, unrelated to this change.
- Bumping `MERGE_RACE_RETRIES` cap to 2  kept at 1 per design directive; trivial to bump if real-world pressure warrants.
