### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.4.0 — 2026-05-01
 
 ### Breaking
 - `mdownreview-cli read --all` removed — use `--include-resolved` instead. (#36)
@@ -7,15 +7,54 @@
 - `args-received` Tauri event no longer carries a payload (signal-only). Listeners must call `get_launch_args` to drain the pending-args queue. (#36)
 
 ### Features
-- `mdownreview-cli read --json` (shorthand for `--format json`) and `read --file <path>` for single-file mode with surfaced errors. (#36)
-- `mdownreview-cli respond --resolve` (folds the old `resolve` subcommand into `respond`). (#36)
-- `mdownreview-cli respond --folder <root>` restricts file resolution to a root directory. (#36)
-- `mdownreview-cli cleanup --include-unresolved` also deletes sidecars containing unresolved comments. (#36)
-- `mdownreview-cli --help` (top-level) prints aggregated help: top-level usage followed by every subcommand's long help. (#36)
+- Multi-window support: open multiple workspaces concurrently with per-window state, watcher routing, and CLI-args forwarding. (#147, #204, #321)
+- macOS support overhaul: native menu system (about/services/edit/window submenus), per-window lifecycle, ad-hoc signing, DMG layout. (#303, #305)
+- Viewer overhaul: `ViewerToolbar` consolidated across all viewers (markdown / source / HTML / Mermaid / image / binary) with sticky toolbar and contextual banners. (#65, #117, #243, #246, #335)
+- Source-view syntax highlighting via Shiki + uniform theming. (#94, #178, #181)
+- Mermaid viewer overhaul: themed popout card, fit-to-window 100% baseline, pixel-perfect zoom. (#276, #330, #336)
+- HTML preview: iframe sandbox, asset-protocol images, in-iframe zoom, persistent per-file `allow_images` toggle. (#213, #214, #335, #337)
+- Sidecar enhancements: `sidecar_root` config + migration UI, format-preserving YAML writes, MRSF v1.0 spec compliance, show-sidecars toggle. (#229, #230, #234, #240, #269, #292)
+- Comments overhaul: panel-only commenting, speech-bubble markers, cross-surface flash, file-level anchor unification, simplified mutation surface. (#226, #227, #275, #292)
+- Settings region overhaul: full-page Settings, CLI-shim install/status/remove, default-handler controls, author preference, removal of welcome screen. (#79, #113, #160, #215)
+- Tab bar visual overhaul (max 5 tabs) and folder-pane improvements (filter shortcut, ESC reset, ghost-entry handling). (#40, #80, #95, #164, #211, #216, #218, #219, #223)
+- CLI improvements: `read --json`, `read --file`, `respond --resolve`, `respond --folder`, `cleanup --include-unresolved`, aggregated `--help`. (#36)
+- Engineering excellence: typed-lint gate + new ESLint rules + build-perf gates (#262); tauri-specta auto-generated bindings (#263); `mdr_command!` runtime tracing macro + `StartupRecorder` + `--trace` launch flag (#264, #285, #289); IPC-event fixtures tied to real Rust emission shapes (#311, #313); cross-library on-disk-shape rule (#300, #312).
+- File / comment status uses filesystem mtime. (#96)
+- Canary release pipeline with client-side channel switching. (#50)
 
 ### Fixes
-- macOS `RunEvent::Opened` no longer clobbers pending launch args — args now flow through a Rust-internal pending-args queue (`PendingArgsState`) drained by `get_launch_args`. (#36)
-- NSIS installer: file-association open verb now uses `%*` instead of `%1` so Explorer multi-select → Enter on .md/.mdx files forwards every selected path to a single mdownreview-cli invocation (one window, not N windows). (#36)
+- HTML preview: zoom now applies inside iframe, asset CSP scheme corrected, contextual banner, Ctrl+wheel zoom, link-handling parity with markdown. (#274, #335, #337)
+- Mermaid: redefine 100% as fit-to-window with pixel-perfect zoom and themed popout. (#336)
+- Sidecar/comment IPC contract: snake_case wire shape, `comments-changed` events from Rust mutations, badge TOCTOU fix, sidecar counter accuracy. (#112, #123, #260, #283)
+- Multi-window: state contamination, duplicate-folder bypass, per-window CLI-args routing, per-window watcher state, broadcast events to all windows, zoom ping-pong guard. (#232, #233, #236, #237, #249, #251, #253)
+- Sidecar config dialog: centering, counting, refresh, `.gitignore` override. (#254, #260)
+- Stranded `.reviews/` rescue when toggle is disabled. (#278)
+- Folder pane no longer jumps to active file on folder expand. (#224)
+- Cold-start: main-window menu attached at build time to eliminate flicker. (#265, #286, #318)
+- macOS `RunEvent::Opened` no longer clobbers pending launch args; pending-args queue (`PendingArgsState`) drained by `get_launch_args`. (#36)
+- NSIS installer: file-association open verb uses `%*` so Explorer multi-select forwards every selected path to a single window. (#36)
+- Source-view tokens render uniform black regression. (#181, #188)
+- Sandbox warning readability + persistent settings. (#212, #220)
+- Hide "Empty folder" label when Other Files section is visible. (#197, #199)
+- File-level comment false-orphan warning. (#131, #187)
+- Saphyr emitter unreadable block scalars for whitespace-leading nested strings. (#293, #294)
+- Saphyr `quote_if_needed` multi-line LF bug. (#297, #314)
+- Replace `std::fs::canonicalize` with `dunce` to strip `\\?\` prefix on Windows. (#89, #126)
+- Memoize `CommentsPanel` grouping/sorting/filtering; cancellation guard for source-highlighting async effect; `FolderTree` `mergedList` memo stability; infinite re-render in `useUnresolvedCounts`.
+- Tauri listener leak on rapid unmount in `useComments`.
+- Many CI / E2E / build / lint / test stabilizations.
+
+### Other
+- Removed in-app context menus; Window → DevTools (F12). (#277)
+- Removed audio-specific viewer; audio files now treated as binary. (#333)
+- Removed welcome screen; CLI-shim/default-handler moved into Settings. (#79, #160)
+- Removed folder context menu and multi-select override from NSIS hooks. (#200)
+- Removed unused "open in default app" toolbar action. (#93, #159)
+- Logging: per-startup new log file + log rotation. (#295)
+- CSP: forbid inline `<style>`; assets allowed via `http://asset.localhost` + `asset:` schemes. (#291)
+- Manual-test sample files for every viewer. (#329)
+- Comprehensive Rust + React + Tauri lint enforcement. (#258)
+- Documentation: viewer consistency guidelines, MRSF v1.0 spec, macOS platform best practices, `AGENTIC_DEVELOPMENT.md`, multi-window best practices, agentic-loop skill suite (`groom-issues`, `iterate-loop`, `iterate-one-issue`, `merge-pr-loop`, `optimize-prompt`, `validate-ci`, `test-exploratory-e2e/loop`). (#62, #63, #98, #102, #132, #133, #134, #138, #142, #144, #158, #163, #228, #239, #245, #258, #301)
 
 ### Known gaps
 - The NSIS multi-select fix is NSIS-only. MSI bundles (if produced) still register `%1` per Tauri defaults; multi-select via MSI installs is not yet covered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdownreview",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdownreview",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@shikijs/rehype": "^4.0.2",
         "@tauri-apps/api": "^2.10.1",
@@ -166,7 +166,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -582,7 +581,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -631,7 +629,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2379,7 +2376,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2796,7 +2794,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2807,7 +2804,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2860,7 +2856,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3384,7 +3379,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -3528,7 +3522,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3569,6 +3562,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3875,7 +3869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4053,7 +4046,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -4202,7 +4194,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4603,7 +4594,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4901,7 +4891,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.0",
@@ -5200,7 +5191,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7313,6 +7303,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8738,7 +8729,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8891,6 +8881,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8906,6 +8897,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8918,7 +8910,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8957,7 +8950,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8967,7 +8959,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10103,7 +10094,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10215,7 +10205,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10388,7 +10377,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -10519,7 +10507,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10595,7 +10582,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -10962,7 +10948,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdownreview",
   "private": true,
   "description": "Review AI Agent's work",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mdownreview"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ members = ["mdr-macros"]
 
 [package]
 name = "mdownreview"
-version = "0.3.4"
+version = "0.4.0"
 description = "A desktop markdown reviewer for developers"
 license = "MIT"
 authors = ["davidzh"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mdownreview",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "identifier": "com.mdownreview.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v0.4.0.

Bumps version in `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json` and prepends the v0.4.0 entry to `CHANGELOG.md` (276 commits since v0.3.4: 68 feats, 73 fix/perf, 0 breaking — minor bump).

Highlights: multi-window support, macOS support overhaul, viewer overhaul (toolbar consolidation, source-view syntax highlighting, Mermaid + HTML preview overhauls), sidecar enhancements (`sidecar_root` config + format-preserving YAML + MRSF v1.0 spec compliance), comments overhaul, Settings region overhaul, engineering excellence (typed-lint gate + tauri-specta codegen + runtime tracing), canary release pipeline. See CHANGELOG.md for full list.

Merge after CI passes; tag will trigger build.

⚠️ Native E2E (`npm run test:e2e:native:build`) must be run on Windows before merge — cannot be exercised in GitHub Actions.