### PR TITLE
fix(mermaid): redefine 100% as fit-to-window, pixel-perfect zoom, themed popout card

### DIFF
--- a/src/components/viewers/MermaidView.tsx
+++ b/src/components/viewers/MermaidView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 
 import { MermaidCanvas } from "./mermaid/MermaidCanvas";
 import { MermaidControls } from "./mermaid/MermaidControls";
@@ -11,7 +11,7 @@ interface Props {
   content: string;
   /** Optional file path; when provided, MermaidRenderer stamps data-source-line for click-to-comment. */
   path?: string;
-  /** Per-filetype zoom from EnhancedViewer's useZoom('.mmd'). */
+  /** Per-filetype zoom from EnhancedViewer's useZoom('.mmd'). 1.0 = "fits the viewing area". */
   zoom?: number;
 }
 
@@ -21,9 +21,8 @@ interface Props {
  * Render + theme + transform + pan/zoom now live in MermaidCanvas (which
  * composes MermaidRenderer). This file only owns:
  *   1. Wiring the shared `.mmd` zoom (via `useStore`) into MermaidCanvas.
- *   2. Capturing the most recent fit-to-window scale and routing the Fit
- *      button click to it. EnhancedViewer is the zoom source-of-truth — we
- *      mutate via setZoom('.mmd', …) rather than holding local zoom state.
+ *   2. Routing the Fit button click to a zoom reset (1.0 ≡ fit-to-window
+ *      under the hybrid scale model owned by MermaidCanvas).
  *   3. Showing the inline Fit + Pop-out controls ONLY for the dedicated
  *      viewer path (signalled by the presence of `path`). The embedded
  *      markdown-block path (MarkdownComponentsMap → MermaidView, until
@@ -32,27 +31,14 @@ interface Props {
  */
 export function MermaidView({ content, path, zoom = 1 }: Props) {
   const setZoom = useStore((s) => s.setZoom);
+  const bumpZoom = useStore((s) => s.bumpZoom);
   const openMermaidPopout = useStore((s) => s.openMermaidPopout);
 
-  // Fit logic: store the most recent fit scale in a ref. On Fit-button
-  // click, write it to the shared '.mmd' zoom. On first measurement (when
-  // '.mmd' zoom is undefined), seed the shared zoom too so the initial
-  // open lands at fit-to-window rather than 100%.
-  const lastFitRef = useRef<number | null>(null);
-  const handleFitMeasured = useCallback(
-    (fit: number) => {
-      lastFitRef.current = fit;
-      const current = useStore.getState().zoomByFiletype[".mmd"];
-      if (current === undefined) {
-        setZoom(".mmd", fit);
-      }
-    },
-    [setZoom],
-  );
-
+  // 1.0 ≡ fit under MermaidCanvas's scale model, so "Fit" is just a zoom
+  // reset. Same chokepoint chrome's ViewerToolbar uses for Cmd+0 etc.
   const handleFitClick = useCallback(() => {
-    if (lastFitRef.current !== null) setZoom(".mmd", lastFitRef.current);
-  }, [setZoom]);
+    bumpZoom(".mmd", "reset");
+  }, [bumpZoom]);
 
   const handlePopout = useCallback(() => {
     openMermaidPopout(content, path ?? null);
@@ -69,7 +55,6 @@ export function MermaidView({ content, path, zoom = 1 }: Props) {
         zoom={zoom}
         setZoom={(v) => setZoom(".mmd", v)}
         readOnly={false}
-        onFitMeasured={handleFitMeasured}
       />
       {path !== undefined && (
         <MermaidControls

--- a/src/components/viewers/__tests__/MermaidCanvas.test.tsx
+++ b/src/components/viewers/__tests__/MermaidCanvas.test.tsx
@@ -103,19 +103,16 @@ afterEach(() => {
 async function renderCanvas(overrides: {
   zoom?: number;
   setZoom?: (v: number) => void;
-  onFitMeasured?: (v: number) => void;
   content?: string;
   path?: string | null;
 } = {}) {
   const setZoom = overrides.setZoom ?? vi.fn();
-  const onFitMeasured = overrides.onFitMeasured ?? vi.fn();
   const utils = render(
     <MermaidCanvas
       content={overrides.content ?? "graph TD; A --> B"}
       path={overrides.path ?? null}
       zoom={overrides.zoom ?? 1}
       setZoom={setZoom}
-      onFitMeasured={onFitMeasured}
     />,
   );
   // Wait for the async renderMermaid → useLayoutEffect → svg injection.
@@ -127,7 +124,7 @@ async function renderCanvas(overrides: {
   // Stub pointer-capture for jsdom (mirror ImageViewer.test.tsx:76-77).
   canvas.setPointerCapture = vi.fn();
   canvas.releasePointerCapture = vi.fn();
-  return { ...utils, canvas, transform, setZoom, onFitMeasured };
+  return { ...utils, canvas, transform, setZoom };
 }
 
 describe("MermaidCanvas — composition", () => {
@@ -139,16 +136,29 @@ describe("MermaidCanvas — composition", () => {
     expect(transform.contains(container.querySelector('[title="Mermaid diagram"]'))).toBe(true);
   });
 
-  it("applies the initial transform on render (translate(0px, 0px) scale(1))", async () => {
-    const { transform } = await renderCanvas({ zoom: 1 });
+  it("applies the initial transform on render and bakes scale into SVG dimensions", async () => {
+    // Hybrid scale model: scale is baked into svg.style.width/height
+    // (committed scale), and the wrapper transform's scale = effective /
+    // committed. After handleSvgReady, committed = effective = zoom × fit
+    // = 1 × 0.4 = 0.4, so transform scale ratio = 1.
+    const { container, transform } = await renderCanvas({ zoom: 1 });
     expect(transform.style.transform).toContain("translate(0px, 0px)");
     expect(transform.style.transform).toContain("scale(1)");
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    // bbox 2000×1500 baked at scale 0.4 → 800×600 (fits the 800×600 container).
+    expect(svg.style.width).toBe("800px");
+    expect(svg.style.height).toBe("600px");
+    // maxWidth disabled so the SVG can grow past mermaid's inline `max-width: 100%`.
+    expect(svg.style.maxWidth).toBe("none");
   });
 });
 
 describe("MermaidCanvas — wheel gestures", () => {
   it("vertical wheel pans (deltaY 100 → pan.y -= 100)", async () => {
-    const { canvas, transform } = await renderCanvas({ zoom: 1 });
+    // Start at zoom=2: under the 100%-as-fit model effective scale = 0.8,
+    // scaledH=1200 vs container 600 → limitY=300, so pan -100 has room.
+    // (At zoom=1 effective=fit=0.4, scaledH=container.h, limitY=0, no pan.)
+    const { canvas, transform } = await renderCanvas({ zoom: 2 });
     await act(async () => {
       fireEvent.wheel(canvas, { deltaY: 100, clientX: 200, clientY: 200 });
     });
@@ -161,13 +171,15 @@ describe("MermaidCanvas — wheel gestures", () => {
     await act(async () => {
       fireEvent.wheel(canvas, { deltaY: -100, ctrlKey: true, clientX: 200, clientY: 200 });
     });
-    // newZoom = 1 * (1 - (-100)*0.001) = 1.1
+    // newZoom = 1 * (1 - (-100)*0.001) = 1.1. The ratio S'/S = newZoom/zoom
+    // (fit cancels) so the formula is identical to the old natural-scale
+    // model and `setZoom` still receives the zoom value, not the effective.
     expect(setZoom).toHaveBeenCalledTimes(1);
     expect(setZoom.mock.calls[0][0]).toBeCloseTo(1.1, 5);
   });
 
   it("shift+wheel pans horizontally (deltaY 100 → pan.x -= 100)", async () => {
-    const { canvas, transform } = await renderCanvas({ zoom: 1 });
+    const { canvas, transform } = await renderCanvas({ zoom: 2 });
     await act(async () => {
       fireEvent.wheel(canvas, { deltaY: 100, shiftKey: true, clientX: 200, clientY: 200 });
     });
@@ -230,10 +242,13 @@ describe("MermaidCanvas — wheel gestures", () => {
 
 describe("MermaidCanvas — pan re-clamp on zoom change", () => {
   it("re-clamps panRef when zoom decreases past the previous limit", async () => {
-    // bbox 2000×1500, container 800×600. At zoom=1 limitX=600 so a wheel
-    // pan of (-100,0) is allowed. Drop zoom to 0.4 → scaledW=800=container,
-    // limitX=0 → pan must snap back to (0,0) on the zoom-effect path.
-    const { canvas, transform, rerender } = await renderCanvas({ zoom: 1 });
+    // Start at zoom=2.5 (effective = 2.5 × 0.4 = 1.0): scaledH=1500 vs
+    // container 600 → limitY=450, so a wheel pan of (0,-100) is allowed.
+    // Drop zoom to 1 → effective=0.4 → scaledH=600=container → limitY=0,
+    // pan must snap back to (0,0) on the zoom-effect path. The wrapper
+    // scale ratio drops from 1.0/1.0=1 (committed at initial bake) to
+    // 0.4/1.0=0.4 (new effective / committed).
+    const { canvas, transform, rerender } = await renderCanvas({ zoom: 2.5 });
     await act(async () => {
       fireEvent.wheel(canvas, { deltaY: 100, clientX: 200, clientY: 200 });
     });
@@ -243,9 +258,8 @@ describe("MermaidCanvas — pan re-clamp on zoom change", () => {
         <MermaidCanvas
           content="graph TD; A --> B"
           path={null}
-          zoom={0.4}
+          zoom={1}
           setZoom={vi.fn()}
-          onFitMeasured={vi.fn()}
         />,
       );
     });
@@ -256,7 +270,9 @@ describe("MermaidCanvas — pan re-clamp on zoom change", () => {
 
 describe("MermaidCanvas — pointer drag", () => {
   it("drag-pan: setPointerCapture called; pan updates; cursor cycles grab → grabbing → grab", async () => {
-    const { canvas, transform } = await renderCanvas({ zoom: 1 });
+    // Use zoom=2 (effective 0.8) so pan limits give room for a (50,80)
+    // delta — at zoom=1 (effective=fit=0.4) scaledW=container.w → no pan.
+    const { canvas, transform } = await renderCanvas({ zoom: 2 });
     expect(canvas.className).toContain("mermaid-canvas--interactive");
     expect(canvas.className).not.toContain("mermaid-canvas--dragging");
 
@@ -285,18 +301,47 @@ describe("MermaidCanvas — pointer drag", () => {
   });
 });
 
-describe("MermaidCanvas — fit measurement + reset", () => {
-  it("emits onFitMeasured with min(cw/bw, ch/bh, 1) when SVG renders", async () => {
-    const onFitMeasured = vi.fn();
-    await renderCanvas({ onFitMeasured });
-    // bbox 2000×1500 inside 800×600 → fit = min(0.4, 0.4, 1) = 0.4
-    await waitFor(() => expect(onFitMeasured).toHaveBeenCalled());
-    const last = onFitMeasured.mock.calls[onFitMeasured.mock.calls.length - 1][0];
-    expect(last).toBeCloseTo(0.4, 5);
+describe("MermaidCanvas — fit-to-window + reset + bake", () => {
+  it("sizes SVG to fit the container at zoom=1 (uncapped fit, allows scaling up too)", async () => {
+    const { container } = await renderCanvas({ zoom: 1 });
+    // bbox 2000×1500 in 800×600 → fit = min(0.4, 0.4) = 0.4 (no `,1` cap).
+    // Effective = 1 × 0.4 = 0.4. SVG baked at 2000×0.4 = 800px wide.
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg.style.width).toBe("800px");
+    expect(svg.style.height).toBe("600px");
   });
 
-  it("resets pan to (0,0) when content changes", async () => {
-    const { canvas, transform, rerender } = await renderCanvas({ zoom: 1, content: "graph TD; A --> B" });
+  it("upscales SVG when natural is smaller than container (fit > 1, no `,1` cap)", async () => {
+    // Override getBBox shim for this test: tiny diagram 200×150 in 800×600.
+    Object.defineProperty(SVGElement.prototype, "getBBox", {
+      configurable: true,
+      value: () => ({ x: 0, y: 0, width: 200, height: 150 }),
+    });
+    const { container } = await renderCanvas({ zoom: 1 });
+    // fit = min(800/200, 600/150) = min(4, 4) = 4.
+    // Effective = 1 × 4 = 4. SVG baked at 200×4 = 800px wide.
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg.style.width).toBe("800px");
+    expect(svg.style.height).toBe("600px");
+  });
+
+  it("caps baked SVG dimensions at 8192px to prevent pathological growth", async () => {
+    // Container 2000×2000, bbox 2000×1500 (default shim) → fit=min(1,1.33)=1.
+    // At zoom=ZOOM_MAX=8 effective=8, would bake at 16000×12000.
+    // Cap kicks in: k = min(8192/16000, 8192/12000) = 0.512 → 8192×6144.
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, get: () => 2000 });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => 2000 });
+    const { container } = await renderCanvas({ zoom: 8 });
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(parseFloat(svg.style.width)).toBeCloseTo(8192, 0);
+    expect(parseFloat(svg.style.height)).toBeCloseTo(6144, 0);
+  });
+
+  it("resets pan to (0,0) when content changes and re-bakes SVG dimensions", async () => {
+    const { canvas, container, transform, rerender } = await renderCanvas({
+      zoom: 2,
+      content: "graph TD; A --> B",
+    });
     await act(async () => {
       fireEvent.wheel(canvas, { deltaY: 100, clientX: 200, clientY: 200 });
     });
@@ -307,13 +352,18 @@ describe("MermaidCanvas — fit measurement + reset", () => {
         <MermaidCanvas
           content="graph TD; X --> Y"
           path={null}
-          zoom={1}
+          zoom={2}
           setZoom={vi.fn()}
-          onFitMeasured={vi.fn()}
         />,
       );
     });
     // Content effect resets panRef; useLayoutEffect re-applies.
     expect(transform.style.transform).toContain("translate(0px, 0px)");
+    // Re-bake fired (handleSvgReady runs again on new svg) — SVG dims still
+    // reflect natural × effective at the new content's measurement.
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    // bbox 2000×1500 (shim is module-level), zoom=2, fit=0.4 → effective=0.8.
+    expect(svg.style.width).toBe("1600px");
+    expect(svg.style.height).toBe("1200px");
   });
 });

--- a/src/components/viewers/__tests__/MermaidPopout.test.tsx
+++ b/src/components/viewers/__tests__/MermaidPopout.test.tsx
@@ -16,7 +16,6 @@ type CanvasProps = {
   zoom: number;
   setZoom: (v: number) => void;
   readOnly?: boolean;
-  onFitMeasured?: (v: number) => void;
 };
 type ControlsProps = {
   mode: "inline" | "popout";
@@ -116,7 +115,7 @@ describe("MermaidPopout — visibility gating", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders the dialog overlay when open", () => {
+  it("renders the dialog overlay + inner card when open", () => {
     state.mermaidPopoutOpenFor = { content: "graph TD; A-->B", path: "/x.mmd" };
     const { container } = render(<MermaidPopout />);
     const overlay = container.querySelector(
@@ -124,6 +123,13 @@ describe("MermaidPopout — visibility gating", () => {
     );
     expect(overlay).not.toBeNull();
     expect(overlay?.classList.contains("mermaid-popout-overlay")).toBe(true);
+    // aria-modal=false reflects reality: no focus trap, no backdrop dim.
+    expect(overlay?.getAttribute("aria-modal")).toBe("false");
+    // Inner card is the visible chrome (theme background, border, shadow);
+    // overlay is just a transparent click interceptor.
+    const card = container.querySelector(".mermaid-popout-card");
+    expect(card).not.toBeNull();
+    expect(overlay?.contains(card)).toBe(true);
   });
 });
 
@@ -143,6 +149,17 @@ describe("MermaidPopout — child wiring", () => {
     expect(captured.controls).not.toBeNull();
     expect(captured.controls?.mode).toBe("popout");
     expect(typeof captured.controls?.onClose).toBe("function");
+  });
+
+  it("Fit handler calls bumpZoom('.mmd', 'reset') — 1.0 ≡ fit-to-window", () => {
+    state.mermaidPopoutOpenFor = { content: "x", path: null };
+    render(<MermaidPopout />);
+    expect(captured.controls?.onFit).toBeDefined();
+    act(() => {
+      captured.controls?.onFit();
+    });
+    // useZoom('.mmd').reset() routes through bumpZoom('reset') → ZOOM_DEFAULT (1.0).
+    expect(state.bumpZoom).toHaveBeenCalledWith(".mmd", "reset");
   });
 });
 
@@ -171,28 +188,5 @@ describe("MermaidPopout — Esc keydown", () => {
     });
     fireEvent.keyDown(document, { key: "Escape" });
     expect(state.closeMermaidPopout).not.toHaveBeenCalled();
-  });
-});
-
-describe("MermaidPopout — fit-to-window seeding", () => {
-  it("seeds setZoom on first measurement when zoomByFiletype['.mmd'] is undefined", () => {
-    state = freshState({ zoomByFiletype: {} });
-    state.mermaidPopoutOpenFor = { content: "x", path: null };
-    render(<MermaidPopout />);
-    expect(captured.canvas?.onFitMeasured).toBeDefined();
-    act(() => {
-      captured.canvas?.onFitMeasured?.(0.7);
-    });
-    expect(state.setZoom).toHaveBeenCalledWith(".mmd", 0.7);
-  });
-
-  it("does NOT seed setZoom when zoomByFiletype['.mmd'] already exists", () => {
-    state = freshState({ zoomByFiletype: { ".mmd": 2 } });
-    state.mermaidPopoutOpenFor = { content: "x", path: null };
-    render(<MermaidPopout />);
-    act(() => {
-      captured.canvas?.onFitMeasured?.(0.7);
-    });
-    expect(state.setZoom).not.toHaveBeenCalled();
   });
 });

--- a/src/components/viewers/mermaid/MermaidCanvas.tsx
+++ b/src/components/viewers/mermaid/MermaidCanvas.tsx
@@ -8,22 +8,39 @@ interface Props {
   content: string;
   /** Source path; forwarded to MermaidRenderer for the data-source-line walk. */
   path?: string | null;
-  /** Current zoom (1.0 = 100%). React-owned via useZoom('.mmd') from the parent. */
+  /**
+   * Current zoom (1.0 = "fits the viewing area"). React-owned via
+   * `useZoom('.mmd')` from the parent. The diagram's effective on-screen
+   * scale is `zoom × fitScale`, where `fitScale = min(cw/naturalW, ch/naturalH)`
+   * is recomputed from the rendered SVG. This is a deliberate departure
+   * from "1.0 = natural pixels" — Mermaid SVGs have no meaningful natural
+   * pixel size (vector-only), so anchoring 100% to fit-to-window matches
+   * user expectations and produces a sensible default open size for both
+   * tiny and oversized diagrams.
+   */
   zoom: number;
   /** Setter for the zoom state. Used by wheel-zoom + pinch + Fit. */
   setZoom: (value: number) => void;
   /** When true: data-source-line walk skipped (popout). */
   readOnly?: boolean;
-  /**
-   * Called once per content change with the computed fit-to-window scale.
-   * Caller decides whether to seed setZoom (avoid clobbering shared zoom on
-   * subsequent opens).
-   */
-  onFitMeasured?: (fitScale: number) => void;
 }
 
 /** Cursor-anchored zoom sensitivity (unitless: deltaY * sens scales 1.0 → 1.1 per ~100px wheel tick). */
 const ZOOM_SENSITIVITY = 0.001;
+
+/** Hard cap on the SVG's baked pixel dimensions per axis. Prevents
+ *  pathological cases where a tiny diagram + uncapped fit-upscale +
+ *  ZOOM_MAX (8.0) could produce gigantic intrinsic sizes. Per
+ *  `docs/performance.md` rule 1 (every unbounded input has a hard cap).
+ *  8192 is a common GPU texture limit; staying under it keeps each
+ *  axis representable as a single GPU layer if the browser promotes one. */
+const MAX_BAKED_PX = 8192;
+
+/** Idle window after which interactive `transform: scale(...)` is
+ *  committed to crisp baked SVG `style.width/height`. Keeps wheel/pinch
+ *  zoom on the cheap GPU compositor path during interaction; only pays
+ *  the layout/paint cost once per "settle". */
+const SETTLE_MS = 150;
 
 function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
@@ -33,21 +50,37 @@ function clamp(v: number, lo: number, hi: number): number {
  * Interaction shell for the dedicated Mermaid viewer (issue #276).
  *
  * Composes <MermaidRenderer/> inside a transform wrapper and owns wheel /
- * pointer / pinch gestures plus the pan + transform state. Pan and zoom are
- * applied imperatively — refs hold the live values, a single
- * useLayoutEffect on every render writes `style.transform` so React cannot
- * stomp the value when re-rendering for unrelated reasons (per
+ * pointer / pinch gestures plus the pan + transform state.
+ *
+ * Hybrid scale model:
+ *   - **Effective scale** = `zoom × fitScale`. `zoom = 1.0` ≡ fit-to-window.
+ *   - **During interaction**: cheap CSS `transform: scale(effective/committed)`
+ *     on the wrapper div (pan applied via `translate(...)` on the same
+ *     wrapper). GPU-composited; no DOM reflow per frame.
+ *   - **On settle** (150 ms idle): write the new effective scale into the
+ *     SVG's intrinsic `style.width/height` and reset the wrapper's
+ *     transform scale to 1. The browser re-rasterizes text /
+ *     foreignObject content at the new intrinsic size → crisp output.
+ *
+ * Imperative refs hold the live values (pan, committed scale, fit, zoom
+ * mirror) and a single `useLayoutEffect` on every render writes the
+ * wrapper's `style.transform`, so React cannot stomp the value when
+ * re-rendering for unrelated reasons (per
  * `docs/best-practices-common/react/rerender-optimization.md`: the
  * "pan tick = no re-render" pattern).
  */
-export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMeasured }: Props) {
+export function MermaidCanvas({ content, path, zoom, setZoom, readOnly }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const transformRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
 
-  // Imperative state — pan in pixels, natural svg bbox, latest fit scale.
+  // Imperative state — pan in pixels, natural svg size in CSS px,
+  // latest fit scale, latest committed (baked) scale, zoom mirror.
   const panRef = useRef({ x: 0, y: 0 });
   const naturalRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
   const fitScaleRef = useRef(1);
+  const committedScaleRef = useRef(1);
+  const zoomRef = useRef(zoom);
 
   // Drag + pinch state. Plain refs so updates never trigger re-render.
   const draggingRef = useRef<
@@ -56,15 +89,44 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
   const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
   const pinchRef = useRef<{ initialDistance: number; initialZoom: number } | null>(null);
   const rafRef = useRef<number | null>(null);
+  const settleTimerRef = useRef<number | null>(null);
 
   // Sole React state — drives the cursor: grab vs grabbing.
   const [isDragging, setIsDragging] = useState(false);
 
-  // Imperative transform writer. Reads zoom prop directly from closure.
+  /** Bake `scale` into the SVG's intrinsic CSS dimensions so the browser
+   *  re-rasterizes text/foreignObject at the new size (crisp). Capped at
+   *  MAX_BAKED_PX per axis with aspect preserved. */
+  const applyScaleToSvg = (scale: number): number => {
+    const svg = svgRef.current;
+    const nat = naturalRef.current;
+    if (!svg || nat.w <= 0 || nat.h <= 0) return scale;
+    let w = nat.w * scale;
+    let h = nat.h * scale;
+    if (w > MAX_BAKED_PX || h > MAX_BAKED_PX) {
+      const k = Math.min(MAX_BAKED_PX / w, MAX_BAKED_PX / h);
+      w *= k;
+      h *= k;
+    }
+    svg.style.maxWidth = "none";
+    svg.style.width = `${w}px`;
+    svg.style.height = `${h}px`;
+    // Return the actually-applied scale (may differ from input when capped)
+    // so the caller can keep `committedScaleRef` in sync.
+    return nat.w > 0 ? w / nat.w : scale;
+  };
+
+  /** Imperative transform writer. The wrapper owns translate (pan) AND a
+   *  scale ratio (`effective / committed`) that bridges the gap between
+   *  the user's current effective scale and the most recently baked SVG
+   *  size. After settle, ratio = 1 and the transform is translate-only. */
   const applyTransform = () => {
     const el = transformRef.current;
     if (!el) return;
-    el.style.transform = `translate(${panRef.current.x}px, ${panRef.current.y}px) scale(${zoom})`;
+    const effective = zoom * fitScaleRef.current;
+    const committed = committedScaleRef.current || 1;
+    const ratio = effective / committed;
+    el.style.transform = `translate(${panRef.current.x}px, ${panRef.current.y}px) scale(${ratio})`;
   };
 
   const scheduleApply = () => {
@@ -75,12 +137,32 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
     });
   };
 
-  // Re-apply on every render. Any React render (theme switch, parent
-  // re-render, etc.) would otherwise reset the imperatively-written
-  // transform back to "" because the wrapper div has no inline style.
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: runs every render
+  /** Debounced "settle" — after `SETTLE_MS` of no zoom changes, commit
+   *  the current effective scale into the SVG's intrinsic dimensions and
+   *  reset the wrapper's transform scale to 1. Cheap no-op when the
+   *  effective scale already equals the committed scale. */
+  const scheduleSettle = () => {
+    if (settleTimerRef.current !== null) {
+      clearTimeout(settleTimerRef.current);
+    }
+    settleTimerRef.current = window.setTimeout(() => {
+      settleTimerRef.current = null;
+      const effective = zoomRef.current * fitScaleRef.current;
+      if (Math.abs(effective - committedScaleRef.current) < 1e-6) return;
+      const applied = applyScaleToSvg(effective);
+      committedScaleRef.current = applied;
+      applyTransform();
+    }, SETTLE_MS);
+  };
+
+  // Mirror the latest zoom into a ref so the deferred settle callback
+  // reads fresh state, then write transform + schedule settle. Runs every
+  // render (any React re-render — theme switch, parent re-render, etc.
+  // — would otherwise leave the imperatively-written transform stale).
   useLayoutEffect(() => {
+    zoomRef.current = zoom;
     applyTransform();
+    scheduleSettle();
   });
 
   // Reset pan when content changes (new diagram → start centered). Path
@@ -92,35 +174,68 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
     // eslint-disable-next-line react-hooks/exhaustive-deps -- applyTransform intentionally reads live refs
   }, [content, path]);
 
-  // Cleanup pending rAF on unmount.
+  // Cleanup pending rAF + settle timer on unmount.
   useEffect(() => {
     return () => {
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
     };
   }, []);
 
-  // Fit-to-window measurement — invoked when MermaidRenderer injects the
-  // <svg/>. Captures natural bbox into naturalRef (used by clampPan) and
-  // emits the computed fit scale through onFitMeasured. The parent decides
-  // whether to seed setZoom — this component never auto-applies it.
+  // SVG-ready callback — fires when MermaidRenderer injects the rendered
+  // SVG. Captures natural size (preferring `viewBox` for accuracy, falling
+  // back to `getBBox()` for jsdom), recomputes fit (uncapped — small
+  // diagrams scale UP to fit), bakes the current effective scale into the
+  // SVG's intrinsic dimensions, and re-clamps pan against the new natural
+  // size. Theme switches re-render mermaid (new SVG, possibly different
+  // bbox) without changing `zoom` or container dimensions, so the
+  // existing `[zoom]` and ResizeObserver re-clamp paths can miss the
+  // change — re-clamping here covers them.
   const handleSvgReady = useCallback((svg: SVGSVGElement) => {
-    let bbox: { width: number; height: number };
-    try {
-      const b = svg.getBBox();
-      bbox = { width: b.width, height: b.height };
-    } catch {
-      return; // jsdom without getBBox shim — bail silently.
+    svgRef.current = svg;
+    // Defeat mermaid's inline `style="max-width: 100%; ..."` so the SVG
+    // can grow past its natural rendered size when we bake larger dims.
+    svg.style.maxWidth = "none";
+
+    let natW = 0;
+    let natH = 0;
+    const vb = svg.viewBox?.baseVal;
+    if (vb && vb.width > 0 && vb.height > 0) {
+      natW = vb.width;
+      natH = vb.height;
+    } else {
+      try {
+        const b = svg.getBBox();
+        natW = b.width;
+        natH = b.height;
+      } catch {
+        return; // jsdom without getBBox shim — bail silently.
+      }
     }
-    if (bbox.width <= 0 || bbox.height <= 0) return;
-    naturalRef.current = { w: bbox.width, h: bbox.height };
+    if (natW <= 0 || natH <= 0) return;
+    naturalRef.current = { w: natW, h: natH };
+
     const c = containerRef.current;
     const cw = c?.clientWidth ?? 0;
     const ch = c?.clientHeight ?? 0;
     if (cw <= 0 || ch <= 0) return;
-    const fit = Math.min(cw / bbox.width, ch / bbox.height, 1);
+    // No `, 1` cap — fit > 1 is allowed so small diagrams scale UP to
+    // fill the viewport. Effective scale is then capped on the user-
+    // facing side via ZOOM_MIN/MAX × fit.
+    const fit = Math.min(cw / natW, ch / natH);
     fitScaleRef.current = fit;
-    onFitMeasured?.(fit);
-  }, [onFitMeasured]);
+
+    const effective = zoomRef.current * fit;
+    const applied = applyScaleToSvg(effective);
+    committedScaleRef.current = applied;
+
+    // Re-clamp pan against the new natural+effective. Pan was set in
+    // user-pixel space at a previous (now-stale) scale and may sit
+    // outside the new permissible window.
+    const next = clampPan(panRef.current, { w: cw, h: ch }, naturalRef.current, effective);
+    panRef.current = next;
+    applyTransform();
+  }, []);
 
   // Re-clamp pan whenever zoom changes (Fit / Reset / chrome shortcuts /
   // popout open) so a previously-allowed pan offset can't leave the diagram
@@ -132,11 +247,12 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
     const c = containerRef.current;
     const nat = naturalRef.current;
     if (!c || nat.w <= 0 || nat.h <= 0) return;
+    const effective = zoom * fitScaleRef.current;
     const next = clampPan(
       panRef.current,
       { w: c.clientWidth, h: c.clientHeight },
       nat,
-      zoom,
+      effective,
     );
     if (next.x !== panRef.current.x || next.y !== panRef.current.y) {
       panRef.current = next;
@@ -145,8 +261,10 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
     // eslint-disable-next-line react-hooks/exhaustive-deps -- applyTransform reads live refs/zoom
   }, [zoom]);
 
-  // ResizeObserver — recompute fit when the container resizes. We DO NOT
-  // auto-apply; the parent owns the seed-vs-keep decision.
+  // ResizeObserver — recompute fit, re-bake SVG dims at the new effective
+  // scale (so a window resize keeps the diagram sized to the new viewport
+  // even when the user has not touched zoom), and re-clamp pan. We do NOT
+  // rate-limit further — ResizeObserver itself is throttled by the browser.
   useEffect(() => {
     const c = containerRef.current;
     if (!c || typeof ResizeObserver === "undefined") return;
@@ -156,20 +274,22 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
       const cw = c.clientWidth;
       const ch = c.clientHeight;
       if (cw <= 0 || ch <= 0) return;
-      const fit = Math.min(cw / nat.w, ch / nat.h, 1);
+      const fit = Math.min(cw / nat.w, ch / nat.h);
       fitScaleRef.current = fit;
-      onFitMeasured?.(fit);
-      // Re-clamp pan against the new container dims at current zoom so
-      // shrinking the window doesn't leave the diagram off-screen.
-      const next = clampPan(panRef.current, { w: cw, h: ch }, nat, zoom);
+      const effective = zoomRef.current * fit;
+      const applied = applyScaleToSvg(effective);
+      committedScaleRef.current = applied;
+      // Re-clamp pan against the new container dims at current effective
+      // scale so shrinking the window doesn't leave the diagram off-screen.
+      const next = clampPan(panRef.current, { w: cw, h: ch }, nat, effective);
       if (next.x !== panRef.current.x || next.y !== panRef.current.y) {
         panRef.current = next;
-        scheduleApply();
       }
+      applyTransform();
     });
     ro.observe(c);
     return () => ro.disconnect();
-  }, [onFitMeasured, zoom]);
+  }, []);
 
   // Wheel — preventDefault always (we own scroll inside the canvas).
   // ctrl/meta = cursor-anchored zoom; shift = horizontal pan; else vertical.
@@ -183,17 +303,22 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
       const rect = el.getBoundingClientRect();
       const container = { w: el.clientWidth || rect.width, h: el.clientHeight || rect.height };
       const nat = naturalRef.current;
+      const fit = fitScaleRef.current;
       if (e.ctrlKey || e.metaKey) {
         const cx = e.clientX - rect.left - rect.width / 2 - panRef.current.x;
         const cy = e.clientY - rect.top - rect.height / 2 - panRef.current.y;
         const newZoom = clamp(zoom * (1 - e.deltaY * ZOOM_SENSITIVITY), ZOOM_MIN, ZOOM_MAX);
         if (newZoom === zoom) return;
+        // Cursor-anchored math: the ratio S'/S in screen space is
+        // (newZoom×fit) / (zoom×fit) = newZoom/zoom — fit cancels.
         const ratio = newZoom / zoom;
         const nextPan = {
           x: panRef.current.x + cx * (1 - ratio),
           y: panRef.current.y + cy * (1 - ratio),
         };
-        panRef.current = nat.w > 0 && nat.h > 0 ? clampPan(nextPan, container, nat, newZoom) : nextPan;
+        const nextEffective = newZoom * fit;
+        panRef.current =
+          nat.w > 0 && nat.h > 0 ? clampPan(nextPan, container, nat, nextEffective) : nextPan;
         setZoom(newZoom);
         // Don't scheduleApply — setZoom triggers a render and the
         // useLayoutEffect re-applies synchronously before paint.
@@ -202,8 +327,9 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
       const dx = e.shiftKey ? -e.deltaY : 0;
       const dy = e.shiftKey ? 0 : -e.deltaY;
       const nextPan = { x: panRef.current.x + dx, y: panRef.current.y + dy };
+      const effective = zoom * fit;
       panRef.current =
-        nat.w > 0 && nat.h > 0 ? clampPan(nextPan, container, nat, zoom) : nextPan;
+        nat.w > 0 && nat.h > 0 ? clampPan(nextPan, container, nat, effective) : nextPan;
       scheduleApply();
     };
     el.addEventListener("wheel", onWheel, { passive: false });
@@ -264,7 +390,8 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly, onFitMea
     const c = containerRef.current;
     const nat = naturalRef.current;
     if (c && nat.w > 0 && nat.h > 0) {
-      panRef.current = clampPan(next, { w: c.clientWidth, h: c.clientHeight }, nat, zoom);
+      const effective = zoom * fitScaleRef.current;
+      panRef.current = clampPan(next, { w: c.clientWidth, h: c.clientHeight }, nat, effective);
     } else {
       panRef.current = next;
     }

--- a/src/components/viewers/mermaid/MermaidPopout.tsx
+++ b/src/components/viewers/mermaid/MermaidPopout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 
 import { MermaidCanvas } from "./MermaidCanvas";
 import { MermaidControls } from "./MermaidControls";
@@ -12,6 +12,18 @@ import "@/styles/mermaid-popout.css";
  * MermaidPopout — overlay sibling inside `.main-area` that shows the active
  * mermaid diagram in a maximised, interaction-rich surface (issue #276).
  *
+ * DOM structure:
+ *   <div class="mermaid-popout-overlay">     ← transparent full-bleed
+ *                                              click interceptor (so gap
+ *                                              clicks don't fall through
+ *                                              to the underlying viewer)
+ *     <div class="mermaid-popout-card">      ← visible card with border,
+ *                                              shadow, theme background
+ *       <MermaidCanvas .../>
+ *       <MermaidControls mode="popout" .../>
+ *     </div>
+ *   </div>
+ *
  * Layering:
  * - Single-primitive store selector at the top (`mermaidPopoutOpenFor`) so the
  *   bulk of the inner component is gated behind the cheapest possible
@@ -22,11 +34,14 @@ import "@/styles/mermaid-popout.css";
  *   `docs/architecture.md` rule 16 — NOT here. The only reactive close path
  *   owned by this component is the document-level Esc keydown listener.
  *
- * Zoom: shares the `.mmd` zoom key with the dedicated viewer
- * (see `src/lib/file-types.ts`). The first time the popout ever opens (no
- * persisted `.mmd` zoom yet) we seed it to the canvas-measured fit scale;
- * subsequent opens preserve the user's chosen zoom. The "Fit" button is the
- * explicit re-fit affordance.
+ * Zoom: shares the `.mmd` zoom key with the dedicated viewer. `zoom = 1.0`
+ * ≡ "fits the viewing area" under MermaidCanvas's hybrid scale model, so
+ * no fit-seeding dance is needed: the popout simply opens at whatever
+ * zoom is shared, and the "Fit" button is a `bumpZoom(".mmd", "reset")`
+ * call (reset = ZOOM_DEFAULT = 1.0).
+ *
+ * `aria-modal="false"` reflects reality: there's no focus trap and no
+ * backdrop dim. The dialog is dismissable via Esc + the close button.
  */
 export function MermaidPopout() {
   const openFor = useStore((s) => s.mermaidPopoutOpenFor);
@@ -41,10 +56,6 @@ function PopoutInner({ content, path }: { content: string; path: string | null }
   // Ctrl+- / Ctrl+0) and the popout share a single source of truth.
   const { zoom, zoomIn, zoomOut, reset } = useZoom(".mmd");
 
-  // Latest fit scale measured by MermaidCanvas. Held in a ref so the Fit
-  // button can reapply it without re-rendering on every measurement.
-  const lastFitRef = useRef<number | null>(null);
-
   // Esc closes the overlay. Document-level listener so focus need not be
   // inside the dialog (consistent with ImageViewer's overlay pattern).
   useEffect(() => {
@@ -55,51 +66,39 @@ function PopoutInner({ content, path }: { content: string; path: string | null }
     return () => document.removeEventListener("keydown", onKey);
   }, [closeMermaidPopout]);
 
-  // Fit measurement callback: always cache, but only seed setZoom on the
-  // first ever interaction (no `.mmd` entry yet). Subsequent opens keep the
-  // user's current zoom — see "rubber-duck rule" docs/architecture.md#16.
-  const handleFitMeasured = useCallback(
-    (fit: number) => {
-      lastFitRef.current = fit;
-      const current = useStore.getState().zoomByFiletype[".mmd"];
-      if (current === undefined) setZoom(".mmd", fit);
-    },
-    [setZoom],
-  );
-
-  // Explicit "Fit" button — re-applies the most recent measured fit.
-  const handleFitClick = useCallback(() => {
-    if (lastFitRef.current !== null) setZoom(".mmd", lastFitRef.current);
-  }, [setZoom]);
-
   // Inline wrapper to bridge MermaidCanvas's setZoom(value) to the slice's
   // setZoom(filetype, value). Re-created per render — MermaidCanvas does not
   // memoize on prop identity for setZoom so reference stability is moot.
   const canvasSetZoom = (v: number) => setZoom(".mmd", v);
+
+  // Fit = reset (1.0 ≡ fit-to-window under the hybrid scale model).
+  const handleFit = useCallback(() => reset(), [reset]);
 
   return (
     <div
       className="mermaid-popout-overlay"
       role="dialog"
       aria-label="Mermaid diagram preview"
+      aria-modal="false"
     >
-      <MermaidCanvas
-        content={content}
-        path={path}
-        zoom={zoom}
-        setZoom={canvasSetZoom}
-        readOnly
-        onFitMeasured={handleFitMeasured}
-      />
-      <MermaidControls
-        mode="popout"
-        zoom={zoom}
-        onZoomIn={zoomIn}
-        onZoomOut={zoomOut}
-        onReset={reset}
-        onFit={handleFitClick}
-        onClose={closeMermaidPopout}
-      />
+      <div className="mermaid-popout-card">
+        <MermaidCanvas
+          content={content}
+          path={path}
+          zoom={zoom}
+          setZoom={canvasSetZoom}
+          readOnly
+        />
+        <MermaidControls
+          mode="popout"
+          zoom={zoom}
+          onZoomIn={zoomIn}
+          onZoomOut={zoomOut}
+          onReset={reset}
+          onFit={handleFit}
+          onClose={closeMermaidPopout}
+        />
+      </div>
     </div>
   );
 }

--- a/src/styles/mermaid-popout.css
+++ b/src/styles/mermaid-popout.css
@@ -5,17 +5,39 @@
  * toolbar / tab bar / status bar remain visible above and below.
  * `.main-area { position: relative }` (added in app.css) anchors the
  * absolute positioning here.
+ *
+ * DOM:
+ *   .mermaid-popout-overlay  ← transparent full-bleed click interceptor
+ *     .mermaid-popout-card   ← visible card (border + shadow + theme bg)
+ *
+ * The overlay is transparent and full-bleed only so pointer events in
+ * the gap between the card and the main-area edges are intercepted
+ * (and not routed to the underlying viewer). Visual chrome lives on
+ * the inner `.mermaid-popout-card`.
  */
 .mermaid-popout-overlay {
   position: absolute;
   inset: 0;
   z-index: 10;
-  background: var(--color-background, #ffffff);
-  display: flex;
-  flex-direction: column;
 }
 
-/* Floating control bar at bottom-center for popout mode. */
+.mermaid-popout-card {
+  position: absolute;
+  inset: 24px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.18),
+    0 4px 12px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Floating control bar at bottom-center for popout mode. Anchored to the
+   nearest positioned ancestor — `.mermaid-popout-card` (which has
+   position: absolute). */
 .mermaid-popout-bar {
   position: absolute;
   bottom: 16px;
@@ -39,7 +61,7 @@
   border-radius: 3px;
 }
 .mermaid-popout-bar button:hover {
-  background: var(--color-hover, #f3f4f6);
+  background: var(--color-tab-hover, #f3f4f6);
 }
 .mermaid-popout-bar-zoom-display {
   font-size: 12px;
@@ -60,7 +82,7 @@
   font-size: 12px;
 }
 .mermaid-popout-close:hover {
-  background: var(--color-hover, #f3f4f6);
+  background: var(--color-tab-hover, #f3f4f6);
 }
 
 /* Embedded mermaid block — hover-revealed pop-out button.


### PR DESCRIPTION
Closes user-reported Mermaid viewer bugs:

1. **Default 100% too small.** Redefine zoom semantics so `zoom = 1.0` ≡ fits the viewing area (instead of mermaid's natural SVG pixel size, which has no meaningful unit for vector diagrams). Effective scale = `zoom × fitScale` where `fitScale = min(cw/natW, ch/natH)` (no `, 1` cap — small diagrams scale UP to fill the viewport too). Drops the obsolete seed-on-first-measure dance in `MermaidView` / `MermaidPopout`; **Fit** button is now `bumpZoom('.mmd', 'reset')`.

2. **Blurry text when zoomed.** Hybrid scale model: keep cheap CSS `transform: scale(effective/committed)` on the wrapper during interactive zoom (GPU compositing), then **debounce-commit** (150 ms idle) by writing the new effective scale into the SVG's intrinsic `style.width/height`. The browser re-rasterizes text and `foreignObject` at the new size → crisp output. Baked dims capped at **8192 px/axis** to prevent pathological growth at small-diagram × `ZOOM_MAX = 8` (per `docs/performance.md` rule 1).

3. **Popout always white in dark theme.** The CSS variable is `--color-bg`, not `--color-background` — the previous `var(--color-background, #ffffff)` fallback always won. Fixed.

4. **Popout fills entire main-area.** Restructured into a transparent full-bleed `.mermaid-popout-overlay` (intercepts gap clicks so they don't fall through to the underlying viewer) wrapping a visible `.mermaid-popout-card` with `inset: 24px`, `border`, `border-radius: 8px`, `box-shadow`, `overflow: hidden`. `aria-modal="false"` reflects reality (no focus trap, no backdrop dim — Esc + close button remain the dismiss paths).

## Rubber-duck-driven robustness

- Prefer SVG `viewBox` over `getBBox()` for the natural-size source (more reliable across browsers).
- Re-clamp pan after `handleSvgReady` so a theme switch (which re-renders mermaid with a potentially different bbox without `zoom` or container changing) doesn't leave the diagram off-screen.
- Cleanup pending settle timer alongside rAF on unmount.

## Tests

- `MermaidCanvas.test.tsx`: pan-test starting zoom bumped from 1 to 2 so room exists under the new fit-relative scale model. New tests: `sizes SVG to fit container at zoom=1`, `upscales when natural smaller than container (fit > 1)`, `caps baked SVG dims at 8192px`, `resets pan + re-bakes on content change`.
- `MermaidPopout.test.tsx`: dropped obsolete fit-seeding tests (mechanism removed); added overlay-vs-card structure, `aria-modal="false"`, and `Fit handler calls bumpZoom('.mmd', 'reset')` assertions.
- All 1909 Vitest tests pass; `npm run lint`, `npm run lint:typed`, `npm run audit:zoom-cascade`, `npm run build` all clean (0 errors).

## Files

- `src/components/viewers/mermaid/MermaidCanvas.tsx` — core hybrid scale model.
- `src/components/viewers/MermaidView.tsx` — drops fit-seeding plumbing.
- `src/components/viewers/mermaid/MermaidPopout.tsx` — drops fit-seeding; adds `aria-modal="false"` + card wrapper.
- `src/styles/mermaid-popout.css` — `--color-bg` fix; transparent overlay + visible card.
- Test updates as listed above.
