### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ src-tauri/binaries/mdownreview-cli-*
 .claude/iterate-loop/runs/
 .claude/retrospectives/
 
+# Scheduling system runtime lock — regenerated automatically
+.claude/scheduled_tasks.lock
+


### PR DESCRIPTION
## Summary

- The scheduling system regenerates `.claude/scheduled_tasks.lock` automatically every session.
- Without this entry, `iterate-one-issue`'s pre-flight refuses to run because `git status` reports the lock as an untracked file (dirty tree).
- Other `.claude/` runtime artefacts (iterate-loop runs, retrospectives, test-exploratory runs) are already gitignored — same pattern.

## Test plan

- [ ] After merge, delete a local `.claude/scheduled_tasks.lock` (let the scheduler recreate it) and run `git status` — it should not appear.
- [ ] Re-invoke `/iterate-one-issue` against any open issue — pre-flight should pass with a clean tree.