### PR TITLE
fix(viewer): apply HTML preview zoom inside iframe + local-CSS sample coverage

### DIFF
--- a/e2e/browser/zoom-all-viewers.spec.ts
+++ b/e2e/browser/zoom-all-viewers.spec.ts
@@ -4,7 +4,10 @@ import type { Page } from "@playwright/test";
 const FIXTURES_DIR = "/e2e/fixtures";
 
 // Each entry: [filename, extension, viewer selector for the zoom root]
-// HTML uses an iframe — zoom applies to the wrapper but content is isolated.
+// HTML zoom is verified separately in zoom-html.spec.ts because the
+// fontSize-based oracle does not apply to the iframe `contentDocument`
+// (CSS `zoom` is applied directly on `documentElement`, not via wrapper
+// font-size) — see HtmlPreviewView.tsx zoom effect for the rationale.
 // Mermaid uses transform:scale, not font-size zoom — excluded per issue #157.
 // KQL zoom was added in this PR (useZoom in KqlPlanView) and verified by unit
 // test; the e2e test is deferred because the mock IPC doesn't populate the

--- a/e2e/browser/zoom-html.spec.ts
+++ b/e2e/browser/zoom-html.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+const FIXTURES_DIR = "/e2e/fixtures";
+
+const FILE_CONTENTS: Record<string, string> = {
+  "page.html": "<!doctype html><html><head><title>z</title></head><body><h1>Hello</h1><p>World</p></body></html>",
+};
+
+async function setupMocks(page: Page) {
+  await page.addInitScript(({ dir, contents }: { dir: string; contents: Record<string, string> }) => {
+    window.__TAURI_IPC_MOCK__ = async (cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "get_launch_args") return { files: [], folders: [dir] };
+      if (cmd === "read_dir") {
+        return Object.keys(contents).map((name) => ({ name, path: `${dir}/${name}`, is_dir: false }));
+      }
+      if (cmd === "read_text_file") {
+        const path = (args as { path: string }).path;
+        const name = path.split("/").pop() ?? "";
+        return contents[name] ?? "";
+      }
+      if (cmd === "resolve_html_assets") {
+        // Frontend passes the html as the first arg; pass it through unchanged.
+        return (args as { html?: string }).html ?? "";
+      }
+      if (cmd === "load_review_comments") return null;
+      if (cmd === "save_review_comments") return null;
+      if (cmd === "check_path_exists") return "file";
+      if (cmd === "get_log_path") return "/mock/log.log";
+      if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
+      if (cmd === "get_file_viewer_pref") return null;
+      if (cmd === "set_file_viewer_pref") return null;
+      return null;
+    };
+  }, { dir: FIXTURES_DIR, contents: FILE_CONTENTS });
+}
+
+// Read the `zoom` CSS property the production code sets via
+// `documentElement.style.setProperty("zoom", ...)`. Returned as a string —
+// `""` when unset, otherwise the numeric factor.
+async function iframeZoom(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const iframe = document.querySelector(
+      "iframe[title='HTML preview']",
+    ) as HTMLIFrameElement | null;
+    if (!iframe || !iframe.contentDocument) {
+      throw new Error("HTML preview iframe not found or contentDocument null");
+    }
+    return iframe.contentDocument.documentElement.style.getPropertyValue("zoom");
+  });
+}
+
+test.describe("HtmlPreviewView zoom (#157 — iframe content actually scales)", () => {
+  test("Ctrl+= raises iframe `zoom`, Ctrl+0 resets to 1", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/");
+
+    await page.locator(".folder-tree").getByText("page.html").click();
+    await expect(page.locator("iframe[title='HTML preview']")).toBeVisible({ timeout: 10000 });
+
+    // Baseline — production code applies `zoom = "1"` immediately on mount.
+    await expect.poll(async () => await iframeZoom(page)).toBe("1");
+
+    // Two zoom-in steps — must raise the numeric value above 1.
+    await page.keyboard.press("Control+=");
+    await page.keyboard.press("Control+=");
+    await expect.poll(async () => parseFloat(await iframeZoom(page))).toBeGreaterThan(1);
+    const grown = parseFloat(await iframeZoom(page));
+
+    // One zoom-out step — strictly smaller than the two-step zoomed value.
+    await page.keyboard.press("Control+-");
+    await expect.poll(async () => parseFloat(await iframeZoom(page))).toBeLessThan(grown);
+
+    // Reset — back to exactly 1.
+    await page.keyboard.press("Control+0");
+    await expect.poll(async () => await iframeZoom(page)).toBe("1");
+  });
+});

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,7 +13,7 @@ through each subfolder. Each subfolder targets one viewer.
 | [`markdown/`](./markdown/) | `MarkdownViewer` | GFM, KaTeX, Mermaid, footnotes, task lists, GitHub alerts, local + remote images, sanitization edge cases |
 | [`json/`](./json/) | `JsonView` | Flat / nested / array / mixed-types / unicode / `.jsonc` (with comments) |
 | [`csv/`](./csv/) | `CsvView` | Simple / wide / tab-separated / unicode / embedded quotes & commas |
-| [`html/`](./html/) | `HtmlPreviewView` | Sandboxed iframe — simple / styled / **JS-must-not-execute** / with images |
+| [`html/`](./html/) | `HtmlPreviewView` | Sandboxed iframe — simple / styled / **JS-must-not-execute** / with images / local CSS files / local links / anchors / scheme matrix |
 | [`mermaid/`](./mermaid/) | `MermaidView` (.mmd, .mermaid) | Flowchart, sequence, state, class, gantt, ER |
 | [`kql/`](./kql/) | `KqlPlanView` | Simple / multi-stage / `.csl` extension |
 | [`source/`](./source/) | `SourceView` (Shiki) | Rust, TS, Python, Go, C++, Java, SQL, YAML, TOML, Dockerfile, Makefile, shell, diff |
@@ -43,6 +43,13 @@ See [`markdown/README.md`](./markdown/README.md) for the per-file index. Scope s
 
 ### HTML — `html/`
 - Iframe sandbox is `allow-same-origin` only — CSS renders, JS does not (rule 12a in `docs/security.md`).
+- `01-simple.html` · `02-styled.html` (inline `<style>`) · `03-script-sandbox-test.html` (JS must NOT run) · `04-with-images.html`.
+- `05-local-css.html` — single `<link rel="stylesheet" href="./css/theme.css">` inlined as a `<style>` block by `resolve_html_assets` (Rust).
+- `06-multi-stylesheet.html` — three cascading local stylesheets (`reset.css` → `theme.css` → `layout.css`) demonstrating CSS-custom-property propagation across files and a responsive grid.
+- `07-local-links.html` — workspace-relative anchors that open sibling sample files (markdown / json / csv / source / mermaid / images / binary) via `routeLinkClick → openFile`. Includes deliberately out-of-workspace targets (`../../../etc/passwd`) that must be **blocked**.
+- `08-anchors-and-toc.html` — in-page TOC with `#fragment` smooth-scroll, unicode-id anchor (`#unicode-café`), self-link with fragment, and cross-file fragments into markdown headings (`../markdown/11-kitchen-sink.md#heading-anchors`).
+- `09-link-schemes.html` — exhaustive scheme matrix: `https` / `http` / `mailto` / `tel` / fragment / workspace-relative all route correctly; `javascript:` / `file:` / `data:` / `vbscript:` (and a leading-whitespace `\n\tjavascript:` bypass attempt) are dropped with a `warn` per `EXTERNAL_LINK_SCHEME` / `BLOCKED_LINK_SCHEME` in `src/lib/url-policy.ts`.
+- `css/` — shared local stylesheets (`reset.css`, `theme.css`, `layout.css`) referenced by samples 05–09.
 - The 03-script-sandbox-test page should render but **never** show an alert dialog or change its `#result` div text.
 - Images load both relative (`../markdown/images/...`) and remote.
 

--- a/samples/html/05-local-css.html
+++ b/samples/html/05-local-css.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Local CSS — single stylesheet</title>
+  <link rel="stylesheet" href="./css/theme.css">
+</head>
+<body>
+  <main style="max-width: 720px; margin: 2rem auto; padding: 0 1rem;">
+    <h1>Local CSS — one stylesheet</h1>
+
+    <p>
+      This page links a <strong>local</strong> stylesheet:
+    </p>
+<pre><code>&lt;link rel="stylesheet" href="./css/theme.css"&gt;</code></pre>
+
+    <p>
+      The HTML viewer's Rust side (<code>resolve_html_assets</code> in
+      <code>src-tauri/src/core/html_assets.rs</code>) reads
+      <code>css/theme.css</code> from disk and replaces the
+      <code>&lt;link&gt;</code> with an inline <code>&lt;style&gt;</code> block
+      before the iframe ever sees the markup. That's why this works inside the
+      <code>allow-same-origin</code> sandbox without violating the host CSP —
+      the iframe never issues a stylesheet network request.
+    </p>
+
+    <h2>Visible signals that <code>theme.css</code> loaded</h2>
+    <ul>
+      <li>Headings are <strong>blue</strong> (<code>--accent</code>).</li>
+      <li>This paragraph sits on the <span class="badge">cream</span>
+        page background (<code>--bg</code>).</li>
+      <li>Inline <code>code</code> has a grey pill background.</li>
+      <li>
+        Status colour helpers:
+        <span class="good">good</span> ·
+        <span class="warn">warn</span> ·
+        <span class="bad">bad</span> ·
+        <span class="muted">muted</span>.
+      </li>
+    </ul>
+
+    <h2 id="what-to-spot-check">What to spot-check</h2>
+    <ol>
+      <li>If the page renders <em>unstyled</em> (black headings, white
+        background), the inliner failed.</li>
+      <li>If you see a CSP violation in DevTools for
+        <code>./css/theme.css</code>, the <code>&lt;link&gt;</code> wasn't
+        inlined and the iframe attempted a network fetch.</li>
+      <li>Editing <code>css/theme.css</code> on disk and reloading the file
+        should visibly change the colours (the watcher re-renders).</li>
+    </ol>
+
+    <p class="muted">
+      See also <a href="./06-multi-stylesheet.html">06 — multiple cascading
+      stylesheets</a> and <a href="./02-styled.html">02 — inline
+      <code>&lt;style&gt;</code></a>.
+    </p>
+  </main>
+</body>
+</html>

--- a/samples/html/06-multi-stylesheet.html
+++ b/samples/html/06-multi-stylesheet.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Local CSS — multiple stylesheets cascading</title>
+  <link rel="stylesheet" href="./css/reset.css">
+  <link rel="stylesheet" href="./css/theme.css">
+  <link rel="stylesheet" href="./css/layout.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Local CSS — three stylesheets, cascading</h1>
+
+    <p>
+      This page links <strong>three</strong> local stylesheets in order:
+    </p>
+<pre><code>&lt;link rel="stylesheet" href="./css/reset.css"&gt;
+&lt;link rel="stylesheet" href="./css/theme.css"&gt;
+&lt;link rel="stylesheet" href="./css/layout.css"&gt;</code></pre>
+    <p>
+      Each <code>&lt;link&gt;</code> is independently inlined by
+      <code>resolve_html_assets</code> in the order it appears, so the cascade
+      is preserved — <code>reset.css</code> first (box-sizing + base type),
+      then <code>theme.css</code> (palette via custom properties), then
+      <code>layout.css</code> (grid + cards consuming those properties).
+    </p>
+
+    <div class="toolbar">
+      <strong>Toolbar</strong>
+      <span class="muted">styled by <code>layout.css</code></span>
+      <span class="spacer"></span>
+      <span class="badge good">cascade ok</span>
+    </div>
+
+    <h2>Card grid (responsive)</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Reset</h3>
+        <p class="meta"><code>reset.css</code></p>
+        <p>Box model, base typography, link colour inheritance.</p>
+      </div>
+      <div class="card">
+        <h3>Theme</h3>
+        <p class="meta"><code>theme.css</code></p>
+        <p>Palette via CSS custom properties — <code>--accent</code>,
+          <code>--card-bg</code>, etc.</p>
+      </div>
+      <div class="card">
+        <h3>Layout</h3>
+        <p class="meta"><code>layout.css</code></p>
+        <p>Page frame, toolbar, responsive card grid using
+          <code>grid-template-columns: repeat(auto-fit, …)</code>.</p>
+      </div>
+      <div class="card">
+        <h3>Cascade order</h3>
+        <p class="meta">specificity + source order</p>
+        <p>The <code>&lt;link&gt;</code> tags are inlined in declaration order
+          so <code>layout.css</code> wins ties.</p>
+      </div>
+    </div>
+
+    <h2>Two-column section</h2>
+    <div class="cols-2">
+      <div>
+        <h3>What works</h3>
+        <ul>
+          <li>Custom properties (<code>--accent</code>) defined in
+            <code>theme.css</code> are read by <code>layout.css</code>.</li>
+          <li>Media query in <code>layout.css</code> collapses to a single
+            column under 600px viewport width.</li>
+          <li>Multiple stylesheets do not double-inline; each is replaced
+            once.</li>
+        </ul>
+      </div>
+      <div>
+        <h3>What to spot-check</h3>
+        <ul>
+          <li>Resize the window — the grid should flow.</li>
+          <li>Inspect the iframe DOM: there should be three
+            <code>&lt;style&gt;</code> blocks instead of three
+            <code>&lt;link&gt;</code> tags.</li>
+          <li>No CSP violation entries in DevTools.</li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>Tabular data</h2>
+    <table class="layout">
+      <thead>
+        <tr><th>File</th><th>Role</th><th>Affects</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>reset.css</code></td><td>Reset</td><td>box-sizing, base type</td></tr>
+        <tr><td><code>theme.css</code></td><td>Tokens + type</td><td>colours, headings, code</td></tr>
+        <tr><td><code>layout.css</code></td><td>Layout</td><td>page, toolbar, grid, cols-2, table</td></tr>
+      </tbody>
+    </table>
+
+    <p class="muted">
+      Back to <a href="./05-local-css.html">05 — single stylesheet</a> ·
+      <a href="./07-local-links.html">07 — local links</a>.
+    </p>
+  </div>
+</body>
+</html>

--- a/samples/html/07-local-links.html
+++ b/samples/html/07-local-links.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Local links — into the workspace</title>
+  <link rel="stylesheet" href="./css/reset.css">
+  <link rel="stylesheet" href="./css/theme.css">
+  <link rel="stylesheet" href="./css/layout.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Local links — opening sibling files in mdownreview</h1>
+
+    <p>
+      Inside the HTML preview iframe, an anchor <code>href</code> that does
+      <em>not</em> match an external scheme (<code>http</code>,
+      <code>https</code>, <code>mailto</code>, <code>tel</code>) and is not a
+      pure <code>#fragment</code> is treated as a
+      <strong>workspace-relative path</strong>. The viewer's click handler
+      (<code>routeLinkClick</code> in <code>src/lib/url-policy.ts</code>)
+      resolves it against this file's directory, asserts it stays inside the
+      workspace root, and then calls
+      <code>useStore.getState().openFile(path)</code> to open the file in a
+      new mdownreview tab.
+    </p>
+
+    <div class="toolbar">
+      <strong>Click any link below</strong>
+      <span class="muted">— it should open in mdownreview, not navigate the iframe.</span>
+      <span class="spacer"></span>
+      <span class="badge good">workspace-routed</span>
+    </div>
+
+    <h2>Other HTML samples (sibling directory)</h2>
+    <ul>
+      <li><a href="./01-simple.html">01 · Simple HTML</a></li>
+      <li><a href="./02-styled.html">02 · Inline-styled HTML</a></li>
+      <li><a href="./03-script-sandbox-test.html">03 · Sandbox test (JS must NOT execute)</a></li>
+      <li><a href="./04-with-images.html">04 · HTML with images</a></li>
+      <li><a href="./05-local-css.html">05 · Single local stylesheet</a></li>
+      <li><a href="./06-multi-stylesheet.html">06 · Three cascading local stylesheets</a></li>
+      <li><a href="./08-anchors-and-toc.html">08 · Anchors + TOC + cross-file fragments</a></li>
+      <li><a href="./09-link-schemes.html">09 · Allowed vs blocked link schemes</a></li>
+    </ul>
+
+    <h2>Markdown samples (relative-up navigation)</h2>
+    <ul>
+      <li><a href="../markdown/01-gfm-basics.md">../markdown/01-gfm-basics.md</a></li>
+      <li><a href="../markdown/03-code-blocks.md">../markdown/03-code-blocks.md</a></li>
+      <li><a href="../markdown/05-math-katex.md">../markdown/05-math-katex.md</a></li>
+      <li><a href="../markdown/06-mermaid.md">../markdown/06-mermaid.md</a></li>
+      <li><a href="../markdown/11-kitchen-sink.md">../markdown/11-kitchen-sink.md</a></li>
+      <li><a href="../markdown/README.md">../markdown/README.md</a></li>
+    </ul>
+
+    <h2>Other viewers</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>JSON</h3>
+        <p class="meta">routes to <code>JsonView</code></p>
+        <ul>
+          <li><a href="../json/01-simple.json">01-simple.json</a></li>
+          <li><a href="../json/03-deeply-nested.json">03-deeply-nested.json</a></li>
+          <li><a href="../json/05-config.jsonc">05-config.jsonc</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>CSV</h3>
+        <p class="meta">routes to <code>CsvView</code></p>
+        <ul>
+          <li><a href="../csv/01-simple.csv">01-simple.csv</a></li>
+          <li><a href="../csv/03-wide-many-columns.csv">03-wide-many-columns.csv</a></li>
+          <li><a href="../csv/04-tab-separated.tsv">04-tab-separated.tsv</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Source</h3>
+        <p class="meta">routes to <code>SourceView</code> (Shiki)</p>
+        <ul>
+          <li><a href="../source/cache.rs">cache.rs</a></li>
+          <li><a href="../source/cache.go">cache.go</a></li>
+          <li><a href="../source/hooks.ts">hooks.ts</a></li>
+          <li><a href="../source/Dockerfile">Dockerfile</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Mermaid</h3>
+        <p class="meta">routes to <code>MermaidView</code></p>
+        <ul>
+          <li><a href="../mermaid/01-flowchart.mmd">01-flowchart.mmd</a></li>
+          <li><a href="../mermaid/02-sequence.mmd">02-sequence.mmd</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Images</h3>
+        <p class="meta">routes to <code>ImageViewer</code></p>
+        <ul>
+          <li><a href="../images/01-photo.jpg">01-photo.jpg</a></li>
+          <li><a href="../images/12-diagram.svg">12-diagram.svg</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Binary</h3>
+        <p class="meta">routes to <code>BinaryPlaceholder</code></p>
+        <ul>
+          <li><a href="../binary/archive.zip">archive.zip</a></li>
+          <li><a href="../binary/tone-440hz-1s.wav">tone-440hz-1s.wav</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>Edge cases — should be <span class="bad">blocked</span></h2>
+    <p>
+      These point outside the workspace root and must be rejected by
+      <code>resolveWorkspacePath</code>; clicking them should
+      <em>not</em> open anything (DevTools console will show
+      <code>HtmlPreviewView: blocked iframe link (outside-workspace): …</code>).
+    </p>
+    <ul>
+      <li><a href="../../../etc/passwd">../../../etc/passwd</a></li>
+      <li><a href="../../../../Windows/System32/drivers/etc/hosts">../../../../Windows/System32/drivers/etc/hosts</a></li>
+    </ul>
+
+    <h2>What to spot-check</h2>
+    <ol>
+      <li>Each sibling-folder link opens that file in a new tab in
+        mdownreview (or focuses an existing tab).</li>
+      <li>The HTML iframe itself never navigates — its content stays on
+        this page.</li>
+      <li>The blocked links above produce a console <code>warn</code> and
+        do not open anything.</li>
+    </ol>
+  </div>
+</body>
+</html>

--- a/samples/html/08-anchors-and-toc.html
+++ b/samples/html/08-anchors-and-toc.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Anchors — in-page TOC + cross-file fragments</title>
+  <link rel="stylesheet" href="./css/reset.css">
+  <link rel="stylesheet" href="./css/theme.css">
+  <link rel="stylesheet" href="./css/layout.css">
+  <style>
+    nav.toc {
+      position: sticky;
+      top: 0;
+      background: var(--bg);
+      padding: 0.5rem 0;
+      border-bottom: 1px solid var(--card-edge);
+      margin-bottom: 1rem;
+      z-index: 1;
+    }
+    section { padding-top: 1rem; }
+    h2 { scroll-margin-top: 4rem; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <h1>Anchors — in-page TOC + cross-file fragments</h1>
+
+    <p>
+      The HTML preview's click router (<code>routeLinkClick</code>) classifies
+      <code>href</code>s into four buckets:
+    </p>
+    <ul>
+      <li><code>#fragment</code> — scroll to the element with that
+        <code>id</code> inside this iframe.</li>
+      <li><code>./other.html#fragment</code> or
+        <code>../markdown/file.md#fragment</code> — open that workspace file
+        in a new tab and queue the fragment for scroll on load via
+        <code>setPendingFragment</code>.</li>
+      <li>External (<code>https://…</code>, <code>mailto:</code>) — hand off
+        to the OS via <code>openExternalUrl</code>.</li>
+      <li>Anything else (<code>javascript:</code>, <code>file:</code>,
+        <code>data:</code>) — drop with a warn.</li>
+    </ul>
+
+    <nav class="toc" aria-label="Table of contents">
+      <strong>Jump to:</strong>
+      <a href="#alpha">Alpha</a> ·
+      <a href="#beta">Beta</a> ·
+      <a href="#gamma">Gamma</a> ·
+      <a href="#delta">Delta with spaces &amp; punctuation</a> ·
+      <a href="#unicode-café">Unicode (#unicode-café)</a> ·
+      <a href="#bottom">Bottom</a>
+    </nav>
+
+    <section id="alpha">
+      <h2>Alpha — clean ASCII id</h2>
+      <p>
+        Plain id <code>alpha</code>. Clicking <code>#alpha</code> in the TOC
+        should smooth-scroll here. The iframe's <code>about:srcdoc</code> URL
+        means the browser's built-in fragment scroll is unreliable, so the
+        click handler always scrolls explicitly via
+        <code>scrollIntoView({ behavior: "smooth" })</code>.
+      </p>
+      <p><a href="#bottom">→ jump to bottom</a></p>
+    </section>
+
+    <section id="beta">
+      <h2>Beta</h2>
+      <p>Same shape, different anchor.</p>
+    </section>
+
+    <section id="gamma">
+      <h2>Gamma</h2>
+      <p>Yet another section, just for scroll-distance.</p>
+    </section>
+
+    <section id="delta">
+      <h2>Delta with spaces &amp; punctuation</h2>
+      <p>
+        The id here is the simple slug <code>delta</code>; the TOC entry above
+        uses <code>#delta</code>. Heading text with punctuation does not need
+        to match the id verbatim.
+      </p>
+    </section>
+
+    <section id="unicode-café">
+      <h2>Unicode anchor — café</h2>
+      <p>
+        The fragment <code>#unicode-café</code> contains a non-ASCII
+        character. The click handler decodes the URL-encoded form
+        (<code>%C3%A9</code>) before <code>getElementById</code>, so both
+        <code>#unicode-café</code> and <code>#unicode-caf%C3%A9</code> work.
+      </p>
+    </section>
+
+    <h2>Cross-file fragments — open another doc and scroll</h2>
+    <p>
+      These open a <em>different</em> file and queue a fragment for the
+      destination viewer to honour:
+    </p>
+    <ul>
+      <li><a href="./05-local-css.html#what-to-spot-check">05-local-css.html#what-to-spot-check</a>
+        — opens the single-stylesheet sample, scrolls to the spot-check
+        section. (Cross-file fragments work when the destination has an
+        explicit <code>id</code>; HTML pages don't auto-slug headings.)</li>
+      <li><a href="../markdown/11-kitchen-sink.md#heading-anchors">../markdown/11-kitchen-sink.md#heading-anchors</a>
+        — opens the kitchen-sink markdown, scrolls to "Heading anchors".
+        rehype-slug on the markdown side generates the id.</li>
+      <li><a href="../markdown/01-gfm-basics.md#links">../markdown/01-gfm-basics.md#links</a>
+        — opens GFM basics, scrolls to "Links".</li>
+      <li><a href="../markdown/01-gfm-basics.md#blockquotes--single-nested-with-content">
+        ../markdown/01-gfm-basics.md#blockquotes--single-nested-with-content</a>
+        — slug generated from "## Blockquotes — single, nested, with
+        content".</li>
+    </ul>
+
+    <h2>Self-link with fragment</h2>
+    <p>
+      <a href="./08-anchors-and-toc.html#alpha">./08-anchors-and-toc.html#alpha</a>
+      — same file as we're on. The handler detects this case
+      (<code>route.path === filePath</code>) and scrolls inside <em>this</em>
+      iframe rather than re-opening the tab.
+    </p>
+
+    <p style="height: 50vh"></p>
+
+    <section id="bottom">
+      <h2>Bottom</h2>
+      <p><a href="#top">↑ jump to top</a> (no <code>#top</code> id exists, so
+        nothing happens — the click is dropped silently because
+        <code>getElementById("top")</code> returns <code>null</code>).</p>
+      <p><a href="#alpha">↑ jump to Alpha</a></p>
+    </section>
+  </div>
+</body>
+</html>

--- a/samples/html/09-link-schemes.html
+++ b/samples/html/09-link-schemes.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Link schemes — allowed vs blocked</title>
+  <link rel="stylesheet" href="./css/reset.css">
+  <link rel="stylesheet" href="./css/theme.css">
+  <link rel="stylesheet" href="./css/layout.css">
+</head>
+<body>
+  <div class="page">
+    <h1>Link schemes — allowed vs blocked</h1>
+
+    <p>
+      The HTML preview's click router routes anchors by URL scheme. This is a
+      visible matrix of every shape it classifies. The actual classification
+      lives in <code>src/lib/url-policy.ts</code>:
+    </p>
+<pre><code>EXTERNAL_LINK_SCHEME = /^(https?|mailto|tel):/i
+BLOCKED_LINK_SCHEME  = /^(javascript|file|data|vbscript):/i</code></pre>
+
+    <table class="layout">
+      <thead>
+        <tr>
+          <th>Click target</th>
+          <th>Scheme</th>
+          <th>Expected route</th>
+          <th>What you should see</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://github.com/dryotta/mdownreview">GitHub repo</a></td>
+          <td><code>https</code></td>
+          <td><span class="badge good">external</span></td>
+          <td>Opens in your default browser; iframe does not navigate.</td>
+        </tr>
+        <tr>
+          <td><a href="http://example.com">example.com</a></td>
+          <td><code>http</code></td>
+          <td><span class="badge good">external</span></td>
+          <td>Same as above (downgraded HTTP still routes externally).</td>
+        </tr>
+        <tr>
+          <td><a href="mailto:hello@example.com?subject=mdownreview">Email us</a></td>
+          <td><code>mailto</code></td>
+          <td><span class="badge good">external</span></td>
+          <td>Hands off to your default mail client.</td>
+        </tr>
+        <tr>
+          <td><a href="tel:+1-555-0100">Call +1 555 0100</a></td>
+          <td><code>tel</code></td>
+          <td><span class="badge good">external</span></td>
+          <td>Hands off to the OS dialer (where one is registered).</td>
+        </tr>
+        <tr>
+          <td><a href="./01-simple.html">./01-simple.html</a></td>
+          <td>(none — relative)</td>
+          <td><span class="badge good">workspace</span></td>
+          <td>Opens that HTML file in a new mdownreview tab.</td>
+        </tr>
+        <tr>
+          <td><a href="../markdown/01-gfm-basics.md">../markdown/01-gfm-basics.md</a></td>
+          <td>(none — relative)</td>
+          <td><span class="badge good">workspace</span></td>
+          <td>Opens the markdown sample in a new tab.</td>
+        </tr>
+        <tr>
+          <td><a href="#bottom">#bottom</a></td>
+          <td>(fragment-only)</td>
+          <td><span class="badge good">fragment</span></td>
+          <td>Smooth-scrolls inside this iframe.</td>
+        </tr>
+        <tr>
+          <td><a href="javascript:alert('blocked')">javascript:alert('blocked')</a></td>
+          <td><code>javascript</code></td>
+          <td><span class="badge bad">blocked</span></td>
+          <td>Click is preventDefault'd; <code>warn</code> in DevTools; no
+            alert (sandbox would also stop it, but the router blocks
+            <em>first</em>).</td>
+        </tr>
+        <tr>
+          <td><a href="file:///C:/Windows/System32/drivers/etc/hosts">file:///…/hosts</a></td>
+          <td><code>file</code></td>
+          <td><span class="badge bad">blocked</span></td>
+          <td>Click dropped; <code>warn</code> in DevTools.</td>
+        </tr>
+        <tr>
+          <td><a href="data:text/html,<h1>data url</h1>">data:text/html,…</a></td>
+          <td><code>data</code></td>
+          <td><span class="badge bad">blocked</span></td>
+          <td>Click dropped; <code>warn</code> in DevTools.</td>
+        </tr>
+        <tr>
+          <td><a href="vbscript:msgbox(1)">vbscript:msgbox(1)</a></td>
+          <td><code>vbscript</code></td>
+          <td><span class="badge bad">blocked</span></td>
+          <td>Click dropped; <code>warn</code> in DevTools.</td>
+        </tr>
+        <tr>
+          <td><a href="
+javascript:alert('leading-newline')">leading-newline javascript:</a></td>
+          <td><code>javascript</code> (after whitespace strip)</td>
+          <td><span class="badge bad">blocked</span></td>
+          <td>The router strips leading whitespace before classifying so
+            <code>"\n\tjavascript:"</code> still hits the blocklist.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 id="bottom">What to spot-check</h2>
+    <ol>
+      <li><strong>Allowed external</strong> rows — clicking opens the OS
+        opener; the iframe never navigates.</li>
+      <li><strong>Workspace</strong> rows — clicking opens a new mdownreview
+        tab pointed at the sibling sample.</li>
+      <li><strong>Blocked</strong> rows — clicking does nothing visible; a
+        <code>HtmlPreviewView: blocked iframe link (blocked-scheme): …</code>
+        line appears in DevTools.</li>
+      <li>The fragment-only <code>#bottom</code> link smooth-scrolls inside
+        this iframe (you arrived here by clicking it, presumably).</li>
+    </ol>
+  </div>
+</body>
+</html>

--- a/samples/html/css/layout.css
+++ b/samples/html/css/layout.css
@@ -1,0 +1,73 @@
+/* layout.css — page frame + card grid for the multi-stylesheet sample. */
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--card-edge, #e5e7eb);
+  border-radius: 6px;
+  margin: 1rem 0 2rem;
+}
+
+.toolbar .spacer {
+  flex: 1;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.card {
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--card-edge, #e5e7eb);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card .meta {
+  font-size: 0.85rem;
+  color: var(--muted, #6b7280);
+}
+
+.cols-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 600px) {
+  .cols-2 { grid-template-columns: 1fr; }
+}
+
+table.layout {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table.layout th,
+table.layout td {
+  border: 1px solid var(--card-edge, #e5e7eb);
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+table.layout th {
+  background: var(--code-bg, #f3f4f6);
+  font-weight: 600;
+}

--- a/samples/html/css/reset.css
+++ b/samples/html/css/reset.css
@@ -1,0 +1,40 @@
+/* reset.css — minimal box-model reset shared across the local-CSS samples. */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  color: #111827;
+  background: #ffffff;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+}
+
+ul, ol {
+  padding-left: 1.5rem;
+}
+
+code, pre, kbd, samp {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+  margin: 2rem 0;
+}

--- a/samples/html/css/theme.css
+++ b/samples/html/css/theme.css
@@ -1,0 +1,71 @@
+/* theme.css — colour palette + typography for the local-CSS samples. */
+
+:root {
+  --bg:        #fafafa;
+  --fg:        #111827;
+  --muted:     #6b7280;
+  --accent:    #2563eb;
+  --accent-2:  #7c3aed;
+  --good:      #059669;
+  --warn:      #d97706;
+  --bad:       #dc2626;
+  --card-bg:   #ffffff;
+  --card-edge: #e5e7eb;
+  --code-bg:   #f3f4f6;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+}
+
+h1, h2, h3 {
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+h1 { font-size: 2rem; margin: 1.5rem 0 0.5rem; }
+h2 { font-size: 1.4rem; margin: 1.5rem 0 0.5rem; }
+h3 { font-size: 1.15rem; margin: 1rem 0 0.4rem; }
+
+p { margin: 0.75rem 0; }
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--accent-2);
+}
+
+code {
+  background: var(--code-bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.muted { color: var(--muted); }
+.good  { color: var(--good); }
+.warn  { color: var(--warn); }
+.bad   { color: var(--bad); }
+
+.badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid currentColor;
+}

--- a/src/components/viewers/HtmlPreviewView.tsx
+++ b/src/components/viewers/HtmlPreviewView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import type { RefObject } from "react";
 import {
   resolveHtmlAssets,
   openExternalUrl,
@@ -29,6 +30,30 @@ interface Props {
 // iframe sandbox + CSP.
 const SCRIPT_RE = /<script\b/i;
 const EXTERNAL_IMG_RE = /<img\b[^>]*\bsrc\s*=\s*["']?https?:\/\//i;
+
+// Run `fn` against the iframe's `contentDocument` exactly once — synchronously
+// if the document is already committed, otherwise after one rAF (covers a
+// WebView2 timing window where `contentDocument` can be null at the very
+// instant `load` fires for `srcdoc` content). Returns a cleanup that cancels
+// the pending rAF; safe to call from `useEffect`. `onMissing` fires only on
+// the rAF path when the retry still finds no document.
+function withIframeDoc(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+  fn: (doc: Document) => void,
+  onMissing?: () => void,
+): () => void {
+  const doc = iframeRef.current?.contentDocument;
+  if (doc) {
+    fn(doc);
+    return () => {};
+  }
+  const raf = requestAnimationFrame(() => {
+    const retry = iframeRef.current?.contentDocument;
+    if (retry) fn(retry);
+    else onMissing?.();
+  });
+  return () => cancelAnimationFrame(raf);
+}
 
 export function HtmlPreviewView({ content, filePath }: Props) {
   const [allowImages, setAllowImages] = useState(false);
@@ -166,8 +191,25 @@ export function HtmlPreviewView({ content, filePath }: Props) {
     };
   }, []);
 
+  // Apply zoom to the iframe's document root via CSS `zoom`. CSS does not
+  // cross the iframe boundary so the wrapper's font-size has no effect on
+  // srcDoc content; we set the property directly on the iframe's own
+  // `documentElement`. Re-runs whenever:
+  //   • the zoom factor changes (toolbar +/-/reset, Ctrl+wheel inside iframe)
+  //   • a fresh srcDoc is committed (`iframeDocEpoch` bump on each `onLoad`)
+  // CSS `zoom` is the same property the browser's own zoom uses; it scales
+  // text, images, and px-units consistently inside the iframe document.
+  // The numeric `zoom` is clamped to [ZOOM_MIN, ZOOM_MAX] in the store
+  // (`viewerPrefs.ts`), so the stringified value is always a finite number
+  // — no CSS-injection vector via the template literal.
+  useEffect(() => {
+    return withIframeDoc(iframeRef, (doc) => {
+      doc.documentElement.style.setProperty("zoom", String(zoom));
+    });
+  }, [zoom, iframeDocEpoch]);
+
   return (
-    <div className="html-preview" data-zoom={zoom} style={{ fontSize: `${zoom * 100}%` }}>
+    <div className="html-preview" data-zoom={zoom}>
       {showBanner && (
         <div className="viewer-info-banner" role="status">
           {hasScript && hasExternalImages && (
@@ -268,24 +310,14 @@ export function HtmlPreviewView({ content, filePath }: Props) {
                 const fragment = useStore.getState().consumePendingFragment(filePath);
                 if (fragment) scrollIframeToFragment(doc, fragment);
               };
-              const doc = iframeRef.current?.contentDocument;
-              if (doc) {
-                installClickHandler(doc);
-                consumePendingForThisFile(doc);
-                return;
-              }
-              // Bounded retry — contentDocument can be null when the load
-              // event fires before the document is fully committed (observed
-              // in some Chromium builds with srcdoc). One rAF is enough.
-              requestAnimationFrame(() => {
-                const retryDoc = iframeRef.current?.contentDocument;
-                if (retryDoc) {
-                  installClickHandler(retryDoc);
-                  consumePendingForThisFile(retryDoc);
-                } else {
-                  void warn("[HtmlPreviewView] contentDocument unavailable after rAF retry");
-                }
-              });
+              withIframeDoc(
+                iframeRef,
+                (doc) => {
+                  installClickHandler(doc);
+                  consumePendingForThisFile(doc);
+                },
+                () => void warn("[HtmlPreviewView] contentDocument unavailable after rAF retry"),
+              );
             }}
           />
         </div>

--- a/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
+++ b/src/components/viewers/__tests__/HtmlPreviewView.test.tsx
@@ -30,7 +30,9 @@ vi.mock("@/store", () => {
     toggleCommentsPane: vi.fn(),
     zoomByFiletype: {} as Record<string, number>,
     bumpZoom: () => {},
-    setZoom: () => {},
+    setZoom: vi.fn((ext: string, val: number) => {
+      state.zoomByFiletype[ext] = val;
+    }),
     openFile: vi.fn(),
     pendingFragment: null as { path: string; fragment: string } | null,
     setPendingFragment: vi.fn((entry: { path: string; fragment: string } | null) => {
@@ -51,12 +53,16 @@ vi.mock("@/store", () => {
 import { HtmlPreviewView } from "../HtmlPreviewView";
 import { openExternalUrl, fetchRemoteAsset, getFileViewerPref, setFileViewerPref } from "@/lib/tauri-commands";
 import { warn } from "@/logger";
+import { useStore } from "@/store";
 
 beforeEach(() => {
   (fetchRemoteAsset as unknown as { mockClear: () => void }).mockClear();
   (getFileViewerPref as unknown as { mockClear: () => void }).mockClear();
   (setFileViewerPref as unknown as { mockClear: () => void }).mockClear();
   vi.mocked(warn).mockClear();
+  // Reset zoomByFiletype so per-test mutations cannot leak across tests.
+  const state = (useStore as unknown as { getState: () => { zoomByFiletype: Record<string, number> } }).getState();
+  state.zoomByFiletype = {};
 });
 
 describe("HtmlPreviewView  hard-locked sandbox", () => {
@@ -292,6 +298,71 @@ describe("HtmlPreviewView — safe-mode link interception (H3)", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    cleanup();
+  });
+});
+
+describe("HtmlPreviewView — zoom application", () => {
+  it("sets `zoom` on iframe documentElement at default zoom (1.0)", () => {
+    const { container } = render(<HtmlPreviewView content="<p>x</p>" />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const doc = iframe.contentDocument;
+    if (!doc) throw new Error("contentDocument is null — jsdom limitation");
+    // Production code calls `setProperty("zoom", String(zoom))`. Read back
+    // via the same accessor for an exact-match oracle (no regex).
+    expect(doc.documentElement.style.getPropertyValue("zoom")).toBe("1");
+    // Effect is silent — no warn() should fire for the happy path.
+    expect(warn).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("reflects a non-default store zoom on iframe documentElement", () => {
+    const state = (useStore as unknown as { getState: () => { zoomByFiletype: Record<string, number> } }).getState();
+    state.zoomByFiletype[".html"] = 1.25;
+
+    const { container } = render(<HtmlPreviewView content="<p>x</p>" />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    expect(iframe.contentDocument!.documentElement.style.getPropertyValue("zoom")).toBe("1.25");
+    cleanup();
+  });
+
+  it("re-applies `zoom` after iframe `load` (regression — srcDoc swap re-runs effect)", () => {
+    const state = (useStore as unknown as { getState: () => { zoomByFiletype: Record<string, number> } }).getState();
+    state.zoomByFiletype[".html"] = 1.5;
+
+    const { container } = render(<HtmlPreviewView content="<p>x</p>" />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const doc = iframe.contentDocument!;
+    // Simulate the wholesale-document swap that happens when `srcDoc` is
+    // committed by removing the prior `zoom` property; the effect must
+    // re-set it after the iframeDocEpoch bump triggered by `load`.
+    doc.documentElement.style.removeProperty("zoom");
+    expect(doc.documentElement.style.getPropertyValue("zoom")).toBe("");
+
+    fireEvent.load(iframe);
+    expect(doc.documentElement.style.getPropertyValue("zoom")).toBe("1.5");
+    cleanup();
+  });
+
+  it("re-applies `zoom` when the store value changes (regression — `zoom` dep)", () => {
+    const state = (useStore as unknown as { getState: () => { zoomByFiletype: Record<string, number> } }).getState();
+    state.zoomByFiletype[".html"] = 1;
+
+    const { container, rerender } = render(<HtmlPreviewView content="<p>x</p>" />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    expect(iframe.contentDocument!.documentElement.style.getPropertyValue("zoom")).toBe("1");
+
+    state.zoomByFiletype[".html"] = 2;
+    rerender(<HtmlPreviewView content="<p>x</p>" />);
+    expect(iframe.contentDocument!.documentElement.style.getPropertyValue("zoom")).toBe("2");
+    cleanup();
+  });
+
+  it("wrapper no longer carries an inline fontSize style (regression — wrapper CSS does not cross iframe boundary)", () => {
+    const { container } = render(<HtmlPreviewView content="<p>x</p>" />);
+    const wrapper = container.querySelector(".html-preview") as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.style.fontSize).toBe("");
     cleanup();
   });
 });


### PR DESCRIPTION
## Summary

Two tightly-coupled improvements to the HTML viewer:

1. **Fix HTML preview zoom** — the wrapper-level inline `font-size` added in #335 was a no-op (CSS doesn't cross the iframe boundary). Toolbar `+`/`-`/reset and `Ctrl+wheel` updated the store but the iframe never re-rendered. Now sets `zoom` on the iframe's own `documentElement` so the change actually applies.
2. **Local-CSS sample coverage** — five new HTML samples (`05`–`09`) plus shared `samples/html/css/*` exercise the existing `resolve_html_assets` Rust inliner, the `routeLinkClick` scheme matrix (`src/lib/url-policy.ts`), and cross-file fragment navigation. Smoke-test fodder for the next regression.

## Production change (1 file)

`src/components/viewers/HtmlPreviewView.tsx`:

- Drops the wrapper `style={{ fontSize: ... }}`.
- New `useEffect` that calls `documentElement.style.setProperty("zoom", String(zoom))` on the iframe `contentDocument`. Re-runs on `zoom` change and on each `srcDoc` reload (existing `iframeDocEpoch` bump from `onLoad`).
- Extracts a module-scope `withIframeDoc(iframeRef, fn, onMissing?)` helper that runs `fn` exactly once (sync if the document is committed, else after one `rAF` for the WebView2 timing window). Reused by the existing `onLoad` click-handler installer to flatten the duplicated retry pattern.

## Tests

- **Unit** (`HtmlPreviewView.test.tsx`):
  - Replaced shape regex with exact-match `getPropertyValue("zoom")` oracles.
  - Added regression tests for re-injection on iframe `load` and for zoom-value changes.
  - Reset `zoomByFiletype` in `beforeEach` so per-test mutations cannot leak.
  - Assert `warn` is silent on the happy path.
  - Tightened wrapper-fontSize regression to also assert wrapper presence.
- **Browser e2e** (new `zoom-html.spec.ts`): real-engine assertion that `Ctrl+=` raises `iframe.contentDocument.documentElement.style.zoom` above 1, `Ctrl+-` shrinks, `Ctrl+0` resets to exactly 1 — the visible-scaling oracle that JSDOM cannot provide. `zoom-all-viewers.spec.ts` comment updated to remove the now-stale "content is isolated" claim.

## Sample data

| File | Exercises |
|---|---|
| `samples/html/05-local-css.html` | Single `<link rel=stylesheet>` → inline `<style>` Rust path |
| `samples/html/06-multi-stylesheet.html` | Three cascading local stylesheets, custom-property propagation |
| `samples/html/07-local-links.html` | Workspace-relative anchors into every sibling sample dir + out-of-workspace negatives |
| `samples/html/08-anchors-and-toc.html` | TOC, unicode-id anchor, self-link with fragment, cross-file fragments into markdown |
| `samples/html/09-link-schemes.html` | `EXTERNAL_LINK_SCHEME` / `BLOCKED_LINK_SCHEME` matrix incl. `\n\tjavascript:` bypass attempt |
| `samples/html/css/{reset,theme,layout}.css` | Shared local stylesheets for 05–09 |

## Expert reviews

Six expert agents reviewed before commit; all findings addressed in this PR:

- **architect-expert** — extracted `withIframeDoc` helper, deduped the rAF-retry pattern.
- **bug-expert** — eliminated the `getElementById` collision risk by switching to direct `style` mutation; added `id="what-to-spot-check"` to sample 05 so the cross-file fragment in sample 08 actually scrolls.
- **security-expert** — confirmed safe under iframe sandbox + host CSP + clamped numeric `zoom` (no CSS-injection vector).
- **react-tauri-expert** — idiomatic React 19 + Tauri v2 patterns; `iframeDocEpoch` is the right invalidation primitive.
- **test-expert** — tightened oracles, added missing dep-coverage tests, escalated visible-scaling oracle to browser e2e.
- **lean-expert** — collapsed 22-line `<style>` injection into one-line `setProperty`.

## Verification

| Gate | Result |
|---|---|
| `npm test` (full Vitest suite) | 1914 passed / 1 skipped |
| `npm run lint:typed` | 0 errors (683 pre-existing warnings) |
| `npm run audit:zoom-cascade` | OK — 7 CSS files, no violations |
| `npx playwright test --config=playwright.browser.config.ts` (HTML + zoom + file-viewer specs) | 14 passed |
| `cargo test` (after a `cargo clean` to clear stale rlibs) | All passed |
| `npm run build` | Clean (warnings unchanged from main) |
