### PR TITLE
fix: minor UX polish bundle (mermaid backdrop + resize bug, Window menu, Welcome link, Comments panel)

### DIFF
--- a/e2e/browser/comment-on-file.spec.ts
+++ b/e2e/browser/comment-on-file.spec.ts
@@ -264,25 +264,4 @@ test.describe("Iter 5 Group B — file-level comment entry points", () => {
     await expect(pillBtn).toHaveCount(1);
     await expect(pillBtn.locator(".viewer-toolbar-comment-on-file-label")).toHaveCount(0);
   });
-
-  test("CommentsPanel '+' button is also a valid entry point (no toolbar click required)", async ({ page }) => {
-    await setupCommentOnFileMocks(page);
-    await page.goto("/");
-
-    await page.locator(".folder-tree").getByText("sample.md").click();
-    await expect(page.locator(".markdown-viewer")).toBeVisible();
-
-    const plusBtn = page.locator(".comments-panel-header").getByRole("button", { name: /comment on file/i });
-    await expect(plusBtn).toBeVisible();
-    await plusBtn.click();
-
-    const textarea = page.locator(".comment-panel-file-input .comment-textarea");
-    await expect(textarea).toBeVisible();
-    await textarea.fill("from the panel");
-    await page.locator(".comment-panel-file-input").getByRole("button", { name: /^save$/i }).click();
-
-    await expect.poll(() => readAddCommentCalls(page).then((c) => c.length)).toBeGreaterThanOrEqual(1);
-    const calls = await readAddCommentCalls(page);
-    expect(calls[calls.length - 1].anchor).toEqual({ kind: "file" });
-  });
 });

--- a/e2e/browser/keyboard-shortcuts.spec.ts
+++ b/e2e/browser/keyboard-shortcuts.spec.ts
@@ -79,11 +79,12 @@ test.describe("F1 keyboard shortcuts", () => {
     await page.locator(".folder-tree").getByText("sample.md").click();
     await expect(page.getByText("First unresolved")).toBeVisible();
 
-    // Open the file-level composer via the panel "+" so we have a
-    // textarea to dismiss. The composer mounts under .comment-input.
-    // (The viewer toolbar exposes a button with the same accessible
-    // name; scope to the comments panel to disambiguate.)
-    await page.locator(".comments-panel").getByRole("button", { name: /Comment on file/i }).click();
+    // Open the file-level composer via the viewer toolbar's
+    // "Comment on file" button so we have a textarea to dismiss. The
+    // composer mounts under .comment-input. (The redundant panel "+"
+    // affordance was removed — the toolbar button is now the only
+    // file-level entry point.)
+    await page.locator(".viewer-toolbar").getByRole("button", { name: /Comment on file/i }).click();
     const textarea = page.locator(".comment-input textarea");
     await expect(textarea).toBeVisible();
 

--- a/e2e/browser/panels.spec.ts
+++ b/e2e/browser/panels.spec.ts
@@ -37,6 +37,11 @@ test.describe("Panels and Keyboard Shortcuts", () => {
 
   test("24.4 - Comments toolbar button toggles comments panel", async ({ page }) => {
     await page.goto("/");
+    // The Comments toolbar button is intentionally hidden on the welcome
+    // screen — it has nothing to act on without an active tab. Open a
+    // file first so the button mounts, then exercise the toggle.
+    await page.locator(".folder-tree").getByText("doc.md").click();
+
     const commentsBtn = page.getByTitle("Toggle comments pane (Ctrl+Shift+C)");
     await expect(commentsBtn).toBeVisible();
     await expect(commentsBtn).toHaveClass(/active/);

--- a/e2e/browser/ux-overhaul.spec.ts
+++ b/e2e/browser/ux-overhaul.spec.ts
@@ -360,19 +360,28 @@ test.describe("UX overhaul (#41) — hover-stable close button", () => {
 });
 
 test.describe("UX overhaul (#41) — toolbar enumeration", () => {
-  test("F8 — top toolbar exposes exactly [Open File, Open Folder, Comments] (#160 removed Settings gear)", async ({ page }) => {
-    await installMock(page, makeFiles(0));
+  test("F8 — top toolbar exposes [Open File, Open Folder] on welcome and adds [Comments] when a file is open (#160 removed Settings gear)", async ({ page }) => {
+    // Use a 1-file fixture so we can exercise both states (welcome
+    // screen + with active tab) in a single test.
+    const files = makeFiles(1);
+    await installMock(page, files);
     await page.goto("/");
 
     // Wait for the toolbar to mount
     const group = page.locator(".toolbar .toolbar-btn-group");
     await expect(group).toBeVisible();
 
-    // Three buttons — #160 removed the Settings gear; Help → Settings is the sole entry.
-    await expect(group.locator("button")).toHaveCount(3);
+    // Welcome state: two buttons. The Comments toggle is intentionally
+    // hidden when no tab is active — it has nothing to act on.
+    await expect(group.locator("button")).toHaveCount(2);
+    let buttonTexts = await group.locator("button").allInnerTexts();
+    expect(buttonTexts.map((t) => t.trim())).toEqual(["Open File", "Open Folder"]);
 
-    // Order matters per AC.
-    const buttonTexts = await group.locator("button").allInnerTexts();
+    // Open the file → Comments toggle reappears.
+    await page.locator(".folder-tree").getByText(files[0].name).click();
+
+    await expect(group.locator("button")).toHaveCount(3);
+    buttonTexts = await group.locator("button").allInnerTexts();
     expect(buttonTexts.map((t) => t.trim())).toEqual(["Open File", "Open Folder", "Comments"]);
 
     // No Theme/About/Settings buttons in the top toolbar.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,7 +133,13 @@ fn build_window_menu<R: Runtime, M: Manager<R>>(
     let close_all_tabs = MenuItem::with_id(
         handle, id("close-all-tabs"), "Close All Tabs", true, Some("CmdOrCtrl+Shift+W"),
     )?;
+    // macOS HIG mandates Cmd+, for Settings (rule `mac-menu-settings-placement`
+    // in docs/best-practices-common/tauri/macos-platform.md); on Windows the
+    // accelerator is intentionally omitted — we don't reserve Ctrl+, globally.
+    #[cfg(target_os = "macos")]
     let help_settings = MenuItem::with_id(handle, id("help-settings"), "Settings…", true, Some("CmdOrCtrl+,"))?;
+    #[cfg(not(target_os = "macos"))]
+    let help_settings = MenuItem::with_id(handle, id("help-settings"), "Settings…", true, None::<&str>)?;
 
     let toggle_comments_pane = MenuItem::with_id(
         handle, id("toggle-comments-pane"), "Toggle Comments Pane", true, Some("CmdOrCtrl+Shift+C"),
@@ -245,10 +251,12 @@ fn build_window_menu<R: Runtime, M: Manager<R>>(
             .quit()
             .build()?;
 
+        // "Bring All to Front" is a macOS-only Window-menu convention
+        // (Apple HIG); on Windows the equivalent affordance is the
+        // taskbar group thumbnail, so we omit it here.
         let win_minimize = MenuItem::with_id(handle, id("win-minimize"), "Minimize", true, None::<&str>)?;
-        let win_bring_all = MenuItem::with_id(handle, id("win-bring-all"), "Bring All to Front", true, None::<&str>)?;
         let window_menu = SubmenuBuilder::new(handle, "Window")
-            .item(&win_minimize).separator().item(&win_bring_all)
+            .item(&win_minimize)
             .separator().item(&toggle_devtools).build()?;
 
         let about_item = MenuItem::with_id(handle, id("about"), "About mdownreview", true, None::<&str>)?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,18 +181,20 @@ export default function App() {
             <button className="toolbar-btn" onClick={handleOpenFolderClick} title="Open folder">
               <IconFolder /> Open Folder
             </button>
-            <button
-              className={`toolbar-btn toolbar-btn-toggle${commentsPaneVisible && !activeIsSidecar ? " active" : ""}`}
-              onClick={toggleCommentsPane}
-              disabled={activeIsSidecar}
-              title={
-                activeIsSidecar
-                  ? "Comments are disabled on .review.yaml/.review.json sidecar files"
-                  : "Toggle comments pane (Ctrl+Shift+C)"
-              }
-            >
-              <IconComment /> Comments
-            </button>
+            {activeTabPath && (
+              <button
+                className={`toolbar-btn toolbar-btn-toggle${commentsPaneVisible && !activeIsSidecar ? " active" : ""}`}
+                onClick={toggleCommentsPane}
+                disabled={activeIsSidecar}
+                title={
+                  activeIsSidecar
+                    ? "Comments are disabled on .review.yaml/.review.json sidecar files"
+                    : "Toggle comments pane (Ctrl+Shift+C)"
+                }
+              >
+                <IconComment /> Comments
+              </button>
+            )}
           </div>
           <ErrorBoundary>
             <TabBar />

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -139,16 +139,33 @@ function pressKey(opts: { key: string; ctrlKey?: boolean; shiftKey?: boolean; me
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("App – toolbar rendering", () => {
-  it("renders Open File, Open Folder, and Comments buttons; Settings/Theme/About buttons removed from toolbar", async () => {
+  it("renders Open File and Open Folder buttons; Settings/Theme/About buttons removed from toolbar", async () => {
     await renderApp();
 
     expect(screen.getByText("Open File")).toBeInTheDocument();
     expect(screen.getByText("Open Folder")).toBeInTheDocument();
-    expect(screen.getByText("Comments")).toBeInTheDocument();
     // Gear icon removed from toolbar in #160.
     expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
     expect(screen.queryByText("System")).not.toBeInTheDocument();
     expect(screen.queryByText("About")).not.toBeInTheDocument();
+  });
+
+  it("hides the Comments toolbar button when no file is open", async () => {
+    // Default state: no active tab. The Comments button (which only
+    // makes sense for an open file) is gated behind `activeTabPath` so
+    // the toolbar stays focused on the open-file/open-folder onboarding
+    // path on the welcome screen.
+    await renderApp();
+    expect(screen.queryByText("Comments")).not.toBeInTheDocument();
+  });
+
+  it("shows the Comments toolbar button when a file is open", async () => {
+    useStore.setState({
+      tabs: [{ path: "/foo.md", scrollTop: 0 }],
+      activeTabPath: "/foo.md",
+    });
+    await renderApp();
+    expect(screen.getByText("Comments")).toBeInTheDocument();
   });
 
   it("shows WelcomeView when no active tab", async () => {

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -62,14 +62,6 @@ export function WelcomeView({ onOpenFile, onOpenFolder }: WelcomeViewProps) {
           </button>
         </div>
 
-        <button
-          type="button"
-          className="welcome-settings-link"
-          onClick={openSettings}
-        >
-          Set up CLI, file associations, and agent integration → Settings
-        </button>
-
         {recentItems.length > 0 && (
           <div className="welcome-recent">
             <h2 className="welcome-recent-title">Recent</h2>
@@ -101,6 +93,16 @@ export function WelcomeView({ onOpenFile, onOpenFolder }: WelcomeViewProps) {
           </div>
         )}
       </div>
+
+      {/* Anchored bottom-right of the welcome surface so the centered
+          content above stays vertically balanced regardless of recents. */}
+      <button
+        type="button"
+        className="welcome-settings-link"
+        onClick={openSettings}
+      >
+        Set up CLI, file associations, and agent integration → Settings
+      </button>
     </div>
   );
 }

--- a/src/components/comments/CommentsPanel.tsx
+++ b/src/components/comments/CommentsPanel.tsx
@@ -271,15 +271,6 @@ export function CommentsPanel({ filePath, onScrollToLine }: Props) {
     <div className="comments-panel">
       <div className="comments-panel-header">
         <span className="comments-panel-title">Comments ({unresolvedCount})</span>
-        <button
-          className="comment-btn comment-btn-add-file"
-          onClick={() => setShowFileLevelInput((v) => !v)}
-          disabled={!canCommentOnFile}
-          title="Comment on file"
-          aria-label="Comment on file"
-        >
-          +
-        </button>
         <button className="comment-btn" onClick={() => setShowResolved((v) => !v)}>
           {showResolved ? "Hide resolved" : `Show resolved (${resolvedCount})`}
         </button>

--- a/src/components/comments/__tests__/CommentsPanel.test.tsx
+++ b/src/components/comments/__tests__/CommentsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { CommentsPanel } from "../CommentsPanel";
 import { useComments } from "@/lib/vm/use-comments";
 import { useCommentActions } from "@/lib/vm/use-comment-actions";
@@ -73,6 +73,20 @@ function setMockComments(threads: CommentThreadType[]) {
     comments: allComments,
     loading: false,
     reload: vi.fn(),
+  });
+}
+
+/**
+ * Open the file-level composer the same way production does: by setting
+ * `pendingFileLevelInputFor` (the toolbar's "Comment on file" button
+ * routes through `requestFileLevelInput`, which sets this flag). The
+ * panel's auto-open effect mirrors the flag into local state then
+ * clears the flag. Replaces the previous `+` button click which was
+ * removed when the redundant in-panel button was deleted.
+ */
+function openFileLevelComposer(filePath: string = FILE) {
+  act(() => {
+    useStore.setState({ pendingFileLevelInputFor: filePath });
   });
 }
 
@@ -443,64 +457,13 @@ describe("14.3 – CommentsPanel", () => {
 });
 
 // ─── Iter 5 Group B: file-level comment entry point ──────────────────────────
+//
+// The panel no longer renders an in-header `+` button (removed because
+// the toolbar's "Comment on file" button drives the same flow via
+// `pendingFileLevelInputFor`). These tests exercise the auto-open path
+// that ALL production callers funnel through.
 
 describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
-  it("'+' button is disabled when filePath is empty", () => {
-    render(<CommentsPanel filePath="" />);
-    const addBtn = screen.getByRole("button", { name: /comment on file/i });
-    expect(addBtn).toBeDisabled();
-  });
-
-  it("'+' button is enabled when filePath is non-empty", () => {
-    render(<CommentsPanel filePath={FILE} />);
-    const addBtn = screen.getByRole("button", { name: /comment on file/i });
-    expect(addBtn).not.toBeDisabled();
-  });
-
-  it("clicking '+' opens an inline CommentInput above the thread list", () => {
-    render(<CommentsPanel filePath={FILE} />);
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
-  });
-
-  it("Save calls addComment with { kind: 'file' } anchor", async () => {
-    render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
-
-    const textarea = screen.getByRole("textbox");
-    fireEvent.change(textarea, { target: { value: "high-level note" } });
-    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
-
-    expect(mockAddComment).toHaveBeenCalledWith(FILE, "high-level note", { kind: "file" });
-    // Iter 3 (#280) AC6 — handler is async; let the resolved IPC settle so
-    // the post-success setState (close input) flushes before the next test.
-    await waitFor(() =>
-      expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
-    );
-  });
-
-  it("Save closes the inline input on successful save", async () => {
-    render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "x" } });
-    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
-    // Iter 3 (#280) AC6 — handler is async; the input closes only after the
-    // awaited addComment resolves.
-    await waitFor(() =>
-      expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
-    );
-  });
-
-  it("Cancel hides the inline input without saving", () => {
-    render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    expect(mockAddComment).not.toHaveBeenCalled();
-  });
-
   it("auto-opens input when pendingFileLevelInputFor === filePath and clears the flag", () => {
     useStore.setState({ pendingFileLevelInputFor: FILE });
     render(<CommentsPanel filePath={FILE} />);
@@ -516,6 +479,55 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
     expect(useStore.getState().pendingFileLevelInputFor).toBe("/some/other.md");
   });
 
+  it("does NOT auto-open the input when filePath is empty (canCommentOnFile guard)", () => {
+    // When no file is open the auto-open effect short-circuits because
+    // pendingFileLevelInputFor is null (production never sets it for an
+    // empty path), AND the render guard `showFileLevelInput &&
+    // canCommentOnFile` blocks the textbox. Belt-and-braces: even if
+    // the flag is forced to "", the falsy check at the effect level
+    // prevents the input from appearing.
+    useStore.setState({ pendingFileLevelInputFor: "" });
+    render(<CommentsPanel filePath="" />);
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("Save calls addComment with { kind: 'file' } anchor", async () => {
+    render(<CommentsPanel filePath={FILE} />);
+    openFileLevelComposer();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "high-level note" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(mockAddComment).toHaveBeenCalledWith(FILE, "high-level note", { kind: "file" });
+    // Iter 3 (#280) AC6 — handler is async; let the resolved IPC settle so
+    // the post-success setState (close input) flushes before the next test.
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+    );
+  });
+
+  it("Save closes the inline input on successful save", async () => {
+    render(<CommentsPanel filePath={FILE} />);
+    openFileLevelComposer();
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    // Iter 3 (#280) AC6 — handler is async; the input closes only after the
+    // awaited addComment resolves.
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+    );
+  });
+
+  it("Cancel hides the inline input without saving", () => {
+    render(<CommentsPanel filePath={FILE} />);
+    openFileLevelComposer();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(mockAddComment).not.toHaveBeenCalled();
+  });
+
   // ── Failure surface: AC6 (iter 3 / #280) ──────────────────────────────────
   // For non-typed errors (the common addComment failure path), the panel now
   // RETHROWS so CommentInput's local `.comment-input-error` banner surfaces
@@ -526,7 +538,7 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
   it("non-typed addComment rejection surfaces inside CommentInput (composer stays open)", async () => {
     mockAddComment.mockRejectedValueOnce(new Error("network down"));
     render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "binary note" } });
     fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
 
@@ -542,7 +554,7 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
   it("does not show an error banner on a successful save", async () => {
     mockAddComment.mockResolvedValueOnce(undefined);
     render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "ok" } });
     fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
 
@@ -569,7 +581,7 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
     mockAddComment.mockRejectedValueOnce({ kind: "outside-workspace", path: FILE });
 
     render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "note" } });
     fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
 
@@ -592,7 +604,7 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
     mockAddComment.mockRejectedValueOnce({ kind: "outside-workspace", path: FILE });
 
     render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "important note" } });
     // Verify draft was persisted before save.
     const draftEntry = Object.entries(localStorage).find(([, v]) => v === "important note");
@@ -608,7 +620,7 @@ describe("CommentsPanel — file-level comment entry (iter 5 group B)", () => {
   });
 });
 
-// ─── Iter 6 Group A C5 — file-level "+" composer draftKey persistence ───────
+// ─── Iter 6 Group A C5 — file-level composer draftKey persistence ──────────
 
 describe("CommentsPanel — file-level draft persistence (iter 6 C5)", () => {
   beforeEach(() => {
@@ -617,7 +629,7 @@ describe("CommentsPanel — file-level draft persistence (iter 6 C5)", () => {
 
   it("persists draft to localStorage on type and clears on Save", async () => {
     const { unmount } = render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "WIP draft" } });
 
     // Some key in localStorage now contains the draft text.
@@ -636,7 +648,7 @@ describe("CommentsPanel — file-level draft persistence (iter 6 C5)", () => {
 
   it("clears draft on Cancel", () => {
     render(<CommentsPanel filePath={FILE} />);
-    fireEvent.click(screen.getByRole("button", { name: /comment on file/i }));
+    openFileLevelComposer();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "to discard" } });
     expect(Object.entries(localStorage).find(([, v]) => v === "to discard")).toBeDefined();
 

--- a/src/components/viewers/__tests__/MermaidCanvas.test.tsx
+++ b/src/components/viewers/__tests__/MermaidCanvas.test.tsx
@@ -32,9 +32,11 @@ let originalGetBBox: PropertyDescriptor | undefined;
 let originalClientWidth: PropertyDescriptor | undefined;
 let originalClientHeight: PropertyDescriptor | undefined;
 let originalGetBoundingClientRect: PropertyDescriptor | undefined;
+const capturedROCallbacks: ResizeObserverCallback[] = [];
 
 beforeEach(() => {
   cleanup();
+  capturedROCallbacks.length = 0;
 
   // rAF — run synchronously so scheduleApply() flushes before assertions.
   originalRAF = window.requestAnimationFrame;
@@ -46,9 +48,18 @@ beforeEach(() => {
   window.cancelAnimationFrame = function cafNoop(): void {} as typeof window.cancelAnimationFrame;
 
   // ResizeObserver — jsdom omits it. Use a real class (vitest warns when
-  // vi.fn() is invoked with `new`).
+  // vi.fn() is invoked with `new`). Capture the ctor callback per-instance
+  // on the instance itself so individual specs can opt into firing it
+  // (the stale-closure regression test in particular). The ctor signature
+  // must match the spec: `new ResizeObserver(cb)` is what production code
+  // uses.
   originalRO = window.ResizeObserver;
   class StubResizeObserver {
+    public callback: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.callback = cb;
+      capturedROCallbacks.push(cb);
+    }
     observe(): void {}
     unobserve(): void {}
     disconnect(): void {}
@@ -265,6 +276,84 @@ describe("MermaidCanvas — pan re-clamp on zoom change", () => {
     });
     expect(transform.style.transform).toContain("translate(0px, 0px)");
     expect(transform.style.transform).toContain("scale(0.4)");
+  });
+});
+
+describe("MermaidCanvas — resize after zoom (stale-closure regression)", () => {
+  it("ResizeObserver fires after zoom change → applyTransform reads CURRENT zoom, not the mount-time closure", async () => {
+    // BUG: applyTransform used to close over the `zoom` PROP from the
+    // render that defined it. The ResizeObserver callback is registered
+    // in a `useEffect(..., [])` (mount-once), so it captures the FIRST
+    // render's applyTransform. After a zoom change, the RO would
+    // - bake the SVG correctly via applyScaleToSvg(zoomRef.current × fit)
+    //   (zoomRef IS updated by the per-render layout effect)
+    // - but then call the stale applyTransform, which writes a CSS
+    //   transform with effective = INITIAL zoom × fit.
+    // Net visible effect: the wrapper's CSS scale ratio (effective /
+    // committed) became (initialZoom / currentZoom), so a 4x zoom
+    // displayed at ~1x after resize, a 0.5x zoom displayed at ~1x, etc.
+    //
+    // FIX: applyTransform reads `zoomRef.current` instead of `zoom`.
+    // This regression test fires the captured RO callback after a zoom
+    // re-render and asserts the resulting transform's scale ratio is 1
+    // (effective ≡ committed because the RO already baked the SVG at
+    // the new effective).
+    //
+    // Initial render at zoom=1: bbox 2000×1500 in 800×600 container →
+    // fit=0.4, effective=committed=0.4, ratio=1.
+    const { rerender, transform } = await renderCanvas({ zoom: 1 });
+    expect(transform.style.transform).toContain("scale(1)");
+
+    // Re-render at zoom=4. Per-render layout effect updates zoomRef=4
+    // and writes scale(4) (effective=4×0.4=1.6 vs committed=0.4 → ratio=4).
+    await act(async () => {
+      rerender(
+        <MermaidCanvas content="graph TD; A --> B" path={null} zoom={4} setZoom={vi.fn()} />,
+      );
+    });
+    expect(transform.style.transform).toContain("scale(4)");
+
+    // Now simulate a window resize. The container size in jsdom is
+    // pinned to 800×600 by the prototype shim, so the RO callback re-
+    // computes fit at the SAME 0.4 — what matters for this regression
+    // is the call sequence (RO → applyScaleToSvg → applyTransform), not
+    // a numeric fit change. After: applyScaleToSvg bakes at 4×0.4=1.6
+    // (committedScaleRef=1.6); applyTransform must read zoomRef=4 and
+    // emit ratio=1, NOT ratio=0.25 (the buggy pre-fix value where
+    // applyTransform read the mount-time zoom=1 and computed
+    // 1×0.4 / 1.6 = 0.25).
+    expect(capturedROCallbacks.length).toBeGreaterThan(0);
+    const fire = capturedROCallbacks[capturedROCallbacks.length - 1];
+    await act(async () => {
+      // Cast to any-ish ResizeObserverEntry[] — the production callback
+      // never reads its args (it queries `c.clientWidth`/`clientHeight`
+      // imperatively), so an empty entry list is fine.
+      fire([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    });
+    expect(transform.style.transform).toContain("scale(1)");
+    // Sanity: still translated to (0,0) — the re-clamp shouldn't have
+    // moved pan because we didn't pan.
+    expect(transform.style.transform).toContain("translate(0px, 0px)");
+  });
+
+  it("zoom=0.5 → resize must NOT visually 'reset to 100%' (pre-fix symptom)", async () => {
+    // Pre-fix: at zoom=0.5 the RO baked SVG at 0.5×0.4=0.2 (committed=0.2)
+    // then the stale applyTransform wrote ratio = (1×0.4)/0.2 = 2 — a 2x
+    // CSS upscale that visually rendered the diagram at fit (~100%
+    // effective), exactly the user-reported symptom. Post-fix the ratio
+    // is (0.5×0.4)/0.2 = 1.
+    const { rerender, transform } = await renderCanvas({ zoom: 1 });
+    await act(async () => {
+      rerender(
+        <MermaidCanvas content="graph TD; A --> B" path={null} zoom={0.5} setZoom={vi.fn()} />,
+      );
+    });
+    expect(transform.style.transform).toContain("scale(0.5)");
+    const fire = capturedROCallbacks[capturedROCallbacks.length - 1];
+    await act(async () => {
+      fire([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    });
+    expect(transform.style.transform).toContain("scale(1)");
   });
 });
 

--- a/src/components/viewers/__tests__/MermaidPopout.test.tsx
+++ b/src/components/viewers/__tests__/MermaidPopout.test.tsx
@@ -122,10 +122,11 @@ describe("MermaidPopout — visibility gating", () => {
     );
     expect(overlay).not.toBeNull();
     expect(overlay?.classList.contains("mermaid-popout-overlay")).toBe(true);
-    // aria-modal=false reflects reality: no focus trap, no backdrop dim.
+    // aria-modal=false reflects reality: no focus trap. The overlay paints
+    // a backdrop dim for visual separation, but focus is not trapped.
     expect(overlay?.getAttribute("aria-modal")).toBe("false");
     // Inner card is the visible chrome (theme background, border, shadow);
-    // overlay is just a transparent click interceptor.
+    // overlay is the dimmed click interceptor matching About / Settings.
     const card = container.querySelector(".mermaid-popout-card");
     expect(card).not.toBeNull();
     expect(overlay?.contains(card)).toBe(true);

--- a/src/components/viewers/mermaid/MermaidCanvas.tsx
+++ b/src/components/viewers/mermaid/MermaidCanvas.tsx
@@ -119,11 +119,17 @@ export function MermaidCanvas({ content, path, zoom, setZoom, readOnly }: Props)
   /** Imperative transform writer. The wrapper owns translate (pan) AND a
    *  scale ratio (`effective / committed`) that bridges the gap between
    *  the user's current effective scale and the most recently baked SVG
-   *  size. After settle, ratio = 1 and the transform is translate-only. */
+   *  size. After settle, ratio = 1 and the transform is translate-only.
+   *
+   *  Reads `zoomRef.current` (not the `zoom` prop) so the function
+   *  remains correct when invoked from a closure captured at mount —
+   *  e.g. the ResizeObserver callback in the `[]`-deps useEffect below
+   *  closes over the first render's `applyTransform`. Routing through
+   *  the per-render-updated ref defeats that stale-closure trap. */
   const applyTransform = () => {
     const el = transformRef.current;
     if (!el) return;
-    const effective = zoom * fitScaleRef.current;
+    const effective = zoomRef.current * fitScaleRef.current;
     const committed = committedScaleRef.current || 1;
     const ratio = effective / committed;
     el.style.transform = `translate(${panRef.current.x}px, ${panRef.current.y}px) scale(${ratio})`;

--- a/src/components/viewers/mermaid/MermaidPopout.tsx
+++ b/src/components/viewers/mermaid/MermaidPopout.tsx
@@ -13,7 +13,7 @@ import "@/styles/mermaid-popout.css";
  * mermaid diagram in a maximised, interaction-rich surface (issue #276).
  *
  * DOM structure:
- *   <div class="mermaid-popout-overlay">     ← transparent full-bleed
+ *   <div class="mermaid-popout-overlay">     ← dimmed full-bleed
  *                                              click interceptor (so gap
  *                                              clicks don't fall through
  *                                              to the underlying viewer)
@@ -40,8 +40,10 @@ import "@/styles/mermaid-popout.css";
  * zoom is shared, and the "Fit" button is a `bumpZoom(".mmd", "reset")`
  * call (reset = ZOOM_DEFAULT = 1.0).
  *
- * `aria-modal="false"` reflects reality: there's no focus trap and no
- * backdrop dim. The dialog is dismissable via Esc + the close button.
+ * `aria-modal="false"` reflects reality: there's no focus trap. The
+ * overlay paints a backdrop dim (matching About / Settings) for visual
+ * separation, but the dialog is dismissable via Esc + the close button
+ * and focus is not trapped.
  */
 export function MermaidPopout() {
   const openFor = useStore((s) => s.mermaidPopoutOpenFor);

--- a/src/styles/mermaid-popout.css
+++ b/src/styles/mermaid-popout.css
@@ -7,18 +7,20 @@
  * absolute positioning here.
  *
  * DOM:
- *   .mermaid-popout-overlay  ← transparent full-bleed click interceptor
+ *   .mermaid-popout-overlay  ← dimmed full-bleed click interceptor
  *     .mermaid-popout-card   ← visible card (border + shadow + theme bg)
  *
- * The overlay is transparent and full-bleed only so pointer events in
- * the gap between the card and the main-area edges are intercepted
- * (and not routed to the underlying viewer). Visual chrome lives on
- * the inner `.mermaid-popout-card`.
+ * The overlay dims the viewer area beneath the popout (matching the
+ * About / Settings dialog backdrop at rgba(0, 0, 0, 0.5)) and intercepts
+ * pointer events in the gap between the card and the main-area edges
+ * (so gap clicks don't fall through to the underlying viewer). Visual
+ * chrome lives on the inner `.mermaid-popout-card`.
  */
 .mermaid-popout-overlay {
   position: absolute;
   inset: 0;
   z-index: 10;
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .mermaid-popout-card {

--- a/src/styles/welcome-view.css
+++ b/src/styles/welcome-view.css
@@ -4,6 +4,7 @@
   justify-content: center;
   flex: 1;
   padding: 40px;
+  position: relative;
 }
 
 .welcome-content {
@@ -162,7 +163,9 @@
 }
 
 .welcome-settings-link {
-  margin-top: 1.5rem;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
   background: none;
   border: none;
   color: var(--color-muted);


### PR DESCRIPTION
Bundle of small UX fixes accumulated during a single session.

## Changes

### 1. Mermaid popout backdrop dim
The popout overlay now paints `rgba(0, 0, 0, 0.5)` (matching About / Settings dialogs) instead of being fully transparent. The popout still mounts inside `.main-area` so the toolbar/tabs/status bar stay visible above and below; only the viewer area dims.

### 2. Mermaid resize stale-closure bug fix
**Root cause**: `MermaidCanvas`'s `applyTransform` closed over the `zoom` prop from each render, but the `ResizeObserver` callback was registered in `useEffect(..., [])` (mount-once) so it captured the **first render's** `applyTransform` — which always saw `zoom = 1.0`. After any zoom change, the RO baked the SVG correctly via `applyScaleToSvg(zoomRef.current × fit)` but then called the stale `applyTransform`, which wrote `transform: scale(1.0 × fit / committed)`. Net: the wrapper's CSS scale collapsed to `1.0 / currentZoom`, visually rendering every non-100% zoom as ~100% after a resize.

Symptoms (matched user report):
- zoom 400% + resize → diagram visually rendered at ~100%
- zoom 50% + resize → diagram visually rendered at ~100%
- zoom 100% + resize → unaffected (1.0/1.0 cancels)
- manually nudging zoom after resize → looks correct (re-render rebuilds the closure)

**Fix**: `applyTransform` now reads `zoomRef.current` instead of the closed-over `zoom` prop. The per-render layout effect already keeps `zoomRef` synchronized.

Two regression tests capture the `StubResizeObserver` instances, fire them after a zoom re-render, and pin the resulting wrapper scale. Pre-fix they produce `scale(0.25)` at zoom=4 and `scale(2)` at zoom=0.5; post-fix both produce `scale(1)`.

### 3. Windows: removed "Bring All to Front" from the Window menu
"Bring All to Front" is a macOS-only Apple HIG affordance; on Windows the equivalent is the taskbar group thumbnail. The menu item is now built only on macOS. The Rust `on_menu_event` handler stays — macOS still uses it.

### 4. Windows: dropped the `Ctrl+,` accelerator from "Settings…"
macOS keeps `Cmd+,` per HIG (rule `mac-menu-settings-placement`); on Windows we no longer reserve a global shortcut for Settings. Single-line cfg-split.

### 5. Welcome page: Settings link moved to bottom-right
The "Set up CLI, file associations, and agent integration → Settings" link previously sat below the centered Open File / Open Folder actions, crowding the focal area. It now anchors at the bottom-right corner of the welcome surface. The button name (and accessibility name) is unchanged.

### 6. Removed redundant "+" button in CommentsPanel header
The toolbar's "Comment on file" button (across markdown, source, CSV, JSON, mermaid, HTML, image, binary viewers) already opens the file-level composer via `requestFileLevelInput()` → `pendingFileLevelInputFor` store flag → CommentsPanel auto-open effect. Two affordances for the same action was unnecessary. The composer flow (state, render guard, error banner, draft persistence) is unchanged.

### 7. Hide Comments toolbar button when no file is open
With no active tab, the button has nothing to act on — the comments pane only renders when `activeTabPath` is set anyway, so showing it on the welcome screen was visual noise. The `Ctrl+Shift+C` shortcut still toggles the pane regardless; the button reappears as soon as a file is opened.

## Tests
- `MermaidCanvas.test.tsx` (15 tests, +2 regression specs)
- `MermaidPopout.test.tsx` (7 tests)
- `MermaidView.test.tsx` (4 tests)
- `WelcomeView.test.tsx` (×2 files, 9 tests)
- `CommentsPanel.test.tsx` (30 tests, button-existence specs replaced with store-driven flow specs + "no input when filePath empty" guard)
- `App.test.tsx` (28 tests, toolbar test split into hidden / shown variants)
- Rust: `menu_test`, `parse_menu_id_exhaustiveness_test`, `forbid_app_webview_windows_iteration_test` all green

`npm run lint:typed` reports 0 errors.

## Commits
- `0612bc3` UX polish (backdrop, Bring-All, Ctrl+,, Welcome link)
- `bfd5aee` mermaid resize stale-closure fix + regression tests
- `819090f` remove "+" in CommentsPanel; hide Comments toolbar when no file
