### PR TITLE
feat: implement #331  test-expert bypass-vector enumeration for source-byte regression guards

### DIFF
--- a/.claude/agents/test-expert.md
+++ b/.claude/agents/test-expert.md
@@ -20,6 +20,19 @@ description: Reviews test completeness, pyramid layer choice, reliability, mock 
 - Mock contract drift (IPC mock missing a new command).
 - Flake patterns: `waitFor` without timeout reason, time-based sleeps, ordering assumptions.
 - Cross-library fixture fidelity — does a test that consumes external library output (filenames, paths, structured data) populate its fixture by reading the registered version's actual on-disk shape, or was it hand-written from documentation? Hand-written shape inference is a Rule 26 violation in [`docs/test-strategy.md`](../../docs/test-strategy.md).
+- **Bypass-vector enumeration on source-byte regression guards (issue #331).** Trigger: the diff contains `include_str!(...)` AND `assert!(...contains(...))` (or an equivalent loop over a `forbidden`/`needles`/`bypass`/`bad_patterns` array — also includes `.iter().any(|n| src.contains(n))` shapes). When triggered, enumerate **at least 3 bypass vectors** a future test author could plausibly use to write code that violates the rule the guard is protecting yet still slips past `contains`. For each vector, state explicitly whether the current needle set catches it; if NOT, propose either (a) an additional needle / check the diff should add in the same iteration, OR (b) an explicit out-of-scope rationale for why that vector is intentionally not covered. This is structurally a "red-team your own guard" check — it parallelises the work `rubber-duck` would otherwise catch one panel-turn later.
+
+  **Worked example (PR #323 — Rule-26 log-rotation guard):** the original guard used the year-prefix needle `"<prefix>.20"` to forbid hand-built fixture literals against `tauri-plugin-log`'s rotation filenames. `rubber-duck` red-teamed three bypass vectors that the test-expert pre-consult missed:
+  1. **Constant-interpolation bypass** — `format!("{FILE_PREFIX}.{stamp}{FILE_SUFFIX}")` reconstructs the filename without literal `<prefix>.20...` ever appearing in source.
+  2. **Non-year literal bypass** — `"mdownreview.placeholder.log"` matches the rotation filename shape but has no `20` year prefix.
+  3. **Concat reconstruction** — `[FILE_PREFIX, ".", &stamp, FILE_SUFFIX].concat()` (or `.join("")`) builds the same string from pieces.
+  Forward-fix `9d663d8` adopted vectors 1 and 2 by adding the placeholder needle pair `format!("<prefix>.{` / `format!("<prefix>_{`. Catching these at pre-consult time would have saved one forward-fix iteration. When the trigger fires on a future PR, your output MUST contain a `### Bypass-vector enumeration` block with this shape:
+  ```
+  ### Bypass-vector enumeration (file:line of include_str!/contains site)
+  1. <vector description> — caught? <yes (cite needle) | no — propose: <needle | rationale>>
+  2. <vector description> — caught? <…>
+  3. <vector description> — caught? <…>
+  ```
 
 **Out of scope (handoff):**
 - Underlying bug itself → `bug-expert`.
@@ -35,4 +48,6 @@ description: Reviews test completeness, pyramid layer choice, reliability, mock 
 - [test path] issue — fix
 ### Mock hygiene
 - [mock path] drift — fix
+### Bypass-vector enumeration (issue #331 — only when trigger fires)
+- only emit when the diff contains include_str! + contains/needles loop; format per the worked example in Always check
 ```

--- a/src/__tests__/iterate-skill-contract.test.ts
+++ b/src/__tests__/iterate-skill-contract.test.ts
@@ -40,6 +40,12 @@ const LEAN_EXPERT_PATH = resolve(
   "../../.claude/agents/lean-expert.md",
 );
 const LEAN_EXPERT = readFileSync(LEAN_EXPERT_PATH, "utf8");
+
+const TEST_EXPERT_PATH = resolve(
+  __dirname,
+  "../../.claude/agents/test-expert.md",
+);
+const TEST_EXPERT = readFileSync(TEST_EXPERT_PATH, "utf8");
 describe("iterate-one-issue skill — DIFF_CLASS scoping (issue #122)", () => {
   it("Step 6b classifies the diff into code | prompt-only | docs-only | none", () => {
     expect(SKILL).toMatch(/####\s+6b\.?\s+Classify diff/i);
@@ -815,5 +821,109 @@ describe("iterate-one-issue skill — Phase 1.5 inline-fix carry-over (Done-Achi
     expect(DONE_HANDLERS).not.toMatch(/INLINE_FIX_USED/);
     expect(DONE_HANDLERS).not.toMatch(/inline-fix/i);
     expect(DONE_HANDLERS).not.toMatch(/Phase 1\.5/);
+  });
+});
+
+/**
+ * Issue #331 — test-expert pre-consult must enumerate bypass vectors when
+ * reviewing source-byte regression guards (e.g. `include_str!`-based
+ * `contains` assertions). The original lapse was on PR #323 (Rule-26
+ * log-rotation guard), where rubber-duck caught three bypass vectors that
+ * test-expert's pre-consult had not red-teamed — costing one forward-fix
+ * iteration. Locking the agent prompt here parallelises that check.
+ */
+describe("test-expert agent — bypass-vector enumeration for source-byte regression guards (issue #331)", () => {
+  it("test-expert.md Always-check section embeds the bypass-vector enumeration rule with a trigger pattern", () => {
+    const alwaysCheckIdx = TEST_EXPERT.indexOf("**Always check:**");
+    const outOfScopeIdx = TEST_EXPERT.indexOf("**Out of scope", alwaysCheckIdx);
+    expect(alwaysCheckIdx).toBeGreaterThan(-1);
+    expect(outOfScopeIdx).toBeGreaterThan(alwaysCheckIdx);
+    const alwaysBlock = TEST_EXPERT.slice(alwaysCheckIdx, outOfScopeIdx);
+
+    // Rule must be present and self-identify as the issue #331 follow-on.
+    expect(alwaysBlock).toMatch(/Bypass-vector enumeration/i);
+    expect(alwaysBlock).toMatch(/issue #331/);
+
+    // Trigger pattern must enumerate BOTH halves: include_str! AND a contains/needles loop.
+    expect(alwaysBlock).toMatch(/include_str!/);
+    expect(alwaysBlock).toMatch(/contains/);
+    expect(alwaysBlock).toMatch(/forbidden|needles|bypass|bad_patterns/);
+
+    // Quantitative requirement: ≥3 vectors, each with explicit catches-it verdict.
+    expect(alwaysBlock).toMatch(/at least 3 bypass vectors/);
+    expect(alwaysBlock).toMatch(/state explicitly whether/);
+    // Each uncaught vector must propose either (a) needle/check or (b) out-of-scope rationale.
+    expect(alwaysBlock).toMatch(/needle/);
+    expect(alwaysBlock).toMatch(/out-of-scope rationale/);
+  });
+
+  it("test-expert.md cites the PR #323 worked example with all three bypass-vector categories", () => {
+    // The worked example is the prompt's concrete anchor — without it, "bypass
+    // vector" stays abstract. The PR #323 case spans three vector categories
+    // (constant-interpolation, non-year literal, concat reconstruction) — all
+    // three must be named so a future test-expert call has the templates.
+    expect(TEST_EXPERT).toMatch(/PR #323/);
+
+    // Vector 1 — constant-interpolation bypass.
+    expect(TEST_EXPERT).toMatch(/Constant-interpolation/i);
+    expect(TEST_EXPERT).toMatch(/format!\("\{FILE_PREFIX\}\.\{stamp\}\{FILE_SUFFIX\}"\)/);
+
+    // Vector 2 — non-year literal bypass.
+    expect(TEST_EXPERT).toMatch(/Non-year literal/i);
+    expect(TEST_EXPERT).toMatch(/"mdownreview\.placeholder\.log"/);
+
+    // Vector 3 — concat reconstruction.
+    expect(TEST_EXPERT).toMatch(/Concat reconstruction/i);
+    expect(TEST_EXPERT).toMatch(/concat\(\)|\.join\(""\)/);
+  });
+
+  it("test-expert.md cites the forward-fix commit that closed two of the three vectors (anchor for future regressions)", () => {
+    // Pin the commit SHA that adopted the bypass needles so a future
+    // regression has a concrete recovery reference. If the SHA is ever
+    // amended, this test will fail and force a deliberate refresh.
+    expect(TEST_EXPERT).toMatch(/9d663d8/);
+    // The placeholder needle pair from the forward-fix is the canonical
+    // "what does a bypass needle look like" example.
+    expect(TEST_EXPERT).toMatch(/format!\("<prefix>\.\{/);
+    expect(TEST_EXPERT).toMatch(/format!\("<prefix>_\{/);
+  });
+
+  it("test-expert.md mandates a `### Bypass-vector enumeration` block in the agent's output when the trigger fires", () => {
+    expect(TEST_EXPERT).toMatch(/### Bypass-vector enumeration/);
+    // Output template must enumerate the catches-it verdicts and the
+    // (a)/(b) propose alternatives so the format is consistent across runs.
+    const exampleBlock = TEST_EXPERT.slice(TEST_EXPERT.indexOf("### Bypass-vector enumeration"));
+    expect(exampleBlock).toMatch(/caught\?\s*<yes/);
+    expect(exampleBlock).toMatch(/no\s*[—-]\s*propose:/);
+  });
+
+  it("test-expert.md Output template lists Bypass-vector enumeration as a recognised section (with trigger gate)", () => {
+    const outputIdx = TEST_EXPERT.indexOf("**Output:**");
+    expect(outputIdx).toBeGreaterThan(-1);
+    const outputBlock = TEST_EXPERT.slice(outputIdx);
+    expect(outputBlock).toMatch(/### Bypass-vector enumeration/);
+    // The trigger gate must be reasserted in the Output template so a future
+    // rewrite that strips the Always-check section can't silently leave the
+    // Output expecting a section that's never produced.
+    expect(outputBlock).toMatch(/only when trigger fires|only emit when/i);
+  });
+
+  it("test-expert.md trigger pattern is scoped narrowly enough to avoid noise on every PR (issue #331 'Out of scope' constraint)", () => {
+    // The spec is explicit: "Broader bypass-vector enumeration for non-source-byte
+    // tests (e.g. behaviour-level tests). The trigger is explicitly include_str!
+    // + contains patterns; expanding scope risks noise on every PR."
+    // Verify the trigger names BOTH terms and is attached to the source-byte
+    // guard rule (not the general Always-check pyramid). Drift here would
+    // turn a narrowly-scoped check into a per-PR grind.
+    const alwaysCheckIdx = TEST_EXPERT.indexOf("**Always check:**");
+    const outOfScopeIdx = TEST_EXPERT.indexOf("**Out of scope", alwaysCheckIdx);
+    const alwaysBlock = TEST_EXPERT.slice(alwaysCheckIdx, outOfScopeIdx);
+    // Trigger words must co-locate within the same bullet (within 400 chars
+    // of "Bypass-vector enumeration" header).
+    const ruleIdx = alwaysBlock.indexOf("Bypass-vector enumeration");
+    const ruleSpan = alwaysBlock.slice(ruleIdx, ruleIdx + 600);
+    expect(ruleSpan).toMatch(/include_str!/);
+    expect(ruleSpan).toMatch(/contains/);
+    expect(ruleSpan).toMatch(/Trigger:/);
   });
 });


### PR DESCRIPTION
Implements #331  adds a bypass-vector enumeration check to `test-expert`'s pre-consult so adversarial gaps in source-byte regression guards (e.g. `include_str!`-based `contains` assertions) are caught at pre-consult time instead of at the rubber-duck panel one iteration later.

## What's in this PR

1. `.claude/agents/test-expert.md`  adds:
   - A new `Always check` bullet for cross-library fixtures' sibling: bypass-vector enumeration on source-byte regression guards.
   - A trigger pattern: `include_str!(...)` AND `assert!(...contains(...))` (or equivalent `forbidden` / `needles` loop).
   - A worked example from PR #323 (Rule-26 log-rotation guard) showing the three bypass vectors rubber-duck caught (constant-interpolation `format!(""{FILE_PREFIX}.{stamp}{FILE_SUFFIX}"")`, non-year literal `""mdownreview.placeholder.log""`, concat reconstruction).
2. `src/__tests__/iterate-skill-contract.test.ts`  new describe block (`test-expert bypass-vector enumeration (issue #331)`) that locks the agent-prompt invariants: the trigger pattern, the worked example, and the requirement to enumerate 3 vectors with explicit catches-it-or-not verdicts.

## Acceptance criteria (verbatim from #331 spec)

- [ ] Update `.claude/agents/test-expert.md` to add a checklist item: "When reviewing source-byte regression guards or `include_str!`-based assertions, enumerate at least 3 bypass vectors a future test author could plausibly use to circumvent the assertion. For each, state explicitly whether the current implementation catches it; if not, propose either (a) a needle/check addition OR (b) an explicit out-of-scope rationale."
- [ ] Add a one-line trigger pattern: "If the diff contains `include_str!(...)` AND `assert!(...contains(...))` (or equivalent loop over a `forbidden`/`needles` array), run the bypass-vector enumeration check above as part of the pre-consult."
- [ ] Add a small worked example citing PR #323 (year-prefix needle missed `format!(""<prefix>.{stamp}...` and `""<prefix>.placeholder.log""`).
- [ ] Regression test: agent-prompt invariants asserted in `src/__tests__/iterate-skill-contract.test.ts` (no agent test harness exists; markdown-invariant lock matches the established pattern for `lean-expert`, `exe-task-implementer`, etc.).

## Closes
Closes #331

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>