### PR TITLE
fix(viewer): remove inline mermaid chrome + correct comment-bubble positioning

### DIFF
--- a/e2e/browser/comment-bubble-position.spec.ts
+++ b/e2e/browser/comment-bubble-position.spec.ts
@@ -1,0 +1,215 @@
+// Regression test for the speech-bubble positioning bug fixed alongside
+// the mermaid-button overlap fix (issue surfaced by the bug-expert audit).
+//
+// Bug summary: `.md-commentable-block.has-comments::before` (and the
+// `::after` back-bubble for ≥2 comments) declared `position: absolute;
+// left: 4px; top: 4px`, but the wrappers `.md-commentable-block` and
+// `.md-commentable-li` had no `position: relative`. The pseudos escaped
+// to the next positioned ancestor — `.markdown-body { position:
+// relative }` — and stacked at the top-left of the body regardless of
+// which block carried the comment. Only `.md-commentable-cell` had
+// `position: relative` (with an explicit comment in the CSS noting why
+// cells need it), so cells worked correctly. Block / li variants did
+// not.
+//
+// Fix: add `position: relative` to `.md-commentable-block` and
+// `.md-commentable-li`, then re-tune the `left` offsets to land the
+// bubble in the gutter to the LEFT of the wrapper rather than 4px
+// inside the wrapper's text content area.
+//
+// This test loads a markdown file with several commented blocks at
+// different vertical positions and verifies:
+//   1. Each bubble's effective viewport-Y aligns with its OWN block,
+//      not all stacked at the body top.
+//   2. Each bubble's effective viewport-X is LEFT of the wrapper's
+//      content edge (i.e., in the gutter, not painted over the text).
+
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+const FIXTURES_DIR = "/e2e/fixtures";
+const FILE = `${FIXTURES_DIR}/multi-block-comments.md`;
+
+// Body lines (1-indexed):
+//   1: # Heading
+//   2: <blank>
+//   3: First paragraph.
+//   4: <blank>
+//   5: Second paragraph.
+//   6: <blank>
+//   7: - First list item.
+//   8: - Second list item.
+const BODY = [
+  "# Heading",
+  "",
+  "First paragraph.",
+  "",
+  "Second paragraph.",
+  "",
+  "- First list item.",
+  "- Second list item.",
+  "",
+].join("\n");
+
+async function setupMocks(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ dir, file, body }: { dir: string; file: string; body: string }) => {
+      window.__TAURI_IPC_MOCK__ = async (cmd: string) => {
+        if (cmd === "get_launch_args") return { files: [], folders: [dir] };
+        if (cmd === "read_dir") {
+          return [{ name: "multi-block-comments.md", path: file, is_dir: false }];
+        }
+        if (cmd === "read_text_file") return body;
+        if (cmd === "stat_file") return { size_bytes: body.length };
+        if (cmd === "load_review_comments") return null;
+        if (cmd === "save_review_comments") return null;
+        if (cmd === "check_path_exists") return "file";
+        if (cmd === "get_log_path") return "/mock/log.log";
+        if (cmd === "get_file_badges") return {};
+        if (cmd === "get_file_comments") {
+          // Anchor a comment on heading (1), each paragraph (3, 5), and the
+          // first list item (7). Each thread root carries the matched line
+          // so `useThreadsByLine` buckets them per source line.
+          const make = (line: number, id: string) => ({
+            root: {
+              id,
+              line,
+              matchedLineNumber: line,
+              isOrphaned: false,
+              author: "Tester",
+              text: `comment on line ${line}`,
+              timestamp: new Date().toISOString(),
+              resolved: false,
+              anchor_kind: "line",
+            },
+            replies: [],
+          });
+          return {
+            threads: [
+              make(1, "c1"),
+              make(3, "c2"),
+              make(5, "c3"),
+              make(7, "c4"),
+            ],
+            sidecar_mtime_ms: null,
+          };
+        }
+        return null;
+      };
+    },
+    { dir: FIXTURES_DIR, file: FILE, body: BODY },
+  );
+}
+
+interface BubbleSnapshot {
+  /** data-source-line of the wrapper */
+  line: number;
+  /** Wrapper's bounding rect (viewport-relative) */
+  wrapperTop: number;
+  wrapperBottom: number;
+  /** Effective viewport-Y of the bubble's center */
+  bubbleCenterY: number;
+}
+
+test.describe("comment bubble positioning (regression for the .markdown-body escape bug)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await page.goto("/");
+    await page.locator(".folder-tree").getByText("multi-block-comments.md").click();
+    await expect(page.locator(".markdown-body")).toBeVisible();
+    // Wait for the threads payload to render — at least one bubble visible.
+    await expect(page.locator(".md-commentable-block.has-comments, .md-commentable-li.has-comments"))
+      .toHaveCount(4, { timeout: 5_000 });
+  });
+
+  test("bubbles do NOT all stack at the top of .markdown-body — each bubble sits with its own block", async ({
+    page,
+  }) => {
+    // Snapshot every commented wrapper's viewport position + its ::before
+    // bubble's resolved offsets. Pseudo-elements have no `getBoundingClientRect`,
+    // so we compute their effective viewport position from the wrapper's
+    // bounding rect plus the resolved `top`/`left`/`width`/`height` pulled
+    // from `getComputedStyle(el, '::before')`.
+    const snapshots: BubbleSnapshot[] = await page.evaluate(() => {
+      const wrappers = Array.from(
+        document.querySelectorAll(
+          ".md-commentable-block.has-comments, .md-commentable-li.has-comments",
+        ),
+      );
+      return wrappers.map((el) => {
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        const cs = window.getComputedStyle(el as HTMLElement, "::before");
+        const top = parseFloat(cs.top);
+        const h = parseFloat(cs.height);
+        const line = parseInt(
+          (el as HTMLElement).getAttribute("data-source-line") ?? "0",
+          10,
+        );
+        return {
+          line,
+          wrapperTop: rect.top,
+          wrapperBottom: rect.bottom,
+          bubbleCenterY: rect.top + top + h / 2,
+        };
+      });
+    });
+
+    expect(snapshots.length).toBe(4);
+
+    // Bubbles must have DIFFERENT viewport-Y values (no stacking).
+    const ys = snapshots.map((s) => s.bubbleCenterY);
+    const uniqueYs = new Set(ys.map((y) => Math.round(y)));
+    expect(uniqueYs.size).toBe(snapshots.length);
+
+    // Sort by source line and verify Y is monotonically increasing —
+    // earlier blocks have bubbles HIGHER in the viewport.
+    const sorted = [...snapshots].sort((a, b) => a.line - b.line);
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i].bubbleCenterY).toBeGreaterThan(sorted[i - 1].bubbleCenterY);
+    }
+
+    // Each bubble's center-Y must sit WITHIN its own wrapper's vertical
+    // bounds (with a small tolerance for the bubble extending slightly
+    // above the line-box top).
+    for (const s of snapshots) {
+      expect(s.bubbleCenterY).toBeGreaterThanOrEqual(s.wrapperTop - 4);
+      expect(s.bubbleCenterY).toBeLessThanOrEqual(s.wrapperBottom + 4);
+    }
+  });
+
+  test("each bubble sits in the gutter (LEFT of the wrapper's content edge), not painted over the text", async ({
+    page,
+  }) => {
+    const data = await page.evaluate(() => {
+      const wrappers = Array.from(
+        document.querySelectorAll(
+          ".md-commentable-block.has-comments, .md-commentable-li.has-comments",
+        ),
+      );
+      return wrappers.map((el) => {
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        const cs = window.getComputedStyle(el as HTMLElement, "::before");
+        const left = parseFloat(cs.left);
+        const w = parseFloat(cs.width);
+        return {
+          line: parseInt((el as HTMLElement).getAttribute("data-source-line") ?? "0", 10),
+          wrapperLeft: rect.left,
+          // Effective right edge of the bubble in the viewport.
+          bubbleRight: rect.left + left + w,
+        };
+      });
+    });
+
+    expect(data.length).toBe(4);
+
+    // The bubble's right edge must be ≤ the wrapper's left edge (modulo a
+    // 1px sub-pixel cushion), i.e. the bubble sits entirely OUTSIDE the
+    // wrapper to its left — in the gutter, not on the text.
+    for (const d of data) {
+      expect(
+        d.bubbleRight,
+        `bubble for line ${d.line} bleeds into wrapper text (bubbleRight=${d.bubbleRight}, wrapperLeft=${d.wrapperLeft})`,
+      ).toBeLessThanOrEqual(d.wrapperLeft + 1);
+    }
+  });
+});

--- a/e2e/browser/mermaid-popout.spec.ts
+++ b/e2e/browser/mermaid-popout.spec.ts
@@ -137,17 +137,20 @@ test.describe("mermaid popout (issue #276)", () => {
     await expect(page.locator(".mermaid-popout-overlay")).not.toBeVisible();
   });
 
-  test("renders the dedicated viewer for .mmd files with the floating Pop-out button", async ({
+  test("renders the dedicated viewer for .mmd files with no inline canvas chrome", async ({
     page,
   }) => {
     await setupMocks(page);
     await page.goto("/");
     await page.locator(".folder-tree").getByText("flow.mmd").click();
     await expect(page.locator(".mermaid-canvas svg")).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page.locator(".mermaid-canvas-actions button", { hasText: "Fit" }),
-    ).toBeVisible();
-    await expect(page.locator('button[aria-label="Pop out"]')).toBeVisible();
+    // Inline Fit / Pop-out chrome was removed: zoom + reset live in the
+    // chrome ViewerToolbar (single source of truth via useZoom), and Pop-out
+    // is a no-op when the viewer already IS the full-window view. The
+    // hover-Pop-out affordance only lives on `MermaidEmbedded`.
+    await expect(page.locator(".mermaid-canvas-actions")).toHaveCount(0);
+    await expect(page.locator('button[aria-label="Pop out"]')).toHaveCount(0);
+    await expect(page.locator('button[aria-label="Fit to window"]')).toHaveCount(0);
   });
 
   test("Ctrl+wheel zooms the popout content", async ({ page }) => {

--- a/src/components/viewers/MermaidView.tsx
+++ b/src/components/viewers/MermaidView.tsx
@@ -1,7 +1,4 @@
-import { useCallback } from "react";
-
 import { MermaidCanvas } from "./mermaid/MermaidCanvas";
-import { MermaidControls } from "./mermaid/MermaidControls";
 
 import { useStore } from "@/store";
 
@@ -19,30 +16,17 @@ interface Props {
  * Slim shell for the dedicated `.mmd` viewer (issue #276 — c2-mermaidview).
  *
  * Render + theme + transform + pan/zoom now live in MermaidCanvas (which
- * composes MermaidRenderer). This file only owns:
- *   1. Wiring the shared `.mmd` zoom (via `useStore`) into MermaidCanvas.
- *   2. Routing the Fit button click to a zoom reset (1.0 ≡ fit-to-window
- *      under the hybrid scale model owned by MermaidCanvas).
- *   3. Showing the inline Fit + Pop-out controls ONLY for the dedicated
- *      viewer path (signalled by the presence of `path`). The embedded
- *      markdown-block path (MarkdownComponentsMap → MermaidView, until
- *      c3-markdownmap swaps it for MermaidEmbedded) passes no path and
- *      therefore renders no controls inside the markdown body.
+ * composes MermaidRenderer). This file only owns wiring the shared `.mmd`
+ * zoom (via `useStore`) into MermaidCanvas. The dedicated viewer itself
+ * renders no inline chrome — zoom + reset live in the chrome
+ * ViewerToolbar (single source of truth via `useZoom`), and the Pop-out
+ * affordance lives ONLY on the markdown-embedded path
+ * (`MermaidEmbedded`'s hover button) where it's the only way to enlarge
+ * a tiny embedded diagram. The dedicated viewer already IS the full-
+ * window view, so a Pop-out button there would be a no-op.
  */
 export function MermaidView({ content, path, zoom = 1 }: Props) {
   const setZoom = useStore((s) => s.setZoom);
-  const bumpZoom = useStore((s) => s.bumpZoom);
-  const openMermaidPopout = useStore((s) => s.openMermaidPopout);
-
-  // 1.0 ≡ fit under MermaidCanvas's scale model, so "Fit" is just a zoom
-  // reset. Same chokepoint chrome's ViewerToolbar uses for Cmd+0 etc.
-  const handleFitClick = useCallback(() => {
-    bumpZoom(".mmd", "reset");
-  }, [bumpZoom]);
-
-  const handlePopout = useCallback(() => {
-    openMermaidPopout(content, path ?? null);
-  }, [openMermaidPopout, content, path]);
 
   return (
     <div
@@ -56,17 +40,6 @@ export function MermaidView({ content, path, zoom = 1 }: Props) {
         setZoom={(v) => setZoom(".mmd", v)}
         readOnly={false}
       />
-      {path !== undefined && (
-        <MermaidControls
-          mode="inline"
-          zoom={zoom}
-          onZoomIn={() => useStore.getState().bumpZoom(".mmd", "in")}
-          onZoomOut={() => useStore.getState().bumpZoom(".mmd", "out")}
-          onReset={() => useStore.getState().bumpZoom(".mmd", "reset")}
-          onFit={handleFitClick}
-          onPopout={handlePopout}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/viewers/__tests__/MermaidControls.test.tsx
+++ b/src/components/viewers/__tests__/MermaidControls.test.tsx
@@ -7,129 +7,82 @@ import { MermaidControls } from "../mermaid/MermaidControls";
 const noop = () => {};
 
 describe("MermaidControls", () => {
-  describe("mode=inline", () => {
-    it("renders Fit + Pop-out and wires their handlers", async () => {
-      const user = userEvent.setup();
-      const onFit = vi.fn();
-      const onPopout = vi.fn();
-      render(
-        <MermaidControls
-          mode="inline"
-          zoom={1}
-          onZoomIn={noop}
-          onZoomOut={noop}
-          onReset={noop}
-          onFit={onFit}
-          onPopout={onPopout}
-        />,
-      );
+  it("renders − / zoom-display / + / Fit / X and wires their handlers", async () => {
+    const user = userEvent.setup();
+    const onZoomIn = vi.fn();
+    const onZoomOut = vi.fn();
+    const onReset = vi.fn();
+    const onFit = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MermaidControls
+        zoom={1}
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
+        onReset={onReset}
+        onFit={onFit}
+        onClose={onClose}
+      />,
+    );
 
-      await user.click(screen.getByRole("button", { name: "Fit to window" }));
-      expect(onFit).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "Zoom out" }));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
 
-      await user.click(screen.getByRole("button", { name: "Pop out" }));
-      expect(onPopout).toHaveBeenCalledTimes(1);
-    });
+    await user.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(onZoomIn).toHaveBeenCalledTimes(1);
 
-    it("omits the pop-out button when onPopout is undefined", () => {
-      render(
-        <MermaidControls
-          mode="inline"
-          zoom={1}
-          onZoomIn={noop}
-          onZoomOut={noop}
-          onReset={noop}
-          onFit={noop}
-        />,
-      );
+    await user.click(screen.getByRole("button", { name: "Fit to window" }));
+    expect(onFit).toHaveBeenCalledTimes(1);
 
-      expect(screen.getByRole("button", { name: "Fit to window" })).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Pop out" })).not.toBeInTheDocument();
-    });
+    await user.click(screen.getByRole("button", { name: "Close popout" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Reset zoom is a role="button" span
+    await user.click(screen.getByRole("button", { name: "Reset zoom" }));
+    expect(onReset).toHaveBeenCalledTimes(1);
   });
 
-  describe("mode=popout", () => {
-    it("renders − / zoom-display / + / Fit / X and wires their handlers", async () => {
-      const user = userEvent.setup();
-      const onZoomIn = vi.fn();
-      const onZoomOut = vi.fn();
-      const onReset = vi.fn();
-      const onFit = vi.fn();
-      const onClose = vi.fn();
-      render(
-        <MermaidControls
-          mode="popout"
-          zoom={1}
-          onZoomIn={onZoomIn}
-          onZoomOut={onZoomOut}
-          onReset={onReset}
-          onFit={onFit}
-          onClose={onClose}
-        />,
-      );
-
-      await user.click(screen.getByRole("button", { name: "Zoom out" }));
-      expect(onZoomOut).toHaveBeenCalledTimes(1);
-
-      await user.click(screen.getByRole("button", { name: "Zoom in" }));
-      expect(onZoomIn).toHaveBeenCalledTimes(1);
-
-      await user.click(screen.getByRole("button", { name: "Fit to window" }));
-      expect(onFit).toHaveBeenCalledTimes(1);
-
-      await user.click(screen.getByRole("button", { name: "Close popout" }));
-      expect(onClose).toHaveBeenCalledTimes(1);
-
-      // Reset zoom is a role="button" span
-      await user.click(screen.getByRole("button", { name: "Reset zoom" }));
-      expect(onReset).toHaveBeenCalledTimes(1);
-    });
-
-    it.each([
-      [1, "100%"],
-      [1.21, "121%"],
-      [2.5, "250%"],
-    ])("renders zoom %s as %s", (zoom, expected) => {
-      render(
-        <MermaidControls
-          mode="popout"
-          zoom={zoom}
-          onZoomIn={noop}
-          onZoomOut={noop}
-          onReset={noop}
-          onFit={noop}
-          onClose={noop}
-        />,
-      );
-      expect(screen.getByRole("button", { name: "Reset zoom" })).toHaveTextContent(expected);
-    });
-
-    it("invokes onReset on Enter key activation of the zoom display", async () => {
-      const user = userEvent.setup();
-      const onReset = vi.fn();
-      render(
-        <MermaidControls
-          mode="popout"
-          zoom={1}
-          onZoomIn={noop}
-          onZoomOut={noop}
-          onReset={onReset}
-          onFit={noop}
-          onClose={noop}
-        />,
-      );
-
-      const display = screen.getByRole("button", { name: "Reset zoom" });
-      display.focus();
-      await user.keyboard("{Enter}");
-      expect(onReset).toHaveBeenCalledTimes(1);
-    });
+  it.each([
+    [1, "100%"],
+    [1.21, "121%"],
+    [2.5, "250%"],
+  ])("renders zoom %s as %s", (zoom, expected) => {
+    render(
+      <MermaidControls
+        zoom={zoom}
+        onZoomIn={noop}
+        onZoomOut={noop}
+        onReset={noop}
+        onFit={noop}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toHaveTextContent(expected);
   });
 
-  it("every <button> uses type=\"button\" (no implicit form submit)", () => {
+  it("invokes onReset on Enter key activation of the zoom display", async () => {
+    const user = userEvent.setup();
+    const onReset = vi.fn();
+    render(
+      <MermaidControls
+        zoom={1}
+        onZoomIn={noop}
+        onZoomOut={noop}
+        onReset={onReset}
+        onFit={noop}
+        onClose={noop}
+      />,
+    );
+
+    const display = screen.getByRole("button", { name: "Reset zoom" });
+    display.focus();
+    await user.keyboard("{Enter}");
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('every <button> uses type="button" (no implicit form submit)', () => {
     const { container } = render(
       <MermaidControls
-        mode="popout"
         zoom={1}
         onZoomIn={noop}
         onZoomOut={noop}
@@ -141,20 +94,5 @@ describe("MermaidControls", () => {
     const buttons = container.querySelectorAll("button");
     expect(buttons.length).toBeGreaterThan(0);
     buttons.forEach((b) => expect(b.getAttribute("type")).toBe("button"));
-
-    const inline = render(
-      <MermaidControls
-        mode="inline"
-        zoom={1}
-        onZoomIn={noop}
-        onZoomOut={noop}
-        onReset={noop}
-        onFit={noop}
-        onPopout={noop}
-      />,
-    );
-    const inlineButtons = inline.container.querySelectorAll("button");
-    expect(inlineButtons.length).toBeGreaterThan(0);
-    inlineButtons.forEach((b) => expect(b.getAttribute("type")).toBe("button"));
   });
 });

--- a/src/components/viewers/__tests__/MermaidPopout.test.tsx
+++ b/src/components/viewers/__tests__/MermaidPopout.test.tsx
@@ -18,13 +18,12 @@ type CanvasProps = {
   readOnly?: boolean;
 };
 type ControlsProps = {
-  mode: "inline" | "popout";
   zoom: number;
   onZoomIn: () => void;
   onZoomOut: () => void;
   onReset: () => void;
   onFit: () => void;
-  onClose?: () => void;
+  onClose: () => void;
 };
 const captured: { canvas: CanvasProps | null; controls: ControlsProps | null } = {
   canvas: null,
@@ -143,11 +142,10 @@ describe("MermaidPopout — child wiring", () => {
     expect(captured.canvas?.path).toBe("/y.mmd");
   });
 
-  it('renders MermaidControls with mode="popout" and a close handler', () => {
+  it("renders MermaidControls with a close handler", () => {
     state.mermaidPopoutOpenFor = { content: "graph TD; A-->B", path: null };
     render(<MermaidPopout />);
     expect(captured.controls).not.toBeNull();
-    expect(captured.controls?.mode).toBe("popout");
     expect(typeof captured.controls?.onClose).toBe("function");
   });
 

--- a/src/components/viewers/__tests__/MermaidView.test.tsx
+++ b/src/components/viewers/__tests__/MermaidView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/vm/use-comments", () => ({
@@ -18,9 +18,6 @@ vi.mock("@/lib/mermaid-singleton", () => ({
 const storeState = {
   zoomByFiletype: {} as Record<string, number>,
   setZoom: vi.fn(),
-  bumpZoom: vi.fn(),
-  openMermaidPopout: vi.fn(),
-  closeMermaidPopout: vi.fn(),
 };
 
 vi.mock("@/store", () => {
@@ -39,8 +36,6 @@ beforeEach(() => {
   });
   storeState.zoomByFiletype = {};
   storeState.setZoom.mockReset();
-  storeState.bumpZoom.mockReset();
-  storeState.openMermaidPopout.mockReset();
 });
 
 describe("MermaidView", () => {
@@ -63,30 +58,29 @@ describe("MermaidView", () => {
     errSpy.mockRestore();
   });
 
-  it("hides inline controls when no path is provided (embedded markdown-block path)", async () => {
-    render(<MermaidView content="graph TD; A-->B;" />);
-    // Wait for async mermaid render to settle so React's act warning doesn't fire.
+  it("renders no inline canvas chrome regardless of `path` (zoom + reset live in chrome ViewerToolbar; Pop-out belongs to MermaidEmbedded only)", async () => {
+    // Embedded path (no `path`) — was always chrome-less.
+    const { rerender, container } = render(<MermaidView content="graph TD; A-->B;" />);
     await waitFor(() => {
       expect(screen.getByTitle("Mermaid diagram")).toBeInTheDocument();
     });
-    expect(screen.queryByRole("button", { name: /fit/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /pop out/i })).not.toBeInTheDocument();
-    // Zoom in/out/reset live in the chrome ViewerToolbar — never inside MermaidView.
-    expect(screen.queryByRole("button", { name: /zoom in/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /zoom out/i })).not.toBeInTheDocument();
-  });
+    for (const name of [/fit/i, /pop out/i, /zoom in/i, /zoom out/i]) {
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument();
+    }
+    expect(container.querySelector(".mermaid-canvas-actions")).toBeNull();
 
-  it("shows Fit + Pop-out (but not zoom in/out) when path is provided (dedicated viewer)", async () => {
-    render(<MermaidView content="graph TD; A-->B;" path="/tmp/diagram.mmd" />);
-    expect(await screen.findByRole("button", { name: /fit/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /pop out/i })).toBeInTheDocument();
-    // Flush the async mermaid render before ending the test.
+    // Dedicated viewer path (with `path`) — now also chrome-less. Earlier
+    // iterations rendered Fit + Pop-out here; both were removed because Fit
+    // duplicates the chrome ViewerToolbar's reset and Pop-out is a no-op
+    // when the viewer already IS the full-window view.
+    rerender(<MermaidView content="graph TD; A-->B;" path="/tmp/diagram.mmd" />);
     await waitFor(() => {
       expect(screen.getByTitle("Mermaid diagram")).toBeInTheDocument();
     });
-    // Chrome ViewerToolbar is the only zoom in/out surface.
-    expect(screen.queryByRole("button", { name: /zoom in/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /zoom out/i })).not.toBeInTheDocument();
+    for (const name of [/fit/i, /pop out/i, /zoom in/i, /zoom out/i]) {
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument();
+    }
+    expect(container.querySelector(".mermaid-canvas-actions")).toBeNull();
   });
 
   it("accepts zoom prop and applies it to the canvas transform wrapper", async () => {
@@ -99,18 +93,5 @@ describe("MermaidView", () => {
     const transformDiv = container.querySelector(".mermaid-canvas-transform") as HTMLElement | null;
     expect(transformDiv).not.toBeNull();
     expect(transformDiv!.style.transform).toContain("scale(1.5)");
-  });
-
-  it("clicking Pop-out invokes openMermaidPopout(content, path)", async () => {
-    const content = "graph TD; A-->B;";
-    const path = "/tmp/diagram.mmd";
-    render(<MermaidView content={content} path={path} />);
-    fireEvent.click(await screen.findByRole("button", { name: /pop out/i }));
-    expect(storeState.openMermaidPopout).toHaveBeenCalledTimes(1);
-    expect(storeState.openMermaidPopout).toHaveBeenCalledWith(content, path);
-    // Flush async render.
-    await waitFor(() => {
-      expect(screen.getByTitle("Mermaid diagram")).toBeInTheDocument();
-    });
   });
 });

--- a/src/components/viewers/mermaid/MermaidControls.tsx
+++ b/src/components/viewers/mermaid/MermaidControls.tsx
@@ -1,55 +1,36 @@
 import "@/styles/mermaid-popout.css";
-import "@/styles/mermaid-view.css";
 
 interface Props {
-  /** "inline" → small floating top-right buttons (Fit + Pop-out) used inside the dedicated `.mmd` viewer's MermaidCanvas.
-   *  "popout" → bottom-centred floating bar (− / 100% / + / Fit) plus a top-right close button used inside MermaidPopout. */
-  mode: "inline" | "popout";
-  /** Current zoom value (e.g. 1.21 for 121%). */
+  /** Bottom-centred floating bar (− / 100% / + / Fit) plus a top-right close
+   *  button used inside `MermaidPopout`. The previous `mode="inline"` variant
+   *  used to render Fit + Pop-out at the dedicated `.mmd` viewer's top-right;
+   *  it was removed because zoom + reset live in the chrome `ViewerToolbar`
+   *  and Pop-out is a no-op when the viewer already IS the full-window view. */
   zoom: number;
-  /** Required for both modes — chrome ViewerToolbar shortcuts continue to drive these too (single source of truth via useZoom). */
+  /** Handlers — chrome ViewerToolbar shortcuts also drive these via the
+   *  same `useZoom` source-of-truth so the popout bar stays in sync. */
   onZoomIn: () => void;
   onZoomOut: () => void;
   onReset: () => void;
   /** Mermaid-specific: compute fit-to-window scale and apply via setZoom. */
   onFit: () => void;
-  /** Inline mode: opens the popout overlay. Required when mode === "inline". */
-  onPopout?: () => void;
-  /** Popout mode: closes the overlay (X button). Required when mode === "popout". */
-  onClose?: () => void;
+  /** Closes the overlay (X button). */
+  onClose: () => void;
 }
 
 /**
- * Floating Mermaid canvas controls. Pure controlled component — all state
- * (zoom + handlers) flows in via props. `useZoom` in the parent is the
- * single source of truth so chrome ViewerToolbar shortcuts stay in sync.
+ * Floating Mermaid popout chrome — controlled component, all state and
+ * handlers flow in via props so `useZoom` in the parent is the single
+ * source of truth.
  */
 export function MermaidControls({
-  mode,
   zoom,
   onZoomIn,
   onZoomOut,
   onReset,
   onFit,
-  onPopout,
   onClose,
 }: Props) {
-  if (mode === "inline") {
-    return (
-      <div className="mermaid-canvas-actions">
-        <button type="button" title="Fit to window" aria-label="Fit to window" onClick={onFit}>
-          Fit
-        </button>
-        {onPopout ? (
-          <button type="button" title="Pop out" aria-label="Pop out" onClick={onPopout}>
-            ⤢
-          </button>
-        ) : null}
-      </div>
-    );
-  }
-
-  // mode === "popout"
   const percent = `${Math.round(zoom * 100)}%`;
   return (
     <>

--- a/src/components/viewers/mermaid/MermaidPopout.tsx
+++ b/src/components/viewers/mermaid/MermaidPopout.tsx
@@ -20,7 +20,7 @@ import "@/styles/mermaid-popout.css";
  *     <div class="mermaid-popout-card">      ← visible card with border,
  *                                              shadow, theme background
  *       <MermaidCanvas .../>
- *       <MermaidControls mode="popout" .../>
+ *       <MermaidControls .../>
  *     </div>
  *   </div>
  *
@@ -90,7 +90,6 @@ function PopoutInner({ content, path }: { content: string; path: string | null }
           readOnly
         />
         <MermaidControls
-          mode="popout"
           zoom={zoom}
           onZoomIn={zoomIn}
           onZoomOut={zoomOut}

--- a/src/styles/comments.css
+++ b/src/styles/comments.css
@@ -315,6 +315,24 @@
  * MarkdownViewer's onClick. The pseudo-element is purely visual.
  */
 
+/* Block-level wrappers (`-block` for paragraphs / headings / blockquotes /
+ * fenced code / images / hr / etc., `-li` for list items) need their own
+ * positioning context so the absolute pseudo-elements below resolve
+ * relative to the wrapper they belong to — NOT escape upward to the
+ * `.markdown-body { position: relative }` and stack at the document's
+ * top-left. (The `-cell` rule below documents the same constraint.)
+ *
+ * Once the wrappers are positioned, the `left` offset on the bubbles is
+ * NEGATIVE so the bubble draws in the gutter to the LEFT of the wrapper
+ * (top-level blocks: `.markdown-body`'s 28 px padding-left; nested list
+ * items: the parent `<ul>`'s 2 em padding-left where bullet markers sit
+ * — visually consistent with the per-block-gutter intent documented at
+ * the top of this section). */
+.md-commentable-block,
+.md-commentable-li {
+  position: relative;
+}
+
 /* Cells need their own positioning context for the ::before badge. */
 .md-commentable-cell {
   position: relative;
@@ -334,7 +352,11 @@
 .md-commentable-cell::before {
   content: "+";
   position: absolute;
-  left: 4px;
+  /* No `top` — pseudo falls back to its static-flow Y (the wrapper's
+   * top), which keeps the click hit-area tall enough to capture clicks
+   * on thin wrappers like `<hr>` whose vertical center can be only a
+   * few pixels below the wrapper top. The bubble variant
+   * (`.has-comments::before`) explicitly sets `top: 4px`. */
   width: 20px;
   height: 20px;
   border-radius: 50%;
@@ -351,6 +373,23 @@
   border: none;
   box-sizing: border-box;
   z-index: 5;
+}
+/* Block / list-item: the `+` sits in the gutter to the LEFT of the
+ * wrapper. `-24px` lines up with the body's 28 px padding-left for
+ * top-level blocks (visually identical to the pre-fix placement, just
+ * per-block instead of escaping to `.markdown-body`). For nested list
+ * items the same `-24px` lands in the parent `<ul>`'s 2 em padding
+ * column where bullet markers sit — visually consistent with the
+ * "left ~28 px of any commentable block is the gutter" intent
+ * documented at the top of this section. */
+.md-commentable-block::before,
+.md-commentable-li::before {
+  left: -24px;
+}
+/* Table cell: the `+` lives INSIDE the cell padding (cells have no
+ * external gutter to spill into without breaking the table grid). */
+.md-commentable-cell::before {
+  left: 4px;
 }
 
 .md-commentable-block:hover::before,
@@ -375,13 +414,21 @@
   border-radius: 0;
   width: 16px;
   height: 16px;
-  left: 4px;
   top: 4px;
   opacity: 1;
   -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M3 2.5h10A1.5 1.5 0 0 1 14.5 4v6A1.5 1.5 0 0 1 13 11.5H7.5l-3.1 2.7a.5.5 0 0 1-.83-.38V11.5H3A1.5 1.5 0 0 1 1.5 10V4A1.5 1.5 0 0 1 3 2.5z'/></svg>")
     no-repeat center / 16px 16px;
   mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'><path d='M3 2.5h10A1.5 1.5 0 0 1 14.5 4v6A1.5 1.5 0 0 1 13 11.5H7.5l-3.1 2.7a.5.5 0 0 1-.83-.38V11.5H3A1.5 1.5 0 0 1 1.5 10V4A1.5 1.5 0 0 1 3 2.5z'/></svg>")
     no-repeat center / 16px 16px;
+}
+/* `-22px` puts the 16 px bubble flush within the same 28 px gutter the
+ * 20 px hover `+` uses (`-24px` for the larger glyph). */
+.md-commentable-block.has-comments::before,
+.md-commentable-li.has-comments::before {
+  left: -22px;
+}
+.md-commentable-cell.has-comments::before {
+  left: 4px;
 }
 
 /* Stacked bubbles for ≥2 comments: render the back bubble via ::after,
@@ -392,7 +439,6 @@
 .md-commentable-cell.has-comments:not([data-comment-count="1"])::after {
   content: "";
   position: absolute;
-  left: 6px;
   top: 6px;
   width: 16px;
   height: 16px;
@@ -404,6 +450,15 @@
     no-repeat center / 16px 16px;
   z-index: 4;
   pointer-events: none;
+}
+/* Back bubble sits 2 px down-and-right of the front (block/li:
+ * front=`-22px`, back=`-20px`; cell: front=`4px`, back=`6px`). */
+.md-commentable-block.has-comments:not([data-comment-count="1"])::after,
+.md-commentable-li.has-comments:not([data-comment-count="1"])::after {
+  left: -20px;
+}
+.md-commentable-cell.has-comments:not([data-comment-count="1"])::after {
+  left: 6px;
 }
 
 .comment-edit {

--- a/src/styles/mermaid-view.css
+++ b/src/styles/mermaid-view.css
@@ -69,24 +69,3 @@
   transform-origin: center center;
   user-select: none;
 }
-/* Floating action buttons (top-right of the canvas — Fit + Pop-out). */
-.mermaid-canvas-actions {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: flex;
-  gap: 4px;
-  z-index: 2;
-}
-.mermaid-canvas-actions button {
-  background: var(--color-surface, #f6f8fa);
-  border: 1px solid var(--color-border, #d0d7de);
-  border-radius: 4px;
-  padding: 2px 6px;
-  cursor: pointer;
-  font-size: 12px; /* zoom-cascade: chrome */
-  line-height: 1.2;
-}
-.mermaid-canvas-actions button:hover {
-  background: var(--color-hover, #f3f4f6);
-}


### PR DESCRIPTION
## Why

Two related CSS positioning-context bugs surfaced when the comments pane was open while viewing a Mermaid diagram:

1. **The dedicated `.mmd` viewer's Fit + Pop-out buttons overlapped the comments pane.** `position: absolute` on `.mermaid-canvas-actions` was resolving against `.main-area` (the only positioned ancestor  for the mermaid popout overlay) instead of staying inside the viewer.
2. **Comment speech-bubble markers stacked at the markdown body's top-left** instead of next to their own block. Sister bug, same class: `.md-commentable-block.has-comments::before` was `position: absolute` but `.md-commentable-block` and `.md-commentable-li` had no `position: relative` (only `-cell` did), so pseudos escaped to `.markdown-body`.

## What

### Mermaid (Phase 1)
- **Removed** the inline Fit + Pop-out buttons from the dedicated `.mmd` viewer (`MermaidView.tsx`). Zoom + reset live in the chrome `ViewerToolbar` (single source of truth via `useZoom`); Pop-out is a no-op when the viewer already IS the full-window view. Pop-out only makes sense on `MermaidEmbedded` (markdown-body inline diagrams), which already has its own hover-Pop-out button.
- Dropped `mode=inline` from `MermaidControls` (now popout-only) and the dead `.mermaid-canvas-actions` CSS.

### Comment bubbles (Phase 2)
- Added `position: relative` to `.md-commentable-block` and `.md-commentable-li`.
- Split bubble offset rules: `-block` / `-li` use negative `left` (`-24px` hover `+`, `-22px` front bubble, `-20px` back bubble) so the bubble lands in the gutter LEFT of the wrapper. `-cell` keeps positive insets (cells render bubbles inside their padding because they have no external gutter).
- Did NOT add `top: 4px` to the base hover-`+` rule  vertical fall-back to static keeps click hit-testing working on thin `<hr>` wrappers.

### Tests (Phase 3)
- New `e2e/browser/comment-bubble-position.spec.ts`: asserts bubbles for distinct commented blocks have distinct viewport-Y values (monotonically by source line), each bubble's center sits within its own wrapper's vertical bounds, and each bubble's right edge  wrapper's left edge (in the gutter, not on the text).
- Updated existing specs: `MermaidView.test.tsx`, `MermaidControls.test.tsx`, `MermaidPopout.test.tsx`, and `mermaid-popout.spec.ts:140` all assert the dedicated viewer is now free of inline chrome.

## Verification

| Gate | Result |
|---|---|
| `npm run lint:typed` | 0 errors, 687 warnings (pre-existing) |
| `npm run audit:zoom-cascade` | 7 CSS files, no violations |
| `npx vitest run` (full) | 1918 passed, 1 skipped |
| Playwright browser e2e (full) | 145 passed, 3 skipped |

## Risk

- `MermaidControls` no longer ships an inline mode; revival would need to come from git history rather than dead code.
- Comment-bubble negative `left` offsets are tuned against `.markdown-body { padding-left: 28px }`. If that padding changes, the offsets need re-tuning. CSS comment documents the dependency.
- Nested list items now show their bubble in the parent's indentation column rather than at the body gutter  matches the documented per-block intent.
