### PR TITLE
feat: implement #309 - Consume implementer scope non-action reports

### DIFF
--- a/.claude/skills/iterate-one-issue/SKILL.md
+++ b/.claude/skills/iterate-one-issue/SKILL.md
@@ -391,6 +391,25 @@ Every implementer reports "no changes" → log `SKIPPED — no-op: <reason>` to 
 
 #### 6a. Push
 
+##### 6a-noaction. Scope non-action capture (issue #309) — record implementer-reported deferrals
+
+Every `exe-task-implementer` Implementation Summary contains a `**Did NOT do (scope):** ...` field (see `.claude/agents/exe-task-implementer.md`). Before staging anything in this iteration's commit, parse those reports so deferred work cannot evaporate into agent-output text:
+
+1. For every implementer summary returned in this iteration's wave (Step 5 OR a 6d forward-fix), scan the Implementation Summary for the `**Did NOT do (scope):**` line and any bullet block that follows it.
+2. If the value is `none`, empty, or absent, skip that summary.
+3. Otherwise append a `scope_non_actions[]` entry to the iteration's block in the state file `.claude/iterate-state-<branch-slug>.md` with this shape:
+   ```yaml
+   scope_non_actions:
+     - implementer_attempt_id: <Step5-group-name | 6d-attempt-N>
+       task_id: <one-line task summary the implementer was given>
+       raw_text: <verbatim Did NOT do (scope) bullet — preserve formatting>
+       disposition: pending   # set in 8-pre disposition gate
+       disposition_note: ""   # set when disposition leaves pending
+   ```
+4. Log to stdout: `[scope-noaction] captured: <implementer_attempt_id> -- <raw_text>`.
+
+The state-file capture is the durable record (referenced by Step 8's record field, the PR comment, and the post-loop retro). No commit is needed at this step — the state file is iteration-local.
+
 ##### 6a-pre. Scope-diff guard (issue #302) — block workspace-wide formatter churn
 
 Implementers report their changed files in their Implementation Summary's `**Files changed:**` block. **Before staging anything**, run a scope-diff guard so workspace-wide `cargo fmt` (or any other off-scope edit) cannot leak into the iteration commit:
@@ -562,13 +581,34 @@ Findings flow into 6d's forward-fix wave alongside validator/CI failures. Conver
 
 ### Step 8 — Record
 
-Append to state file:
+#### 8-pre. Scope non-action disposition gate (issue #309) — block PASSED on undisposed deferrals
+
+Before recording PASSED, every `scope_non_actions[]` entry captured by 6a-noaction in this iteration MUST have a non-`pending` disposition. Allowed disposition values (exactly these four — extending the set requires a contract-test update):
+
+- `accepted` — the runner intentionally defers the non-action as out-of-scope for this iteration; `disposition_note` carries a one-line rationale (e.g. `"deferred to next iteration; not blocking AC-3"`).
+- `handled-in-forward-fix` — a subsequent 6d implementer wave addressed the gap; `disposition_note` cites the commit SHA that closed it.
+- `follow-up-issue:<N>` — a separate GitHub issue tracks the work; the runner MUST verify the issue exists and is open with `gh issue view <N>`; `disposition_note` carries a one-line summary.
+- `rejected` — the implementer's report was a mis-categorisation (e.g. the work was actually in scope and got done in the same wave); `disposition_note` carries the rebuttal rationale.
+
+Workflow:
+
+1. Read this iteration's `scope_non_actions[]` from the state file.
+2. For each entry with `disposition: pending`, the runner reviews the entry against this iteration's commits, reviewer feedback, and other implementer summaries; chooses one of the four allowed values; writes a one-line `disposition_note`.
+3. For borderline entries, the runner MAY consult `architect-expert` or `bug-expert` with the entry's `raw_text` + `task_id` + iteration log. The runner makes the final call.
+4. Update the state file in place: replace `disposition: pending` with the chosen value, set `disposition_note`.
+5. **Block PASSED:** if any `scope_non_actions[]` entry remains `pending` after this gate, the iteration cannot record PASSED. Log `DEGRADED — scope non-action <task_id> remains pending: <reason>`, set the iteration's outcome to DEGRADED in the Step 8 record below, and proceed (do NOT loop forever in this gate; PASSED is unavailable until the runner explicitly resolves all entries).
+
+This gate ensures implementer-reported scope deferrals never silently disappear: they get explicit acknowledgement, a follow-up issue, or a documented rejection — visible in the iteration record + PR comment + retro.
+
+#### 8-record. Append to state file
+
 ```markdown
 ## Iteration <N> — <PASSED | DEGRADED | SKIPPED>
 - DIFF_CLASS: <code | prompt-only | docs-only | none>
 - Commits: <SHAs from ITER_BASE_SHA..HEAD>
 - Validate+CI+Experts: <converged in K | degraded after 5>
 - Scope-guard: <K reverted, M blocked | clean>   <!-- issue #302: K = whitespace-only .rs files auto-reverted by 6a-pre; M = unexpected files surfaced as scope-guard BLOCKs into 6d. "clean" if both zero. -->
+- Scope-non-actions: <list of (task_id → disposition + disposition_note) | none>   <!-- issue #309: items captured by 6a-noaction with their 8-pre dispositions. "none" if every implementer reported empty Did NOT do (scope). -->
 - Expert review: <A approved / B blocked — list>
 - Goal assessor confidence: <%>
 - Summary: <one sentence>
@@ -585,6 +625,7 @@ Update PR:
   ### <✅ PASSED | ⚠️ DEGRADED | ⏭️ SKIPPED> Iteration <N>/30
   **DIFF_CLASS:** <…>   **Commits:** <short SHAs>   **Files:** <count>   **Tests:** <count>
   <issue: AC satisfied this iter: …  |  goal: requirements done: …>
+  <if scope_non_actions non-empty: **Scope non-actions:** <K accepted, M handled-in-fix, P follow-up, Q rejected>>
   <if DEGRADED: Carry-over: …>
   Next: iteration <N+1>
   EOF

--- a/.claude/skills/iterate-one-issue/SKILL.md
+++ b/.claude/skills/iterate-one-issue/SKILL.md
@@ -151,6 +151,7 @@ Capture `PR_NUMBER`, `PR_URL`.
 
 ```markdown
 ---
+state_schema_version: 1
 mode: <issue | goal>
 goal: "<GOAL_FOR_ASSESSOR>"
 issue_number: <ISSUE_NUMBER or null>
@@ -163,7 +164,17 @@ iter_base_sha: <SHA — set/refreshed at every Step 1 "After successful rebase">
 iteration_cap: 30
 ---
 # Iteration Log
+
+## Open scope non-actions
+<!-- branch-level (issue #309): 6a-noaction appends entries here with disposition=pending; 8-pre + termination preconditions drain them. Survives across iterations until every entry has a non-pending disposition. -->
+<!-- empty initially -->
+
+## Resolved scope non-actions
+<!-- branch-level (issue #309): entries dispositioned by 8-pre or the termination-precondition gate are moved here for audit history. Never re-imported into Open. -->
+<!-- empty initially -->
 ```
+
+`state_schema_version` is bumped on any structured-block shape change (the YAML frontmatter or the named markdown sections above are part of the schema). Today's shape is version `1`.
 
 This file is the source of truth for iteration history; only Step 1 writes `iter_base_sha`. Release-gate validation is **not** performed by this skill (see [Non-goals](#non-goals)) — `merge-pr-loop` owns that lifecycle and tracks its own state on the PR itself.
 
@@ -395,20 +406,34 @@ Every implementer reports "no changes" → log `SKIPPED — no-op: <reason>` to 
 
 Every `exe-task-implementer` Implementation Summary contains a `**Did NOT do (scope):** ...` field (see `.claude/agents/exe-task-implementer.md`). Before staging anything in this iteration's commit, parse those reports so deferred work cannot evaporate into agent-output text:
 
-1. For every implementer summary returned in this iteration's wave (Step 5 OR a 6d forward-fix), scan the Implementation Summary for the `**Did NOT do (scope):**` line and any bullet block that follows it.
-2. If the value is `none`, empty, or absent, skip that summary.
-3. Otherwise append a `scope_non_actions[]` entry to the iteration's block in the state file `.claude/iterate-state-<branch-slug>.md` with this shape:
+1. For every implementer summary returned in this iteration's wave (Step 5 group OR a 6d forward-fix attempt — see 6d step 4 below for the forward-fix re-run requirement), extract the scope non-action block using these explicit rules:
+   - **Start marker**: the literal line containing `**Did NOT do (scope):**` (case-sensitive — the field name is contractual, see `.claude/agents/exe-task-implementer.md`).
+   - **End marker**: the next top-level Implementation-Summary field marker (`**<Field>:**` matching `^\*\*[A-Z][A-Za-z ]+:\*\*` in markdown), OR end of the summary.
+   - **Body**: the text BETWEEN start and end markers, indentation preserved verbatim. Trim only the start marker line itself.
+   - **Empty/none**: if the body is empty, whitespace-only, or a single bullet `- none` / `none`, treat as no non-action and skip.
+   - **Multiple sections**: if a single Implementation Summary has more than one `**Did NOT do (scope):**` field (anomalous but possible), concatenate all bodies in encounter order, separated by `\n---\n`. Do **not** silently skip later sections.
+   - **Malformed (no end marker found)**: capture from start marker to end of summary; flag with `[scope-noaction] WARN: malformed summary, no closing field marker — captured to EOF`.
+2. Append each captured non-empty body as a `scope_non_actions[]` entry to the **branch-level** `## Open scope non-actions` section in the state file `.claude/iterate-state-<branch-slug>.md` with this shape:
    ```yaml
-   scope_non_actions:
-     - implementer_attempt_id: <Step5-group-name | 6d-attempt-N>
-       task_id: <one-line task summary the implementer was given>
-       raw_text: <verbatim Did NOT do (scope) bullet — preserve formatting>
-       disposition: pending   # set in 8-pre disposition gate
-       disposition_note: ""   # set when disposition leaves pending
+   - implementer_attempt_id: <iter-N-step5-<group> | iter-N-6d-attempt-K>
+     raw_text: |
+       <verbatim Did NOT do (scope) body — multi-line, indentation preserved>
+     disposition: pending   # final value set in 8-pre or the termination-precondition gate
+     disposition_note: ""   # one-line rationale, set when disposition leaves pending
    ```
-4. Log to stdout: `[scope-noaction] captured: <implementer_attempt_id> -- <raw_text>`.
+   Note: capture lives at the **branch level** (one Open list per branch), not per-iteration. This lets pending entries survive across DEGRADED iterations until they are explicitly dispositioned. Per-iteration provenance is preserved in `implementer_attempt_id`.
+3. Log to stdout: `[scope-noaction] captured: <implementer_attempt_id> -- <first 80 chars of raw_text>`.
+4. **Worked example** (locked in the contract test): an implementer that returns `**Did NOT do (scope):** rustfmt outside declared files` produces this entry:
+   ```yaml
+   - implementer_attempt_id: iter-1-step5-rust-changes
+     raw_text: |
+       rustfmt outside declared files
+     disposition: pending
+     disposition_note: ""
+   ```
+   The disposition gate at 8-pre + the termination-precondition gate (see done-handlers) MUST resolve this entry to one of `accepted`, `handled-in-forward-fix`, or `follow-up-issue:<N>` before the iteration can record PASSED or transition to Done-Achieved.
 
-The state-file capture is the durable record (referenced by Step 8's record field, the PR comment, and the post-loop retro). No commit is needed at this step — the state file is iteration-local.
+The state-file capture is the durable record (referenced by Step 8's record field, the PR comment, the post-loop retro, and Phase 2 synthesis). No commit is needed at this step — the state file is iteration-local.
 
 ##### 6a-pre. Scope-diff guard (issue #302) — block workspace-wide formatter churn
 
@@ -527,7 +552,10 @@ Repeat until A, B, AND C are all green/APPROVE, or 5 attempts:
    Minimal change per failure. Tighten existing code over new abstractions. Do NOT reopen approved concerns.
    Return Implementation Summary.
    ```
-3. **Re-apply the scope-diff guard from 6a-pre** against the forward-fix implementer's reported `Files changed` (treat its summary as the new `EXPECTED_FILES`; the original Step 5 `EXPECTED_FILES` from this iteration still counts as in-scope). Then:
+3. **Re-apply scope-noaction capture (6a-noaction, issue #309) AND scope-diff guard (6a-pre, issue #302)** against the forward-fix implementer's Implementation Summary, in that order:
+   - First, run the 6a-noaction parser against the forward-fix Implementation Summary's `**Did NOT do (scope):**` field (per the explicit boundary rules at 6a-noaction step 1). Append any non-empty captures to the branch-level `## Open scope non-actions` section with `implementer_attempt_id: iter-<N>-6d-attempt-<K>`. The forward-fix prompt at step 2 above includes "Return Implementation Summary" — that summary MUST contain the standard `**Did NOT do (scope):**` field per `.claude/agents/exe-task-implementer.md`.
+   - Second, run the 6a-pre scope-diff guard against the forward-fix's reported `Files changed` (treat its summary as the new `EXPECTED_FILES`; the original Step 5 `EXPECTED_FILES` from this iteration still counts as in-scope).
+   Then commit:
    ```bash
    git add <specific files>
    git commit -m "fix(iter-<iteration>): <summary>"
@@ -583,22 +611,23 @@ Findings flow into 6d's forward-fix wave alongside validator/CI failures. Conver
 
 #### 8-pre. Scope non-action disposition gate (issue #309) — block PASSED on undisposed deferrals
 
-Before recording PASSED, every `scope_non_actions[]` entry captured by 6a-noaction in this iteration MUST have a non-`pending` disposition. Allowed disposition values (exactly these four — extending the set requires a contract-test update):
+Before recording PASSED, every entry in the **branch-level** `## Open scope non-actions` section of the state file MUST have a non-`pending` disposition. This includes entries captured by 6a-noaction in this iteration AND any pending entries left over from prior DEGRADED iterations on the same branch.
 
-- `accepted` — the runner intentionally defers the non-action as out-of-scope for this iteration; `disposition_note` carries a one-line rationale (e.g. `"deferred to next iteration; not blocking AC-3"`).
+Allowed disposition values (exactly these three — extending the set requires a contract-test update):
+
+- `accepted` — the runner intentionally defers the non-action (out-of-scope for this iteration, mis-categorised as scope when it was actually in-scope, or any other reason that doesn't warrant a follow-up issue). `disposition_note` carries a one-line rationale.
 - `handled-in-forward-fix` — a subsequent 6d implementer wave addressed the gap; `disposition_note` cites the commit SHA that closed it.
-- `follow-up-issue:<N>` — a separate GitHub issue tracks the work; the runner MUST verify the issue exists and is open with `gh issue view <N>`; `disposition_note` carries a one-line summary.
-- `rejected` — the implementer's report was a mis-categorisation (e.g. the work was actually in scope and got done in the same wave); `disposition_note` carries the rebuttal rationale.
+- `follow-up-issue:<N>` — a separate GitHub issue tracks the work; the runner MUST verify the issue exists and is open with `gh issue view <N>` (closed issues are NOT acceptable — re-categorise to `accepted` if the work was completed under a different issue); `disposition_note` carries a one-line summary.
 
 Workflow:
 
-1. Read this iteration's `scope_non_actions[]` from the state file.
-2. For each entry with `disposition: pending`, the runner reviews the entry against this iteration's commits, reviewer feedback, and other implementer summaries; chooses one of the four allowed values; writes a one-line `disposition_note`.
-3. For borderline entries, the runner MAY consult `architect-expert` or `bug-expert` with the entry's `raw_text` + `task_id` + iteration log. The runner makes the final call.
-4. Update the state file in place: replace `disposition: pending` with the chosen value, set `disposition_note`.
-5. **Block PASSED:** if any `scope_non_actions[]` entry remains `pending` after this gate, the iteration cannot record PASSED. Log `DEGRADED — scope non-action <task_id> remains pending: <reason>`, set the iteration's outcome to DEGRADED in the Step 8 record below, and proceed (do NOT loop forever in this gate; PASSED is unavailable until the runner explicitly resolves all entries).
+1. Read every entry under `## Open scope non-actions` in the state file (this iteration's new entries from 6a-noaction PLUS any leftover `pending` entries from prior iterations on this branch).
+2. For each entry with `disposition: pending`, the runner reviews the entry against this iteration's commits, reviewer feedback, and other implementer summaries; chooses one of the three allowed values; writes a one-line `disposition_note`.
+3. For borderline entries, the runner MAY consult `architect-expert` or `bug-expert` with the entry's `raw_text` + `implementer_attempt_id` + iteration log. The runner makes the final call.
+4. Update the state file in place: replace `disposition: pending` with the chosen value, set `disposition_note`. Move the entry from `## Open scope non-actions` to `## Resolved scope non-actions` (audit history; entries here are never re-imported into Open).
+5. **Block PASSED:** if any entry remains `pending` at the end of this gate, the iteration cannot record PASSED. Log `DEGRADED — scope non-action <implementer_attempt_id> remains pending: <reason>`, set the iteration's outcome to DEGRADED in the Step 8 record below, and proceed (do NOT loop forever in this gate; PASSED is unavailable until the runner resolves all entries — either in a later 8-pre run or in the termination-precondition gate before any Done-X exit, see [`references/done-handlers.md`](references/done-handlers.md)).
 
-This gate ensures implementer-reported scope deferrals never silently disappear: they get explicit acknowledgement, a follow-up issue, or a documented rejection — visible in the iteration record + PR comment + retro.
+This gate ensures implementer-reported scope deferrals never silently disappear: they get explicit acknowledgement, a follow-up issue, or a documented `accepted` rationale — visible in the iteration record, the PR comment, the retro, and Phase 2 synthesis.
 
 #### 8-record. Append to state file
 
@@ -660,6 +689,8 @@ Use the R1 prompt from the shared spec, with skill-specific context block:
 - Expert blocks: <expert + rule, or "none">
 - Assessor confidence: <prev% → curr%>
 - Iteration log entry verbatim: <…>
+- Scope non-actions captured this iter: <list of (implementer_attempt_id → disposition + note); cite the branch-level Open + Resolved sections so cross-iteration patterns are visible>
+- Open scope non-actions still pending (branch-level): <count + implementer_attempt_id list, or "none" — issue #309>
 - BUG_RCA (if applicable): <verbatim>
 ```
 

--- a/.claude/skills/iterate-one-issue/references/done-handlers.md
+++ b/.claude/skills/iterate-one-issue/references/done-handlers.md
@@ -2,6 +2,17 @@
 
 Reached when Step 2's `exe-goal-assessor` returns `achieved` (every `REQUIREMENT` marked `met`). No release-gate dispatch — that lifecycle belongs to `merge-pr-loop`.
 
+#### Termination preconditions (issue #309) — drain `## Open scope non-actions` before any Done-X exit
+
+Before invoking ANY `Done-X` handler — Done-Achieved, Done-Blocked, or Done-TimedOut — the runner MUST drain the **branch-level** `## Open scope non-actions` section of `.claude/iterate-state-<branch-slug>.md`. Step 2's `achieved` shortcut bypasses Steps 3–8.5, including 8-pre, so this gate is the single chokepoint that catches pending scope non-actions on every terminal exit. Workflow:
+
+1. Read every entry under `## Open scope non-actions` in the state file.
+2. For each entry with `disposition: pending`, run the same disposition workflow as 8-pre (`accepted` / `handled-in-forward-fix` / `follow-up-issue:<N>`; one-line `disposition_note`; move resolved entries to `## Resolved scope non-actions`).
+3. **Block Done-Achieved on undisposed entries.** If any entry remains `pending` after step 2 — for example, the runner cannot decide a disposition without human input — the terminal outcome is forced to **Done-Blocked** (NOT Done-Achieved), with reason `scope non-actions undisposed: <implementer_attempt_id list>`. The PR stays draft, the source issue gets the `blocked` label, and `iterate-loop` skips the issue on subsequent sweeps until a human resolves the entries (e.g. by opening follow-up issues and re-disposing them).
+4. Done-Blocked and Done-TimedOut also run this gate, but their outcome is unchanged — the gate just ensures that pending entries are surfaced in the Done-Blocked / Done-TimedOut PR comment so they're visible in the carry-over.
+
+This gate guarantees that no terminal exit (including the Step 2 → Done-Achieved shortcut at SKILL.md "Termination" table) can ship pending scope non-actions silently.
+
 Handler steps (in order):
 
 1. **Bug-mode behavioural verification (`IS_BUG` only).** Before marking the PR ready-for-review, verify the original bug is resolved at the **observation level** of the bug report — not the implementation level.

--- a/src/__tests__/iterate-skill-contract.test.ts
+++ b/src/__tests__/iterate-skill-contract.test.ts
@@ -268,3 +268,123 @@ describe("iterate-one-issue skill — scope guard against workspace-wide formatt
     expect(SKILL).not.toMatch(positiveRunPattern);
   });
 });
+
+describe("iterate-one-issue skill — consume implementer scope non-action reports (issue #309)", () => {
+  // Issue #309 — implementer agents are instructed at `.claude/agents/exe-task-implementer.md`
+  // to fill in `**Did NOT do (scope):** ...` whenever they cannot do all the work in the task,
+  // but the iterate skill had no consumer for those reports — they evaporated into agent text.
+  // The fix is two sub-steps in Step 6 + Step 8:
+  //   1. `6a-noaction. Scope non-action capture` parses every implementer summary's
+  //      `Did NOT do (scope)` block and appends non-empty entries to `scope_non_actions[]`
+  //      in the iteration state file with `disposition: pending`.
+  //   2. `8-pre. Scope non-action disposition gate` requires every captured entry to have
+  //      a non-pending disposition (one of `accepted`, `handled-in-forward-fix`,
+  //      `follow-up-issue:<N>`, `rejected`) BEFORE the iteration can record PASSED.
+  //      Any pending entry forces the iteration into DEGRADED.
+  // Step 8's record template carries a `Scope-non-actions:` field so dispositions are durable.
+
+  it("Step 6 has a 6a-noaction sub-step that parses Did NOT do (scope) from implementer summaries", () => {
+    expect(SKILL).toMatch(/#####\s+6a-noaction/);
+    // Must reference the literal field name from exe-task-implementer.md so a renamed/removed
+    // field is caught loudly.
+    expect(SKILL).toMatch(/\*\*Did NOT do \(scope\)/);
+    expect(SKILL).toMatch(/scope_non_actions/);
+    expect(SKILL).toMatch(/implementer_attempt_id/);
+  });
+
+  it("6a-noaction captures from BOTH Step 5 and 6d (forward-fix) implementer waves", () => {
+    // The skill must process forward-fix implementer summaries too, not just initial Step 5.
+    const sixANoaction = SKILL.indexOf("##### 6a-noaction");
+    const sixAPre = SKILL.indexOf("##### 6a-pre");
+    expect(sixANoaction).toBeGreaterThan(-1);
+    expect(sixAPre).toBeGreaterThan(sixANoaction);
+    const block = SKILL.slice(sixANoaction, sixAPre);
+    expect(block).toMatch(/Step 5/);
+    expect(block).toMatch(/6d/);
+  });
+
+  it("Step 8 has an 8-pre disposition gate enumerating the four allowed values", () => {
+    expect(SKILL).toMatch(/####\s+8-pre/);
+    // All four allowed disposition values must appear verbatim:
+    expect(SKILL).toMatch(/`accepted`/);
+    expect(SKILL).toMatch(/`handled-in-forward-fix`/);
+    expect(SKILL).toMatch(/`follow-up-issue:<N>`|follow-up-issue:<\w+>/);
+    expect(SKILL).toMatch(/`rejected`/);
+  });
+
+  it("8-pre gate appears BEFORE the Step 8 record body (cannot record PASSED with pending dispositions)", () => {
+    const stepEight = SKILL.indexOf("### Step 8 — Record");
+    expect(stepEight).toBeGreaterThan(-1);
+    const stepEightFive = SKILL.indexOf("### Step 8.5", stepEight);
+    expect(stepEightFive).toBeGreaterThan(stepEight);
+    const stepEightBlock = SKILL.slice(stepEight, stepEightFive);
+    const eightPreIdx = stepEightBlock.indexOf("8-pre");
+    const recordIdx = stepEightBlock.indexOf("8-record");
+    expect(eightPreIdx, "8-pre disposition gate missing in Step 8").toBeGreaterThan(-1);
+    expect(recordIdx, "8-record sub-step missing in Step 8").toBeGreaterThan(-1);
+    expect(eightPreIdx).toBeLessThan(recordIdx);
+  });
+
+  it("8-pre explicitly blocks PASSED when a scope_non_actions entry remains pending", () => {
+    // Without this clause, the gate is advisory only — the whole point is hard-blocking.
+    const eightPre = SKILL.indexOf("#### 8-pre");
+    const eightRecord = SKILL.indexOf("#### 8-record", eightPre);
+    expect(eightRecord).toBeGreaterThan(eightPre);
+    const block = SKILL.slice(eightPre, eightRecord);
+    expect(block).toMatch(/[Bb]lock PASSED/);
+    expect(block).toMatch(/DEGRADED/);
+    expect(block).toMatch(/pending/);
+  });
+
+  it("Step 8 iteration template contains Scope-non-actions field for durable visibility", () => {
+    const stepEight = SKILL.indexOf("### Step 8 — Record");
+    const stepEightFive = SKILL.indexOf("### Step 8.5", stepEight);
+    const stepEightBlock = SKILL.slice(stepEight, stepEightFive);
+    expect(stepEightBlock).toMatch(/Scope-non-actions:/);
+    // The same field should appear with a (task_id → disposition) shape so it carries useful info.
+    expect(stepEightBlock).toMatch(/Scope-non-actions:[\s\S]{0,200}disposition/i);
+  });
+
+  it("synthetic 'rustfmt outside declared files' example is the canonical illustration referenced in the spec", () => {
+    // Per AC-5 of issue #309: the regression test must exercise a synthetic implementer
+    // summary containing `Did NOT do (scope): rustfmt outside declared files` and assert
+    // the gate would require disposition. We assert here that:
+    //   (a) The skill contract supports parsing such a string (the parse rule says non-empty),
+    //   (b) The skill names all four allowed dispositions so the synthetic input has at least
+    //       one valid resolution path,
+    //   (c) The synthetic string itself is locked here so a future "what was the canonical
+    //       example?" question has an answer in code.
+    const synthetic = "Did NOT do (scope): rustfmt outside declared files";
+    expect(synthetic).toMatch(/Did NOT do \(scope\)/);
+    // Skill must accept ANY non-empty bullet — assert that the parse rule says so:
+    expect(SKILL).toMatch(/non-empty|\bnon-empty\b/);
+    // And the gate has at least one disposition that maps to "follow-up-issue:<N>" — the most
+    // likely resolution for an out-of-scope formatting deferral.
+    expect(SKILL).toMatch(/follow-up-issue:/);
+  });
+
+  it("PR comment template surfaces non-action disposition counts", () => {
+    // Without this, the disposition state lives only in the gitignored state file —
+    // reviewers wouldn't see it on the PR.
+    const stepEight = SKILL.indexOf("### Step 8 — Record");
+    const stepEightFive = SKILL.indexOf("### Step 8.5", stepEight);
+    const stepEightBlock = SKILL.slice(stepEight, stepEightFive);
+    expect(stepEightBlock).toMatch(/Scope non-actions/i);
+  });
+
+  it("issue #302 scope-diff guard contract remains intact (regression of pre-existing behaviour)", () => {
+    // Belt-and-braces — any of the #302 contract assertions could regress when adding the
+    // 6a-noaction step. Re-affirm the load-bearing ones.
+    expect(SKILL).toMatch(/##### 6a-pre\.?\s+Scope-diff guard/);
+    const sixA = SKILL.indexOf("#### 6a. Push");
+    const sixB = SKILL.indexOf("#### 6b.");
+    const sixABlock = SKILL.slice(sixA, sixB);
+    expect(sixABlock).toMatch(/git diff --name-only/);
+    // 6a-noaction must appear BEFORE 6a-pre (capture before guard, since both inspect
+    // implementer summaries — capturing first lets the guard reuse the parsed scope).
+    const noactionIdx = sixABlock.indexOf("6a-noaction");
+    const preIdx = sixABlock.indexOf("6a-pre");
+    expect(noactionIdx).toBeGreaterThan(-1);
+    expect(preIdx).toBeGreaterThan(noactionIdx);
+  });
+});

--- a/src/__tests__/iterate-skill-contract.test.ts
+++ b/src/__tests__/iterate-skill-contract.test.ts
@@ -34,7 +34,6 @@ const EXE_TASK_IMPLEMENTER_PATH = resolve(
   "../../.claude/agents/exe-task-implementer.md",
 );
 const EXE_TASK_IMPLEMENTER = readFileSync(EXE_TASK_IMPLEMENTER_PATH, "utf8");
-
 describe("iterate-one-issue skill — DIFF_CLASS scoping (issue #122)", () => {
   it("Step 6b classifies the diff into code | prompt-only | docs-only | none", () => {
     expect(SKILL).toMatch(/####\s+6b\.?\s+Classify diff/i);
@@ -272,16 +271,22 @@ describe("iterate-one-issue skill — scope guard against workspace-wide formatt
 describe("iterate-one-issue skill — consume implementer scope non-action reports (issue #309)", () => {
   // Issue #309 — implementer agents are instructed at `.claude/agents/exe-task-implementer.md`
   // to fill in `**Did NOT do (scope):** ...` whenever they cannot do all the work in the task,
-  // but the iterate skill had no consumer for those reports — they evaporated into agent text.
-  // The fix is two sub-steps in Step 6 + Step 8:
+  // but the iterate skill had no consumer for those reports. The fix:
   //   1. `6a-noaction. Scope non-action capture` parses every implementer summary's
-  //      `Did NOT do (scope)` block and appends non-empty entries to `scope_non_actions[]`
-  //      in the iteration state file with `disposition: pending`.
-  //   2. `8-pre. Scope non-action disposition gate` requires every captured entry to have
-  //      a non-pending disposition (one of `accepted`, `handled-in-forward-fix`,
-  //      `follow-up-issue:<N>`, `rejected`) BEFORE the iteration can record PASSED.
-  //      Any pending entry forces the iteration into DEGRADED.
-  // Step 8's record template carries a `Scope-non-actions:` field so dispositions are durable.
+  //      `Did NOT do (scope)` block (with explicit start/end markers and malformed-summary
+  //      rules) and appends non-empty entries to the BRANCH-LEVEL `## Open scope non-actions`
+  //      section of the state file (not per-iteration), so pending entries survive across
+  //      DEGRADED iterations until explicitly dispositioned.
+  //   2. `8-pre. Scope non-action disposition gate` requires every entry in the Open list to
+  //      have a non-pending disposition (one of `accepted`, `handled-in-forward-fix`,
+  //      `follow-up-issue:<N>`) BEFORE the iteration can record PASSED. Pending entries
+  //      force DEGRADED. Resolved entries move to `## Resolved scope non-actions` for audit.
+  //   3. **Termination preconditions** in `references/done-handlers.md` run the same gate
+  //      before ANY Done-X exit so the Step 2 → Done-Achieved shortcut cannot bypass 8-pre.
+  //   4. 6d step 3 explicitly re-runs 6a-noaction against forward-fix Implementation Summaries.
+  //   5. Step 8.5 retro context block + the PR comment include scope non-action data so
+  //      Phase 2 synthesis can consume it as cross-run pattern signal.
+  //   6. State file frontmatter carries `state_schema_version: 1` for forward compatibility.
 
   it("Step 6 has a 6a-noaction sub-step that parses Did NOT do (scope) from implementer summaries", () => {
     expect(SKILL).toMatch(/#####\s+6a-noaction/);
@@ -292,24 +297,60 @@ describe("iterate-one-issue skill — consume implementer scope non-action repor
     expect(SKILL).toMatch(/implementer_attempt_id/);
   });
 
-  it("6a-noaction captures from BOTH Step 5 and 6d (forward-fix) implementer waves", () => {
-    // The skill must process forward-fix implementer summaries too, not just initial Step 5.
+  it("6a-noaction defines explicit parse boundaries (start marker, end marker, malformed)", () => {
+    // duck-309 BLOCK 2: vague "scan the line and any bullet block" was insufficient.
     const sixANoaction = SKILL.indexOf("##### 6a-noaction");
     const sixAPre = SKILL.indexOf("##### 6a-pre");
     expect(sixANoaction).toBeGreaterThan(-1);
     expect(sixAPre).toBeGreaterThan(sixANoaction);
     const block = SKILL.slice(sixANoaction, sixAPre);
-    expect(block).toMatch(/Step 5/);
-    expect(block).toMatch(/6d/);
+    expect(block).toMatch(/[Ss]tart marker/);
+    expect(block).toMatch(/[Ee]nd marker/);
+    expect(block).toMatch(/[Mm]alformed/);
+    expect(block).toMatch(/[Mm]ultiple sections/);
   });
 
-  it("Step 8 has an 8-pre disposition gate enumerating the four allowed values", () => {
+  it("6a-noaction is re-run on BOTH Step 5 AND 6d (forward-fix) implementer waves", () => {
+    // duck-309 BLOCK 1: 6d previously only re-applied 6a-pre, not 6a-noaction. Without this
+    // fix, deferrals introduced during forward-fix bypass scope_non_actions[] entirely.
+    const sixANoaction = SKILL.indexOf("##### 6a-noaction");
+    const sixAPre = SKILL.indexOf("##### 6a-pre");
+    const block = SKILL.slice(sixANoaction, sixAPre);
+    expect(block).toMatch(/Step 5/);
+    expect(block).toMatch(/6d forward-fix/);
+
+    // The 6d block itself MUST also explicitly say "re-run 6a-noaction" (not just 6a-pre).
+    const sixD = SKILL.indexOf("#### 6d.");
+    const stepSeven = SKILL.indexOf("### Step 7");
+    const sixDBlock = SKILL.slice(sixD, stepSeven);
+    expect(sixDBlock).toMatch(/6a-noaction/);
+    expect(sixDBlock).toMatch(/iter-<N>-6d-attempt/);
+  });
+
+  it("scope non-actions live at the BRANCH level (Open + Resolved), not per-iteration", () => {
+    // duck-309 BLOCK 3 + arch-309 BLOCK 2: per-iteration capture would orphan pending entries
+    // across DEGRADED iterations. Branch-level Open + Resolved sections survive carry-over.
+    expect(SKILL).toMatch(/##\s+Open scope non-actions/);
+    expect(SKILL).toMatch(/##\s+Resolved scope non-actions/);
+    // The 8-pre workflow must read from the Open section across iterations.
+    const eightPre = SKILL.indexOf("#### 8-pre");
+    const eightRecord = SKILL.indexOf("#### 8-record", eightPre);
+    const eightPreBlock = SKILL.slice(eightPre, eightRecord);
+    expect(eightPreBlock).toMatch(/branch-level/i);
+    expect(eightPreBlock).toMatch(/prior[\s\S]{0,40}iterations|across iterations/i);
+  });
+
+  it("8-pre disposition gate enumerates exactly three allowed values (no `rejected`)", () => {
     expect(SKILL).toMatch(/####\s+8-pre/);
-    // All four allowed disposition values must appear verbatim:
+    // The three allowed disposition values must appear verbatim:
     expect(SKILL).toMatch(/`accepted`/);
     expect(SKILL).toMatch(/`handled-in-forward-fix`/);
     expect(SKILL).toMatch(/`follow-up-issue:<N>`|follow-up-issue:<\w+>/);
-    expect(SKILL).toMatch(/`rejected`/);
+    // `rejected` was dropped per lean-309 — folded into `accepted` with rationale.
+    const eightPre = SKILL.indexOf("#### 8-pre");
+    const eightRecord = SKILL.indexOf("#### 8-record", eightPre);
+    const eightPreBlock = SKILL.slice(eightPre, eightRecord);
+    expect(eightPreBlock).not.toMatch(/`rejected`/);
   });
 
   it("8-pre gate appears BEFORE the Step 8 record body (cannot record PASSED with pending dispositions)", () => {
@@ -325,15 +366,30 @@ describe("iterate-one-issue skill — consume implementer scope non-action repor
     expect(eightPreIdx).toBeLessThan(recordIdx);
   });
 
-  it("8-pre explicitly blocks PASSED when a scope_non_actions entry remains pending", () => {
-    // Without this clause, the gate is advisory only — the whole point is hard-blocking.
+  it("8-pre causally links pending → block PASSED → DEGRADED (not just co-occurrence)", () => {
+    // Without the causal link, a future edit could leave the words but break the gate.
     const eightPre = SKILL.indexOf("#### 8-pre");
     const eightRecord = SKILL.indexOf("#### 8-record", eightPre);
-    expect(eightRecord).toBeGreaterThan(eightPre);
     const block = SKILL.slice(eightPre, eightRecord);
+    // Must say "remains pending → cannot record PASSED → DEGRADED" in close proximity.
     expect(block).toMatch(/[Bb]lock PASSED/);
-    expect(block).toMatch(/DEGRADED/);
-    expect(block).toMatch(/pending/);
+    expect(block).toMatch(/pending[\s\S]{0,200}DEGRADED|DEGRADED[\s\S]{0,200}pending/);
+  });
+
+  it("Termination preconditions (done-handlers.md) drain Open scope non-actions before any Done-X", () => {
+    // arch-309 BLOCK 1: Step 2 → Done-Achieved skips 3-8.5 (including 8-pre). The
+    // termination-precondition gate is the single chokepoint that catches pending entries
+    // before any terminal exit (Done-Achieved, Done-Blocked, Done-TimedOut).
+    expect(DONE_HANDLERS).toMatch(/Termination preconditions/);
+    expect(DONE_HANDLERS).toMatch(/Open scope non-actions/);
+    expect(DONE_HANDLERS).toMatch(/issue #309/);
+    // Must explicitly mention the Step 2 → Done-Achieved bypass and its mitigation.
+    expect(DONE_HANDLERS).toMatch(/Done-Achieved[\s\S]{0,400}Done-Blocked|forced to.*Done-Blocked/);
+    // Termination gate must appear BEFORE the existing "Handler steps (in order)" list.
+    const termIdx = DONE_HANDLERS.indexOf("Termination preconditions");
+    const handlerStepsIdx = DONE_HANDLERS.indexOf("Handler steps (in order):");
+    expect(termIdx).toBeGreaterThan(-1);
+    expect(handlerStepsIdx).toBeGreaterThan(termIdx);
   });
 
   it("Step 8 iteration template contains Scope-non-actions field for durable visibility", () => {
@@ -341,47 +397,68 @@ describe("iterate-one-issue skill — consume implementer scope non-action repor
     const stepEightFive = SKILL.indexOf("### Step 8.5", stepEight);
     const stepEightBlock = SKILL.slice(stepEight, stepEightFive);
     expect(stepEightBlock).toMatch(/Scope-non-actions:/);
-    // The same field should appear with a (task_id → disposition) shape so it carries useful info.
     expect(stepEightBlock).toMatch(/Scope-non-actions:[\s\S]{0,200}disposition/i);
   });
 
-  it("synthetic 'rustfmt outside declared files' example is the canonical illustration referenced in the spec", () => {
-    // Per AC-5 of issue #309: the regression test must exercise a synthetic implementer
-    // summary containing `Did NOT do (scope): rustfmt outside declared files` and assert
-    // the gate would require disposition. We assert here that:
-    //   (a) The skill contract supports parsing such a string (the parse rule says non-empty),
-    //   (b) The skill names all four allowed dispositions so the synthetic input has at least
-    //       one valid resolution path,
-    //   (c) The synthetic string itself is locked here so a future "what was the canonical
-    //       example?" question has an answer in code.
-    const synthetic = "Did NOT do (scope): rustfmt outside declared files";
-    expect(synthetic).toMatch(/Did NOT do \(scope\)/);
-    // Skill must accept ANY non-empty bullet — assert that the parse rule says so:
-    expect(SKILL).toMatch(/non-empty|\bnon-empty\b/);
-    // And the gate has at least one disposition that maps to "follow-up-issue:<N>" — the most
-    // likely resolution for an out-of-scope formatting deferral.
-    expect(SKILL).toMatch(/follow-up-issue:/);
+  it("Step 8.5 retro context block includes scope non-actions for Phase 2 consumption", () => {
+    // arch-309 BLOCK 3: without this, scope non-action signal evaporates before reaching
+    // cross-run pattern detection in Phase 2's improvement-spec synthesis.
+    const stepEightFive = SKILL.indexOf("### Step 8.5");
+    expect(stepEightFive).toBeGreaterThan(-1);
+    const phaseR = SKILL.indexOf("## Phase R", stepEightFive);
+    const phaseTwo = SKILL.indexOf("## Phase 2", stepEightFive);
+    const block = SKILL.slice(stepEightFive, Math.min(
+      phaseR > -1 ? phaseR : SKILL.length,
+      phaseTwo > -1 ? phaseTwo : SKILL.length,
+    ));
+    expect(block).toMatch(/[Ss]cope non-actions/);
+    expect(block).toMatch(/Open scope non-actions/);
+  });
+
+  it("state file frontmatter carries state_schema_version for forward compatibility", () => {
+    // arch-309 medium: structured nested data is growing; version the schema now to avoid
+    // silent parser breakage when more gates land.
+    const zeroG = SKILL.indexOf("### 0g.");
+    const zeroH = SKILL.indexOf("### 0h.");
+    expect(zeroG).toBeGreaterThan(-1);
+    expect(zeroH).toBeGreaterThan(zeroG);
+    const block = SKILL.slice(zeroG, zeroH);
+    expect(block).toMatch(/state_schema_version:\s*1/);
+  });
+
+  it("worked example — synthetic 'rustfmt outside declared files' is locked into SKILL.md text", () => {
+    // AC-5 of issue #309: regression test asserts a synthetic implementer summary containing
+    // `Did NOT do (scope): rustfmt outside declared files` requires a visible disposition
+    // before PASSED. The test-309 review noted the prior version's tautological assertions
+    // (matching a JS literal against itself); the real lock is to assert the synthetic lives
+    // in SKILL.md as the canonical worked example.
+    const synthetic = "rustfmt outside declared files";
+    expect(SKILL).toContain(synthetic);
+    // The example must sit inside the 6a-noaction block so a future edit moving it elsewhere
+    // would break this test (the canonical illustration belongs with the parser, not adrift).
+    const sixANoaction = SKILL.indexOf("##### 6a-noaction");
+    const sixAPre = SKILL.indexOf("##### 6a-pre");
+    const block = SKILL.slice(sixANoaction, sixAPre);
+    expect(block).toContain(synthetic);
+    // The example must mention all three valid resolution paths (accepted /
+    // handled-in-forward-fix / follow-up-issue:<N>) OR refer to the gate that does so.
+    expect(block).toMatch(/disposition[\s\S]{0,80}(accepted|handled-in-forward-fix|follow-up-issue|gate at 8-pre)/i);
   });
 
   it("PR comment template surfaces non-action disposition counts", () => {
-    // Without this, the disposition state lives only in the gitignored state file —
-    // reviewers wouldn't see it on the PR.
     const stepEight = SKILL.indexOf("### Step 8 — Record");
     const stepEightFive = SKILL.indexOf("### Step 8.5", stepEight);
     const stepEightBlock = SKILL.slice(stepEight, stepEightFive);
     expect(stepEightBlock).toMatch(/Scope non-actions/i);
   });
 
-  it("issue #302 scope-diff guard contract remains intact (regression of pre-existing behaviour)", () => {
-    // Belt-and-braces — any of the #302 contract assertions could regress when adding the
-    // 6a-noaction step. Re-affirm the load-bearing ones.
-    expect(SKILL).toMatch(/##### 6a-pre\.?\s+Scope-diff guard/);
+  it("ordering: 6a-noaction sits BEFORE 6a-pre (capture before scope-diff guard)", () => {
+    // Belt-and-braces — only the ordering invariant is new; #302's full contract is locked
+    // by the prior describe block. Without this ordering, capture would happen after the
+    // guard reverts/blocks files, losing context for any non-actions correlated to those.
     const sixA = SKILL.indexOf("#### 6a. Push");
     const sixB = SKILL.indexOf("#### 6b.");
     const sixABlock = SKILL.slice(sixA, sixB);
-    expect(sixABlock).toMatch(/git diff --name-only/);
-    // 6a-noaction must appear BEFORE 6a-pre (capture before guard, since both inspect
-    // implementer summaries — capturing first lets the guard reuse the parsed scope).
     const noactionIdx = sixABlock.indexOf("6a-noaction");
     const preIdx = sixABlock.indexOf("6a-pre");
     expect(noactionIdx).toBeGreaterThan(-1);


### PR DESCRIPTION
**✅ Ready for review — goal achieved.**

Implements #309 — Consume implementer scope non-action reports.

Surfaced by Phase 2 of the `iterate-one-issue` run for #302: the implementer agent template requires `**Did NOT do (scope):** ...` in every Implementation Summary, but the iterate skill has no consumer for those reports — they evaporate into agent-output text and never reach iteration state, the PR, or follow-up issues.

This PR closes the gap with five coordinated changes:

1. **`6a-noaction. Scope non-action capture`** in SKILL.md Step 6 — parses every implementer summary's `**Did NOT do (scope):**` field with explicit start/end markers (`^\*\*[A-Z][A-Za-z ]+:\*\*` for end), preserves indentation, handles empty/none + multiple sections + malformed (capture to EOF + WARN).
2. **Branch-level state**: `scope_non_actions[]` lives in `## Open scope non-actions` and `## Resolved scope non-actions` sections of the state file (not per-iteration), so pending entries survive across DEGRADED iterations until explicitly dispositioned.
3. **`8-pre. Scope non-action disposition gate`** in SKILL.md Step 8 — requires every Open entry to have a non-pending disposition before recording PASSED. Three-value enum: `accepted` (with rationale), `handled-in-forward-fix` (with commit SHA), `follow-up-issue:<N>` (with verified open issue). Pending → DEGRADED.
4. **Termination preconditions** in `references/done-handlers.md` — runs the same gate before ANY Done-X handler (Done-Achieved, Done-Blocked, Done-TimedOut). Catches the Step 2 → Done-Achieved shortcut at the SKILL.md "Termination" table that bypasses Steps 3–8.5 (and 8-pre). Forces Done-Blocked (NOT Done-Achieved) on undisposed entries.
5. **6d step 3 forward-fix re-run** — both 6a-noaction AND 6a-pre re-run against forward-fix Implementation Summaries (`implementer_attempt_id: iter-<N>-6d-attempt-<K>`).

Plus: Step 8.5 retro context block now includes scope_non_actions for Phase 2 cross-run pattern detection; `state_schema_version: 1` added to 0g frontmatter for forward compatibility.

A 14-assertion regression test in `src/__tests__/iterate-skill-contract.test.ts` locks every invariant against future drift (43/43 contract tests pass, was 29 pre-existing).

## Progress

Acceptance criteria from the groomed spec:

- [x] Update `.claude/skills/iterate-one-issue/SKILL.md` Step 6 so every `exe-task-implementer` result is scanned for a `Did NOT do (scope)` section, and every non-empty item is captured in iteration state with enough context to identify the source implementer attempt. (`6a-noaction` sub-step + `implementer_attempt_id` field.)
- [x] Update `.claude/skills/iterate-one-issue/SKILL.md` Step 6d/finalization rules so every captured `Did NOT do (scope)` item must be dispositioned before PASSED as one of: accepted/no action needed, handled during forward-fix, converted into an explicit follow-up, or rejected with rationale. (`8-pre` gate + 3-value enum — folded `rejected` into `accepted with rationale` per lean-expert review; covers all four conceptual cases. Plus termination-precondition gate in `references/done-handlers.md` to cover the Step 2 → Done-Achieved bypass.)
- [x] Update Step 8 or the final iteration-log requirements in `.claude/skills/iterate-one-issue/SKILL.md` so scope non-action dispositions are visible in the durable run summary/carry-over output, not only in transient agent text. (`Scope-non-actions:` field in Step 8 record template + branch-level `## Open` / `## Resolved` sections + Step 8.5 retro context feed + PR comment surface.)
- [x] Preserve the existing issue #302 formatter guard behavior: the skill must still forbid workspace-wide Rust formatting and still run the scope-diff guard for primary and forward-fix commits. (All 11 #302 contract assertions still pass; 6a-noaction sits BEFORE 6a-pre — locked by ordering assertion.)
- [x] Regression test: update `src/__tests__/iterate-skill-contract.test.ts` with a contract assertion that a synthetic implementer summary containing `Did NOT do (scope): rustfmt outside declared files` requires a visible disposition before PASSED output. (14 new assertions; the synthetic example is locked into SKILL.md's 6a-noaction worked-example block via `expect(SKILL).toContain("rustfmt outside declared files")`.)

## Validation

- `npx tsc --noEmit` PASS
- `npm test` → 1587 passed, 1 skipped (1 known #281 skip)
- `npm run lint` PASS (exit 0; pre-existing warnings only — none from this diff)
- `npx eslint src/__tests__/iterate-skill-contract.test.ts --max-warnings=0` clean
- `npm run test:e2e` → 131 passed
- `npm run test:e2e:native` → 19 passed + 1 missing-NSIS-prerequisite skip (orthogonal to this diff)
- CI on PR: 8 checks pass, 3 skipping per workflow path filters

Expert review (1 forward-fix wave converged): lean / docs / test approve first pass; arch + rubber-duck approve after the consolidated forward-fix that resolved 6 BLOCKs (3 from arch — termination chokepoint, branch-level carry-over, retro feed; 3 from duck — 6d re-run, parse boundaries, cross-iteration closure) plus 5 lean cuts (drop rejected enum, drop task_id, replace tautological synthetic test, trim redundant regression assertion, delete aspirational reuse comment).

Closes #309
