### PR TITLE
fix(updater): register tauri-plugin-process so macOS Restart Now button works

### DIFF
--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -28,10 +28,26 @@ flowchart TD
 
 ## Key source
 
-- **Rust:** `src-tauri/src/update.rs`, `src-tauri/src/lib.rs` (plugin registration)
+- **Rust:** `src-tauri/src/update.rs`, `src-tauri/src/lib.rs` (plugin registration — both `tauri-plugin-updater` for download/install and `tauri-plugin-process` for the post-install `relaunch()` IPC)
 - **Frontend:** `updateSlice` in `src/store/index.ts`
-- **UI:** `src/components/AboutDialog.tsx`
+- **UI:** `src/components/AboutDialog.tsx`, `src/components/UpdateBanner.tsx`
 - **CI:** release workflow files under `.github/workflows/` (triggered by the `/publish-release` skill)
+
+## Restart fallback
+
+The "Restart Now" button in `UpdateBanner` calls `restartApp()` →
+`@tauri-apps/plugin-process` `relaunch()` → `plugin:process|restart`.
+If that IPC rejects (plugin not registered, ACL denied, OS-level
+relaunch failure) the banner switches to a **manual-relaunch**
+message ("Update installed — quit and reopen mdownreview from your
+installed location to apply.") instead of leaving the user staring
+at a dead button. The new `.app` bundle has already been swapped
+in by the updater plugin at this point — quitting and reopening
+the app from its installed location (e.g. `/Applications` on
+macOS) picks it up. A static parity test
+(`src/__tests__/tauri-plugin-registration-parity.test.ts`) prevents
+the underlying class of bug (JS plugin import without matching Rust
+`init()` registration or ACL entry).
 
 ## Related rules
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2916,6 +2916,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-specta",
@@ -5524,6 +5525,16 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,14 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-log = { version = "2", features = ["colored"] }
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+# `tauri-plugin-process` provides the `plugin:process|restart` IPC that
+# `restartApp()` (src/lib/tauri-commands.ts → @tauri-apps/plugin-process
+# `relaunch()`) calls after the updater finishes. Without this dep + its
+# `init()` registration in lib.rs, the updater downloads + verifies +
+# swaps the bundle correctly but the "Restart Now" button silently fails
+# (unrouted IPC), leaving the user stuck on the "Restart to apply update"
+# banner. See docs/features/updates.md.
+tauri-plugin-process = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 log = "0.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "clipboard-manager:allow-write-text",
     "opener:allow-open-url",
     "opener:allow-default-urls",
-    "updater:default"
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -663,6 +663,14 @@ pub fn run() {
 
     let app = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // `plugin:process|restart` — invoked by `restartApp()` /
+        // `@tauri-apps/plugin-process` `relaunch()` after the updater has
+        // staged a new bundle. Must be registered or the "Restart Now"
+        // button on the update banner is a no-op (unrouted IPC). See
+        // capabilities/default.json for the matching `process:allow-restart`
+        // ACL — least-privilege over `process:default` (which would also
+        // grant `allow-exit`, a command we never invoke).
+        .plugin(tauri_plugin_process::init())
         .manage(update::PendingUpdate(std::sync::Mutex::new(None)))
         .manage(watcher::WatcherState::new(sync_tx))
         .manage(watcher::SidecarConfigState::new())

--- a/src/__tests__/tauri-plugin-registration-parity.test.ts
+++ b/src/__tests__/tauri-plugin-registration-parity.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+/**
+ * Tauri plugin registration parity contract.
+ *
+ * Background: shipping v0.4.0 of mdownreview, the macOS auto-update flow
+ * downloaded + verified + installed the new bundle correctly, then the
+ * "Restart Now" button silently failed. Root cause: `@tauri-apps/plugin-process`
+ * was imported on the JS side (for `relaunch()`) but `tauri-plugin-process`
+ * was never added to `src-tauri/Cargo.toml` and never `init()`-registered
+ * in `src-tauri/src/lib.rs`. The matching ACL `process:default` was also
+ * missing from `src-tauri/capabilities/default.json`. Vitest unit tests
+ * passed because they mock `@tauri-apps/plugin-process` end-to-end and
+ * never exercise a real Tauri host.
+ *
+ * Contract enforced here: for every `@tauri-apps/plugin-X` import in
+ * production `src/` code, `tauri-plugin-X` MUST appear in
+ * `src-tauri/Cargo.toml` AND `tauri_plugin_X::init()` MUST appear in
+ * `src-tauri/src/lib.rs`. Built-in `@tauri-apps/api/*` modules need no
+ * registration and are excluded.
+ *
+ * This is a static source-scan test (matches the established
+ * `forbid_*_test.rs` / `ipc-mock-parity.test.ts` pattern in this repo).
+ * Running it under Vitest keeps it close to the JS imports it polices.
+ */
+
+const ROOT = resolve(__dirname, "../..");
+const SRC_DIR = resolve(ROOT, "src");
+const CARGO_TOML = readFileSync(resolve(ROOT, "src-tauri/Cargo.toml"), "utf8");
+const LIB_RS = readFileSync(resolve(ROOT, "src-tauri/src/lib.rs"), "utf8");
+
+// Walk every JSON file under src-tauri/capabilities/ rather than hard-coding
+// `default.json`. Tauri v2 supports multi-file capability layouts (e.g., a
+// future `main-window.json` for window-scoped permissions); restricting the
+// scan to a single file would silently miss permissions defined elsewhere.
+function loadAllCapabilityJson(): string {
+  const dir = resolve(ROOT, "src-tauri/capabilities");
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".json")) continue;
+    out.push(readFileSync(join(dir, entry), "utf8"));
+  }
+  return out.join("\n");
+}
+const CAPS_JSON = loadAllCapabilityJson();
+
+// Walk the src/ tree and collect every `@tauri-apps/plugin-<name>` reference,
+// from both static `import ... from "@tauri-apps/plugin-X"` and dynamic
+// `import("@tauri-apps/plugin-X")` forms. Exclude test/mock files — they
+// must not introduce new plugin dependencies, and a mock import would be a
+// false positive.
+function collectPluginImports(dir: string, out: Set<string> = new Set()): Set<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === "__mocks__" || entry === "__tests__" || entry === "node_modules") {
+        continue;
+      }
+      collectPluginImports(full, out);
+    } else if (
+      st.isFile() &&
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx")
+    ) {
+      const src = readFileSync(full, "utf8");
+      // Restrict to actual import syntax — `from "@tauri-apps/plugin-X"`
+      // (static) and `import("@tauri-apps/plugin-X")` (dynamic). A bare
+      // mention in a comment / doc string / test fixture must NOT trip
+      // the parity contract; the contract is about real wire-up, not
+      // textual references.
+      const re = /(?:from\s+|import\s*\(\s*)["']@tauri-apps\/plugin-([a-z][a-z0-9-]*)["']/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src)) !== null) {
+        out.add(m[1]);
+      }
+    }
+  }
+  return out;
+}
+
+const PLUGIN_NAMES = collectPluginImports(SRC_DIR);
+
+// kebab → snake (e.g. `clipboard-manager` → `clipboard_manager`) for the
+// Rust `tauri_plugin_<name>::init()` symbol.
+function toRustModule(kebab: string): string {
+  return kebab.replace(/-/g, "_");
+}
+
+describe("Tauri plugin registration parity (JS imports ↔ Rust init)", () => {
+  it("scans a non-empty plugin set from production src/ (sanity)", () => {
+    expect(PLUGIN_NAMES.size).toBeGreaterThan(0);
+    // Spot-check well-known plugins so a wholesale rename of src/ doesn't
+    // make this test silently extract zero plugins.
+    expect(PLUGIN_NAMES.has("opener")).toBe(true);
+    expect(PLUGIN_NAMES.has("log")).toBe(true);
+  });
+
+  it("every @tauri-apps/plugin-X import is declared in src-tauri/Cargo.toml", () => {
+    const missing: string[] = [];
+    for (const name of PLUGIN_NAMES) {
+      // Match `tauri-plugin-<name> = ...` at start of a line (ignoring
+      // leading whitespace). Comments mentioning the crate elsewhere
+      // don't count as a real dependency declaration.
+      const re = new RegExp(`^\\s*tauri-plugin-${name}\\s*=`, "m");
+      if (!re.test(CARGO_TOML)) {
+        missing.push(`tauri-plugin-${name}`);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `JS-side imports require these Rust crates in src-tauri/Cargo.toml:\n  ${missing.join("\n  ")}\n` +
+          `Without the dep, the matching tauri_plugin_<name>::init() call will fail to compile.`
+      );
+    }
+  });
+
+  it("every @tauri-apps/plugin-X import has a tauri_plugin_X::init() call in src-tauri/src/lib.rs", () => {
+    const missing: string[] = [];
+    for (const name of PLUGIN_NAMES) {
+      const rustMod = toRustModule(name);
+      // Require an actual call site (`init(` / `Builder::new(`), not a
+      // bare symbol reference. Trailing `\s*\(` rules out comments and
+      // doc-strings that mention the symbol but don't invoke it. The
+      // `Builder::new(` arm covers plugins like `tauri-plugin-log` that
+      // are constructed into a local variable and then registered
+      // separately as `.plugin(local_var)` — requiring a literal
+      // `.plugin(tauri_plugin_X::...)` would false-fail on that idiom.
+      // (Limit: a commented-out `// tauri_plugin_X::init()` line still
+      // matches; static text analysis without a Rust parser cannot
+      // distinguish. Cargo dep + ACL gates would still catch the actual
+      // breakage.)
+      const re = new RegExp(`tauri_plugin_${rustMod}::(?:init|Builder::new)\\s*\\(`);
+      if (!re.test(LIB_RS)) {
+        missing.push(`tauri_plugin_${rustMod}`);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `JS-side imports require these init() calls in src-tauri/src/lib.rs:\n  ${missing
+          .map((m) => `.plugin(${m}::init())`)
+          .join("\n  ")}\n` +
+          `Without the registration, the matching plugin:<name>|<command> IPC will be unrouted ` +
+          `and reject at runtime — exactly the bug class that hid the missing tauri-plugin-process ` +
+          `registration through v0.4.0 (macOS "Restart Now" no-op after auto-update).`
+      );
+    }
+  });
+
+  it("every @tauri-apps/plugin-X import has at least one matching <name>:* ACL entry under capabilities/", () => {
+    const missing: string[] = [];
+    for (const name of PLUGIN_NAMES) {
+      // Match any colon-suffixed permission for this plugin —
+      // `<name>:default`, `<name>:allow-*`, `<name>:deny-*`, or any future
+      // Tauri v2 permission shape. Presence of any permission proves the
+      // plugin's IPC has been ACL-considered, which is the property this
+      // test exists to enforce. (The narrower question of whether the
+      // chosen permission is least-privilege is a security-review concern,
+      // not a parity concern.)
+      const re = new RegExp(`"${name}:[a-z][a-z0-9-]*"`);
+      if (!re.test(CAPS_JSON)) {
+        missing.push(`${name}:<permission>`);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `JS-side imports require at least one ACL entry per plugin under src-tauri/capabilities/*.json:\n  ${missing
+          .map((m) => `"${m}"`)
+          .join(",\n  ")}\n` +
+          `Without any ACL, the plugin commands will be denied at runtime even if the plugin is registered.`
+      );
+    }
+  });
+});

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { UpdateBanner } from "./UpdateBanner";
 import { useStore } from "@/store";
+import { restartApp } from "@/lib/tauri-commands";
+import { warn } from "@/logger";
 
 vi.mock("@tauri-apps/api/core");
 vi.mock("@/lib/tauri-events", () => ({
@@ -15,6 +17,18 @@ vi.mock("@/lib/vm/use-update-actions", () => ({
   useUpdateActions: () => ({ install: mockInstall }),
 }));
 
+// Partial mock — `restartApp` is the only post-install Tauri call we need
+// to drive (success default + rejection path for the regression guard
+// against the missing `tauri-plugin-process` registration class of bug).
+// Spreading `actual` keeps the rest of the IPC façade live so a future
+// `restartApp`-adjacent import in this component (e.g., `getAppVersion`
+// for telemetry-on-update) doesn't silently become `undefined`.
+vi.mock("@/lib/tauri-commands", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/tauri-commands")>(
+    "@/lib/tauri-commands"
+  );
+  return { ...actual, restartApp: vi.fn() };
+});
 
 beforeEach(() => {
   useStore.setState({
@@ -22,6 +36,9 @@ beforeEach(() => {
     updateVersion: null,
     updateProgress: 0,
   });
+  vi.mocked(restartApp).mockReset();
+  vi.mocked(restartApp).mockResolvedValue(undefined);
+  vi.mocked(warn).mockClear();
 });
 
 describe("UpdateBanner", () => {
@@ -63,5 +80,103 @@ describe("UpdateBanner", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Dismiss update" }));
     expect(useStore.getState().updateStatus).toBe("idle");
+  });
+
+  it("clicking Restart Now invokes restartApp and does not show fallback", async () => {
+    useStore.setState({ updateStatus: "ready" });
+    render(<UpdateBanner />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Restart Now" }));
+    expect(restartApp).toHaveBeenCalledTimes(1);
+    // Negative oracle: success path must not flip into the fallback UI.
+    expect(screen.queryByTestId("update-banner-fallback")).not.toBeInTheDocument();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Regression guard: when the `plugin:process|restart` IPC rejects (e.g.
+  // tauri-plugin-process not registered, ACL denied, OS relaunch failure),
+  // the banner must (a) log the failure via `warn(...)` so it is captured
+  // in the local log, and (b) surface a manual-relaunch fallback instead
+  // of leaving the user staring at a dead "Restart Now" button. This is
+  // the user-visible symptom of the macOS auto-update bug fixed by this
+  // commit.
+  it("surfaces a manual-relaunch fallback (and logs warn) when restartApp rejects", async () => {
+    vi.mocked(restartApp).mockRejectedValueOnce(new Error("plugin not found"));
+    useStore.setState({ updateStatus: "ready", updateVersion: "1.0.0" });
+    render(<UpdateBanner />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Restart Now" }));
+    expect(await screen.findByTestId("update-banner-fallback")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Restart Now" })).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("UpdateBanner: restartApp failed")
+    );
+  });
+
+  it("dismiss button on the fallback UI resets status to idle", async () => {
+    vi.mocked(restartApp).mockRejectedValueOnce(new Error("plugin not found"));
+    useStore.setState({ updateStatus: "ready", updateVersion: "1.0.0" });
+    render(<UpdateBanner />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Restart Now" }));
+    await screen.findByTestId("update-banner-fallback");
+    await user.click(screen.getByRole("button", { name: "Dismiss update" }));
+    expect(useStore.getState().updateStatus).toBe("idle");
+  });
+
+  // Regression guard for the rubber-duck "blocking #1" finding: the banner
+  // is mounted for the entire app lifetime (not conditionally rendered in
+  // App.tsx), so a sticky `restartFailed` flag would carry over from one
+  // failed update into the next available update in the same session and
+  // permanently hide the "Restart Now" button. Drive the full state cycle
+  // and prove the button comes back.
+  it("recovers the Restart Now button on a subsequent ready transition after an earlier failure", async () => {
+    vi.mocked(restartApp).mockRejectedValueOnce(new Error("plugin not found"));
+    useStore.setState({ updateStatus: "ready", updateVersion: "1.0.0" });
+    const { rerender } = render(<UpdateBanner />);
+    const user = userEvent.setup();
+    // Step 1 — first ready cycle, restart fails, fallback shows.
+    await user.click(screen.getByRole("button", { name: "Restart Now" }));
+    await screen.findByTestId("update-banner-fallback");
+    expect(screen.queryByRole("button", { name: "Restart Now" })).not.toBeInTheDocument();
+    // Step 2 — user dismisses, store goes idle, fallback unmounts.
+    await user.click(screen.getByRole("button", { name: "Dismiss update" }));
+    rerender(<UpdateBanner />);
+    expect(screen.queryByTestId("update-banner-fallback")).not.toBeInTheDocument();
+    // Step 3 — a later check finds another update on a NEW version and
+    // lands on `ready` again. The button MUST be live; the previous
+    // failure on v1.0.0 must not suppress restart for v1.1.0. The
+    // version-keyed `failedVersion` makes this derived state. `act(...)`
+    // wraps the external store transition so React flushes the resulting
+    // re-render synchronously inside the test.
+    act(() => {
+      useStore.setState({ updateStatus: "ready", updateVersion: "1.1.0" });
+    });
+    rerender(<UpdateBanner />);
+    expect(screen.queryByTestId("update-banner-fallback")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart Now" })).toBeInTheDocument();
+  });
+
+  // Sibling regression to the recovery test: when the SAME version is
+  // re-presented as ready (e.g. user dismissed without restarting and the
+  // next periodic check re-detects the already-staged bundle), the
+  // fallback MUST stay because the IPC failure is not transient — the
+  // plugin/ACL situation is identical and `restartApp()` would reject
+  // again. Version-keyed `failedVersion` encodes exactly this semantic.
+  it("keeps the fallback when the same version is re-presented as ready after a failure", async () => {
+    vi.mocked(restartApp).mockRejectedValueOnce(new Error("plugin not found"));
+    useStore.setState({ updateStatus: "ready", updateVersion: "1.0.0" });
+    const { rerender } = render(<UpdateBanner />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Restart Now" }));
+    await screen.findByTestId("update-banner-fallback");
+    await user.click(screen.getByRole("button", { name: "Dismiss update" }));
+    rerender(<UpdateBanner />);
+    act(() => {
+      useStore.setState({ updateStatus: "ready", updateVersion: "1.0.0" });
+    });
+    rerender(<UpdateBanner />);
+    expect(screen.getByTestId("update-banner-fallback")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Restart Now" })).not.toBeInTheDocument();
   });
 });

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { restartApp } from "@/lib/tauri-commands";
 import { useUpdateActions } from "@/lib/vm/use-update-actions";
+import { warn } from "@/logger";
 import { useUpdateState } from "@/store";
 import "@/styles/update-banner.css";
 
@@ -11,6 +13,17 @@ export function UpdateBanner() {
     dismissUpdate,
   } = useUpdateState();
   const { install } = useUpdateActions();
+  // `failedVersion` records the update version whose `restartApp()`
+  // rejected. The banner is mounted for the entire app lifetime (see
+  // App.tsx — not conditionally rendered), so a naive boolean would
+  // sticky-stick across `ready -> dismiss -> idle -> (new) ready`
+  // cycles. Keying off the version makes the fallback derived state:
+  // a new version automatically resets it without a cascading
+  // `useEffect`. Rejection is recorded against the version that
+  // failed so a re-try of the SAME version (which would hit the same
+  // unrouted IPC) keeps the fallback in place.
+  const [failedVersion, setFailedVersion] = useState<string | null>(null);
+  const restartFailed = failedVersion !== null && failedVersion === updateVersion;
 
   if (updateStatus === "idle" || updateStatus === "checking" || updateStatus === "error") {
     return null;
@@ -21,7 +34,16 @@ export function UpdateBanner() {
   };
 
   const handleRestart = async () => {
-    await restartApp();
+    try {
+      await restartApp();
+    } catch (e) {
+      // Log + surface — never silently swallow. The new bundle is on disk
+      // either way, so a manual relaunch will pick it up. Recording the
+      // version (rather than a bare boolean) is what makes the fallback
+      // self-heal across multiple update cycles in one session.
+      void warn(`UpdateBanner: restartApp failed — ${String(e)}`);
+      setFailedVersion(updateVersion);
+    }
   };
 
   return (
@@ -39,10 +61,18 @@ export function UpdateBanner() {
           <progress className="update-banner-progress" value={updateProgress} max={100} />
         </>
       )}
-      {updateStatus === "ready" && (
+      {updateStatus === "ready" && !restartFailed && (
         <>
           <span>Restart to apply update</span>
           <button className="update-banner-btn" onClick={handleRestart}>Restart Now</button>
+          <button className="update-banner-dismiss" onClick={dismissUpdate} aria-label="Dismiss update">✕</button>
+        </>
+      )}
+      {updateStatus === "ready" && restartFailed && (
+        <>
+          <span data-testid="update-banner-fallback">
+            Update installed — quit and reopen mdownreview from your installed location to apply.
+          </span>
           <button className="update-banner-dismiss" onClick={dismissUpdate} aria-label="Dismiss update">✕</button>
         </>
       )}


### PR DESCRIPTION
## Summary

Fixes the macOS auto-update flow: download + verify + bundle-swap all worked, but the post-install **Restart Now** button was a silent no-op, leaving users stuck on "Restart to apply update" forever.

## Root cause

`restartApp()` in `src/lib/tauri-commands.ts` calls `@tauri-apps/plugin-process` `relaunch()`, which dispatches `plugin:process|restart` over IPC. The matching Rust crate `tauri-plugin-process` was never declared in `Cargo.toml`, never `init()`-registered in `lib.rs`, and had no ACL entry. The IPC was unrouted; the renderer swallowed the rejection silently.

## Fix (three axes — all required)

| Axis | Change |
|---|---|
| **Cargo dep** | `tauri-plugin-process = "2"` in `src-tauri/Cargo.toml` |
| **Rust init** | `.plugin(tauri_plugin_process::init())` in `src-tauri/src/lib.rs` next to `tauri-plugin-updater` |
| **ACL** | `process:allow-restart` in `src-tauri/capabilities/default.json` (least-privilege over `process:default`, which would also grant `allow-exit`) |

## Frontend hardening

`UpdateBanner.tsx` now wraps `restartApp()` in try/catch:
- Logs the failure via `warn(...)` (so it lands in the local log and can be triaged).
- Surfaces a manual-relaunch fallback message keyed off `updateVersion`. Version-keyed (not boolean) state self-heals across multi-update cycles in one session — a NEW version automatically restores the **Restart Now** button; the SAME version keeps the fallback (the IPC failure is non-transient).

## Regression coverage

- **NEW** `src/__tests__/tauri-plugin-registration-parity.test.ts` — static parity test that walks every `@tauri-apps/plugin-X` import under `src/` and asserts:
  1. `tauri-plugin-X` exists in `Cargo.toml` (line-anchored, ignores comments)
  2. `tauri_plugin_X::init|Builder::new(` call site exists in `lib.rs` (call-shape required, blocks comment-mention false-pass)
  3. At least one `<name>:*` ACL entry exists across `capabilities/*.json` (multi-file walk for forward-compat)
- Mutation-tested: reverting any of the three axes (or replacing the call with a comment-only mention) makes the corresponding subtest fail with a precise error.
- `UpdateBanner.test.tsx` grows from 6 → 11 tests covering happy path, IPC-rejects path, dismiss-from-fallback, recovery on new version, and stuck-on-same-version paths.

## Expert review

Three reviewer subagents consulted:
- **security-expert** (no critical/high/medium) → adopted ACL tightening
- **test-expert** (7 must-act items) → all adopted: warn assertion, `data-testid`, partial `importActual` mock, multi-file capability walk, broadened ACL regex, deleted dead state reset, etc.
- **rubber-duck** (1 blocking + 5 non-blocking) → adopted blocking sticky-state recovery + version-keyed redesign + tightened parity regex (call-shape) + softened relaunch copy + restricted import-syntax scan + lib.rs comment fix

## Local validation (all CI gates green)

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors |
| `npm run build` | tsc + vite ok |
| `cargo clippy --all-targets -- -D clippy::dbg_macro -D clippy::todo` (CI's exact invocation) | clean |
| `cargo test` | all suites green (502+ root + integration tests) |
| `npm test` | **1932 passing**, 1 skipped |
| `npm run test:e2e` (Playwright browser) | **143 passing**, 3 skipped |

Native E2E is Windows-only — not run on this macOS dev machine.

## Files changed

- `src-tauri/Cargo.toml` (+8) · `src-tauri/Cargo.lock` (regen)
- `src-tauri/src/lib.rs` (+8)
- `src-tauri/capabilities/default.json` (+1)
- `src/components/UpdateBanner.tsx` (try/catch + version-keyed fallback)
- `src/components/UpdateBanner.test.tsx` (6 → 11 tests)
- **NEW** `src/__tests__/tauri-plugin-registration-parity.test.ts` (+161)
- `docs/features/updates.md` (+16)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>