### PR TITLE
ci: fix silent macOS verify-adhoc abort on v0.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,13 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          APP_PATH=$(ls -d src-tauri/target/release/bundle/macos/*.app src-tauri/target/*/release/bundle/macos/*.app 2>/dev/null | head -1)
+          # Use matrix.target_dir (single, always-correct path) like the DMG verify step.
+          # A dual-glob `ls a/*.app b/*.app` here aborted the script silently under
+          # `set -e -o pipefail` whenever one glob didn't expand: bash kept the literal,
+          # ls errored on it (stderr suppressed), and pipefail propagated the non-zero
+          # exit through `| head -1`. Single glob matches the bundle path Tauri actually
+          # produced and avoids that booby-trap.
+          APP_PATH=$(ls -d ${{ matrix.target_dir }}/bundle/macos/*.app 2>/dev/null | head -1)
           [ -n "$APP_PATH" ] || { echo "::error::No .app bundle found"; exit 1; }
           codesign -dv --verbose=4 "$APP_PATH" 2>&1 | tee codesign.log
           grep -q 'Signature=adhoc' codesign.log || { echo "::error::App is not ad-hoc signed"; exit 1; }


### PR DESCRIPTION
## Why

The v0.4.0 release build [failed](https://github.com/dryotta/mdownreview/actions/runs/25223711595) on the macOS-arm64 job, in the **Verify ad-hoc signing (macOS)** step. Symptom: 80 ms run, zero output, exit code 1 — none of the script's own `::error::` echoes ran.

## Root cause

The verification step (added after v0.3.4 in #55-iter-1, so v0.4.0 is the first release that actually exercises it) uses a dual-glob `ls` followed by `head -1`:

```bash
APP_PATH=$(ls -d src-tauri/target/release/bundle/macos/*.app src-tauri/target/*/release/bundle/macos/*.app 2>/dev/null | head -1)
```

Under `set -e -o pipefail` (the default for `shell: bash` here), this is a silent booby-trap:

1. For macos-arm64 `tauri_args=""`, only the first glob expands (bundle is at `src-tauri/target/release/bundle/macos/mdownreview.app`).
2. The second glob `src-tauri/target/*/release/bundle/macos/*.app` doesn't match (no `bundle/macos` under `target/aarch64-apple-darwin/release/` — that dir holds the staged CLI binary only).
3. With default bash settings (no `nullglob`), the unmatched pattern is passed to `ls` literally.
4. `ls` errors on the missing path; stderr suppressed by `2>/dev/null`, but exit status is still non-zero.
5. `pipefail` propagates `ls`'s non-zero exit through `| head -1`.
6. `set -e` aborts the script **before** the next line that would echo `::error::No .app bundle found`.

That's why the failure log between `##[endgroup]` and `##[error]Process completed with exit code 1.` is silent and ~80 ms long — no command output, no error message.

The bundle itself was signed correctly (build log shows four `Signing with identity "-"` cycles; updater bundle, DMG, and `.sig` all produced). Only the post-build verification step is broken.

## Fix

Use `matrix.target_dir` directly — a single, always-correct path — exactly like the sibling **Verify DMG layout (macOS)** step does at line 173. Single glob → no missing-path failure → no pipefail trip.

## Plan to unbreak v0.4.0

After this PR merges, force-move the `v0.4.0` tag to the resulting `main` HEAD. The push event re-triggers `release.yml` from the new commit (which includes this fix). The draft release is idempotent (`gh release view ... &>/dev/null || gh release create`), and `gh release upload --clobber` replaces the existing Windows assets with rebuilt ones plus the missing macOS artifacts.

Bonus: the moved tag also includes the multiwin `emit_to` fix from #341 (already release-gate-validated).
