### PR TITLE
ci: fix DMG verify step that fails to mount on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,35 @@ jobs:
           DMG=$(ls -t ${{ matrix.target_dir }}/bundle/dmg/*.dmg 2>/dev/null | head -1)
           [ -n "$DMG" ] || { echo "::error::No DMG found to verify"; exit 1; }
           echo "Verifying DMG layout: $DMG"
-          MOUNT=$(hdiutil attach -nobrowse -readonly -plist "$DMG" \
-            | /usr/libexec/PlistBuddy -c "Print :system-entities:0:mount-point" /dev/stdin 2>/dev/null \
-            || true)
-          if [ -z "$MOUNT" ] || [ ! -d "$MOUNT" ]; then
-            # Fallback: parse mount point from plain hdiutil output
-            MOUNT=$(hdiutil attach -nobrowse -readonly "$DMG" | awk '/\/Volumes\// {sub(/^[^\/]*/, ""); print; exit}')
+          # Defensive: detach any existing mount of THIS DMG before attaching ourselves.
+          # Tauri's bundle_dmg.sh has historically left the DMG attached in some
+          # failure modes (tauri-apps/tauri#3055, electron-builder#3115), which makes
+          # our `hdiutil attach` below fail silently with "Resource busy".
+          DMG_ABS=$(cd "$(dirname "$DMG")" && pwd)/$(basename "$DMG")
+          hdiutil info | awk -v target="$DMG_ABS" '
+            BEGIN { path="" }
+            /^=+$/ { path=""; next }
+            $1 == "image-path" { sub(/^image-path[ \t]*:[ \t]*/, ""); path=$0; next }
+            $1 ~ /^\/dev\/disk[0-9]+$/ && path == target { print $1 }
+          ' | while IFS= read -r dev; do
+            hdiutil detach "$dev" -force >/dev/null 2>&1 || true
+          done
+          # Single attach with stderr captured. Avoid PlistBuddy ":system-entities:0:mount-point":
+          # Tauri DMGs put the GUID-partition-scheme entity at index 0 (no mount-point);
+          # the actual filesystem entity with mount-point is at index 1+. PlistBuddy errors
+          # there were silently swallowed by 2>/dev/null + ||true, leaving the DMG mounted
+          # while the fallback retried and tripped "Resource busy".
+          if ! ATTACH_OUT=$(hdiutil attach -nobrowse -readonly "$DMG" 2>&1); then
+            echo "::error::hdiutil attach failed"
+            echo "$ATTACH_OUT"
+            exit 1
           fi
+          echo "$ATTACH_OUT"
+          # Use match()+substr() — `sub(/^[^\/]*/, "")` is broken for hdiutil lines that
+          # already start with `/dev/...` (it strips zero chars and prints the whole line,
+          # so $MOUNT becomes the entire `/dev/diskN  Apple_HFS  /Volumes/Foo` row and
+          # `[ -d "$MOUNT" ]` fails). match()/substr() also preserves spaces in volume names.
+          MOUNT=$(echo "$ATTACH_OUT" | awk 'match($0, /\/Volumes\/.*/) { print substr($0, RSTART); exit }')
           [ -n "$MOUNT" ] && [ -d "$MOUNT" ] || { echo "::error::Failed to mount DMG"; exit 1; }
           trap 'hdiutil detach "$MOUNT" -force >/dev/null 2>&1 || true' EXIT
           echo "Mounted at: $MOUNT"


### PR DESCRIPTION
## Why

Builds on #343. After the verify-adhoc fix landed, the **next** step in the same macOS job — `Verify DMG layout (macOS)` — failed with `::error::Failed to mount DMG` after only ~470 ms. See [run 25226709948 → Build (macos-arm64)](https://github.com/dryotta/mdownreview/actions/runs/25226709948). Build itself succeeded; DMG was created.

## Root cause — two compounding bugs

Both introduced in the same PR (#55-iter-2 in commit `333415c`) that added the verify steps. v0.4.0 is the first release that actually exercises them on macOS.

### Bug 1 — PlistBuddy hardcoded to wrong array index

```bash
MOUNT=$(hdiutil attach -nobrowse -readonly -plist "$DMG" \
  | /usr/libexec/PlistBuddy -c "Print :system-entities:0:mount-point" /dev/stdin 2>/dev/null \
  || true)
```

Tauri DMGs put the GUID-partition-scheme entity at `system-entities[0]` — and that entity has **no `mount-point` key**. The actual filesystem entity (with `mount-point`) is at index 1+. PlistBuddy emitted "Does Not Exist" to stderr (silenced by `2>/dev/null`), failed, `|| true` swallowed it → `MOUNT=""`.

But the `hdiutil attach` succeeded — so the DMG was now mounted with no record of where.

### Bug 2 — Fallback awk parser was always broken

```bash
MOUNT=$(hdiutil attach -nobrowse -readonly "$DMG" | awk '/\/Volumes\// {sub(/^[^\/]*/, ""); print; exit}')
```

`hdiutil` text output lines start with `/dev/diskN`, so `^[^\/]*` matches **zero** characters. `sub` strips nothing. The whole line is printed. `MOUNT` becomes `/dev/disk5s1<TAB>Apple_HFS<TAB>/Volumes/Foo`, which fails `[ -d "$MOUNT" ]`.

Even if Bug 1 hadn't pre-mounted the DMG, this fallback would have failed identically.

In practice: PlistBuddy mounts the DMG and returns nothing; the fallback `hdiutil attach` then fails with "Resource busy" (already mounted); awk extracts nothing; error fires. Total step time: ~470 ms (matches two fast hdiutil calls hitting cached/error paths, not real attaches).

## Fix

1. **Drop PlistBuddy entirely.** Tauri DMGs are simple single-partition images — the plain-text `hdiutil attach` output is reliable and easier to debug. Single attach, single source of truth.
2. **Replace the broken awk** with `match()` + `substr()` extraction starting from the first `/Volumes/` substring. Preserves spaces in volume names (`/Volumes/My App 1.0` works correctly).
3. **Pre-detach defensively.** Parse `hdiutil info` (with block-reset on `=` separator lines so `path` doesn't carry over to a block without an `image-path`) to find any existing mounts of THIS DMG and detach them. Tauri's `bundle_dmg.sh` has historically left the DMG attached on some flaky paths (tauri-apps/tauri#3055).
4. **Capture `hdiutil` stderr explicitly** with `if ! ATTACH_OUT=$(... 2>&1)` so a future failure shows the real `hdiutil` error instead of going silent.

## Local verification

Verified both awk parsers on Windows with synthetic `hdiutil` output via Git-Bash gawk:

- **Pre-detach awk:** correctly extracts `/dev/disk5` (whole-disk only, not partition slices) when our DMG is among multiple blocks; the `/^=+$/ { path=""; next }` line prevents `path` from carrying over into a subsequent block that has no `image-path`.
- **MOUNT awk:** extracts `/Volumes/mdownreview 0.4.0` from a tab-separated `/dev/disk5s1<TAB>Apple_HFS<TAB>/Volumes/mdownreview 0.4.0` row, including the space.

## Plan

After this PR merges, force-move the `v0.4.0` tag forward again to the new `main` HEAD. The release workflow re-triggers and builds all three platforms; macOS should now reach the upload step.
