### PR TITLE
fix: folder pane drag handle now actually resizes the pane

### DIFF
--- a/e2e/browser/folder-pane-resize.spec.ts
+++ b/e2e/browser/folder-pane-resize.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Browser E2E — folder-pane drag handle must actually resize the
+ * visible folder pane.
+ *
+ * Regression for the bug filed on 2026-05-02: dragging the handle
+ * updated `--folder-pane-width` but the wrapper had only `max-width`
+ * (no `width`/`flex-basis`), so the wrapper stayed sized to its
+ * content. The slider could only narrow the pane below the natural
+ * content width — never widen it past that.
+ *
+ * The fix lives in `src/styles/folder-tree.css` (`width: var(...)` +
+ * `flex-shrink: 0` on `.folder-pane-wrapper`) and
+ * `src/components/FolderPaneShell.tsx` (`is-dragging` class to
+ * suppress the width transition during a live drag).
+ *
+ * This spec asserts the user-visible geometry: the pane's bounding
+ * box must grow when the user drags right and shrink when the user
+ * drags left.
+ */
+
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+const FIXTURES_DIR = "/e2e/fixtures";
+const SEEDED_WIDTH = 240;
+
+async function setupMocks(page: Page): Promise<void> {
+  await page.addInitScript(({ dir, seededWidth }: { dir: string; seededWidth: number }) => {
+    window.__TAURI_IPC_MOCK__ = async (cmd: string) => {
+      if (cmd === "get_launch_args") return { files: [], folders: [dir] };
+      if (cmd === "read_dir")
+        return [
+          { name: "a.md", path: `${dir}/a.md`, is_dir: false },
+          { name: "b.md", path: `${dir}/b.md`, is_dir: false },
+        ];
+      if (cmd === "read_text_file") return "# Doc";
+      if (cmd === "load_review_comments") return null;
+      if (cmd === "check_path_exists") return "file";
+      if (cmd === "get_log_path") return "/mock/log.log";
+      if (cmd === "get_file_comments") return { threads: [], sidecar_mtime_ms: null };
+      if (cmd === "get_file_badges") return {};
+      return null;
+    };
+    // Seed a known starting width so deltas are deterministic.
+    try {
+      localStorage.setItem(
+        "mdownreview-ui",
+        JSON.stringify({
+          state: { folderPaneWidth: seededWidth, commentsPaneVisible: false },
+          version: 1,
+        }),
+      );
+    } catch {
+      // best effort
+    }
+  }, { dir: FIXTURES_DIR, seededWidth: SEEDED_WIDTH });
+}
+
+/**
+ * Wait until the wrapper's visible bounding box matches the seeded
+ * `folderPaneWidth` to within 1 px. The wrapper has a 0.2 s `width`
+ * transition (folder-tree.css) that runs on open/close. After the
+ * workspace auto-opens on page load the wrapper animates from 0 →
+ * --folder-pane-width; measuring during the transition returns
+ * intermediate values and produces flaky deltas.
+ */
+async function waitForFolderPaneAtRest(page: Page, targetWidth: number): Promise<void> {
+  await expect.poll(
+    async () =>
+      page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>(".folder-pane-wrapper");
+        return el ? el.getBoundingClientRect().width : 0;
+      }),
+    { timeout: 2000, intervals: [50, 100, 200] },
+  ).toBeCloseTo(targetWidth, 0);
+}
+
+async function readFolderPaneWidth(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>(".folder-pane-wrapper");
+    if (!el) return NaN;
+    return parseFloat(getComputedStyle(el).getPropertyValue("--folder-pane-width"));
+  });
+}
+
+async function dragHandle(page: Page, deltaX: number): Promise<void> {
+  const handle = page.locator(".folder-pane-wrapper .drag-handle");
+  const box = await handle.boundingBox();
+  if (!box) throw new Error("drag-handle has no bounding box");
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+
+  // Use Playwright's high-level mouse API. The drag handler in
+  // FolderPaneShell.tsx listens on `window` for mousemove/mouseup and
+  // captures `e.clientX` at mousedown time, so all three events must
+  // share a real synthesised mouse position. `page.mouse.{down,move,up}`
+  // walks a real cursor through the chromium input pipeline, which is
+  // what the React synthetic-event layer expects.
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Multiple intermediate moves so the handler sees several store
+  // updates (mirrors a real user drag).
+  const steps = 8;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(startX + (deltaX * i) / steps, startY);
+  }
+  await page.mouse.up();
+}
+
+test.describe("Folder pane resize (regression for 2026-05-02 bug)", () => {
+  test("dragging the handle right widens the visible folder pane", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setupMocks(page);
+    await page.goto("/");
+    const wrapper = page.locator(".folder-pane-wrapper");
+    await expect(wrapper).toBeVisible();
+    await expect(page.locator(".folder-tree").getByText("a.md")).toBeVisible();
+    await waitForFolderPaneAtRest(page, SEEDED_WIDTH);
+
+    const before = await wrapper.boundingBox();
+    if (!before) throw new Error("wrapper has no bounding box");
+    const widthBefore = await readFolderPaneWidth(page);
+
+    await dragHandle(page, 120);
+
+    const widthAfter = await readFolderPaneWidth(page);
+    const after = await wrapper.boundingBox();
+    if (!after) throw new Error("wrapper has no bounding box after drag");
+
+    // The CSS variable MUST have grown by ~120 px. The pre-fix bug did
+    // not fail this assertion — the variable did update; what failed
+    // was the visible bounding box.
+    expect(widthAfter - widthBefore).toBeGreaterThan(100);
+    expect(widthAfter - widthBefore).toBeLessThan(140);
+
+    // The visible pane width MUST track the variable. The pre-fix bug
+    // returned `after.width ≈ before.width` because the wrapper was
+    // pinned to its content width, not the slider value.
+    const visibleDelta = after.width - before.width;
+    const variableDelta = widthAfter - widthBefore;
+    expect(Math.abs(visibleDelta - variableDelta)).toBeLessThan(2);
+  });
+
+  test("dragging the handle left narrows the visible folder pane", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setupMocks(page);
+    await page.goto("/");
+    const wrapper = page.locator(".folder-pane-wrapper");
+    await expect(wrapper).toBeVisible();
+    await expect(page.locator(".folder-tree").getByText("a.md")).toBeVisible();
+    await waitForFolderPaneAtRest(page, SEEDED_WIDTH);
+
+    const before = await wrapper.boundingBox();
+    if (!before) throw new Error("wrapper has no bounding box");
+    const widthBefore = await readFolderPaneWidth(page);
+
+    await dragHandle(page, -60);
+
+    const widthAfter = await readFolderPaneWidth(page);
+    const after = await wrapper.boundingBox();
+    if (!after) throw new Error("wrapper has no bounding box after drag");
+
+    // Variable went down by ~60 px. The drag handler clamps at 160 px
+    // minimum; seed 240 − 60 = 180, safely above the clamp.
+    expect(widthBefore - widthAfter).toBeGreaterThan(40);
+    expect(widthBefore - widthAfter).toBeLessThan(80);
+
+    // Visible pane tracks the variable.
+    const visibleDelta = before.width - after.width;
+    const variableDelta = widthBefore - widthAfter;
+    expect(Math.abs(visibleDelta - variableDelta)).toBeLessThan(2);
+  });
+
+  test("during an active drag the wrapper carries the `is-dragging` class so the width transition is suppressed", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setupMocks(page);
+    await page.goto("/");
+    const wrapper = page.locator(".folder-pane-wrapper");
+    await expect(wrapper).toBeVisible();
+    await waitForFolderPaneAtRest(page, SEEDED_WIDTH);
+
+    const handle = page.locator(".folder-pane-wrapper .drag-handle");
+    const box = await handle.boundingBox();
+    if (!box) throw new Error("drag-handle has no bounding box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+
+    // Mid-drag: the wrapper should now carry `is-dragging`.
+    await expect(wrapper).toHaveClass(/\bis-dragging\b/);
+
+    // The CSS transition for `width` should be suppressed during drag.
+    const transitionDuringDrag = await wrapper.evaluate(
+      (el) => getComputedStyle(el).transitionDuration,
+    );
+    // `transition: none` resolves to "0s" for every property.
+    expect(transitionDuringDrag).toMatch(/^0s($|,)/);
+
+    await page.mouse.up();
+
+    // After mouseup the class is gone and the open/close transition
+    // is back in effect.
+    await expect(wrapper).not.toHaveClass(/\bis-dragging\b/);
+  });
+});

--- a/src/components/FolderPaneShell.tsx
+++ b/src/components/FolderPaneShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { useRenderCount } from "@/hooks/dev/useRenderCount";
 import { useStore } from "@/store";
@@ -28,17 +28,24 @@ interface Props {
  * the FolderTree subtree (passed via `children`) re-uses the same
  * element identity from App and bails out via React's children
  * referential-equality optimisation.
+ *
+ * While a drag is in progress, the `is-dragging` class disables the
+ * wrapper's `width` transition so the pane tracks the cursor exactly.
+ * Without this the 0.2 s ease-out in folder-tree.css runs on every
+ * mousemove tick, making the pane lag behind the pointer.
  */
 export function FolderPaneShell({ children, hideDragHandle }: Props) {
   useRenderCount("FolderPaneShell");
   const folderPaneWidth = useStore((s) => s.folderPaneWidth);
   const setFolderPaneWidth = useStore((s) => s.setFolderPaneWidth);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
 
   const onDragStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       dragRef.current = { startX: e.clientX, startWidth: folderPaneWidth };
+      setIsDragging(true);
       const onMove = (e: MouseEvent) => {
         if (!dragRef.current) return;
         const delta = e.clientX - dragRef.current.startX;
@@ -50,6 +57,7 @@ export function FolderPaneShell({ children, hideDragHandle }: Props) {
       };
       const onUp = () => {
         dragRef.current = null;
+        setIsDragging(false);
         window.removeEventListener("mousemove", onMove);
         window.removeEventListener("mouseup", onUp);
       };
@@ -59,9 +67,17 @@ export function FolderPaneShell({ children, hideDragHandle }: Props) {
     [folderPaneWidth, setFolderPaneWidth]
   );
 
+  const className = [
+    "folder-pane-wrapper",
+    hideDragHandle ? "folder-pane-hidden" : "",
+    isDragging ? "is-dragging" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <div
-      className={`folder-pane-wrapper${hideDragHandle ? " folder-pane-hidden" : ""}`}
+      className={className}
       style={{ "--folder-pane-width": `${folderPaneWidth}px` } as React.CSSProperties}
     >
       {children}

--- a/src/components/__tests__/FolderPaneShell.test.tsx
+++ b/src/components/__tests__/FolderPaneShell.test.tsx
@@ -1,4 +1,6 @@
 import { render, fireEvent } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 
 import { FolderPaneShell } from "../FolderPaneShell";
@@ -51,5 +53,50 @@ describe("FolderPaneShell — RC1/P2.4 drag isolation", () => {
     );
     expect(container.querySelector(".drag-handle")).toBeNull();
     expect(container.querySelector(".folder-pane-hidden")).toBeTruthy();
+  });
+
+  it("regression: wrapper sizing rule uses `width` not `max-width` so the pane can grow past content width", () => {
+    // Why this assertion is structural, not visual:
+    // jsdom does not run a real layout engine, so `getBoundingClientRect`
+    // returns 0×0 for everything. We instead assert against the loaded
+    // CSS rule itself — the bug was that `.folder-pane-wrapper` had only
+    // `max-width: var(--folder-pane-width)` and no `width`, so dragging
+    // the handle right could not widen the pane past its content.
+    // The visual / pointer-driven layout regression is covered by
+    // e2e/browser/folder-pane-resize.spec.ts.
+    const cssPath = resolve(__dirname, "../../styles/folder-tree.css");
+    const css = readFileSync(cssPath, "utf-8");
+    // `width: var(--folder-pane-width …)` MUST exist on
+    // `.folder-pane-wrapper` so the wrapper takes the slider value as
+    // its actual size, not just an upper cap.
+    expect(css).toMatch(
+      /\.folder-pane-wrapper\s*\{[^}]*\bwidth:\s*var\(--folder-pane-width/
+    );
+    // `flex-shrink: 0` MUST be present so the flex parent (.main-area)
+    // does not shrink the wrapper back below the slider value when the
+    // viewer area is wider than its remaining space.
+    expect(css).toMatch(/\.folder-pane-wrapper\s*\{[^}]*\bflex-shrink:\s*0/);
+  });
+
+  it("regression: an active drag toggles the `is-dragging` class so the width transition is suppressed", () => {
+    const { container } = render(
+      <FolderPaneShell hideDragHandle={false}>
+        <div />
+      </FolderPaneShell>
+    );
+    const wrapper = container.querySelector(".folder-pane-wrapper") as HTMLElement;
+    const handle = container.querySelector(".drag-handle") as HTMLElement;
+
+    expect(wrapper.classList.contains("is-dragging")).toBe(false);
+
+    fireEvent.mouseDown(handle, { clientX: 200 });
+    // After mousedown the shell rerendered with isDragging=true.
+    expect(wrapper.classList.contains("is-dragging")).toBe(true);
+
+    fireEvent.mouseMove(window, { clientX: 250 });
+    expect(wrapper.classList.contains("is-dragging")).toBe(true);
+
+    fireEvent.mouseUp(window);
+    expect(wrapper.classList.contains("is-dragging")).toBe(false);
   });
 });

--- a/src/styles/folder-tree.css
+++ b/src/styles/folder-tree.css
@@ -1,4 +1,11 @@
 .folder-tree {
+  /* Fill the wrapper. Without `flex: 1` the tree is content-sized and
+     leaves a gap before .drag-handle when the wrapper is wider than the
+     content (the visible drag handle would float at the content edge,
+     not at the right of the visible pane). `min-width: 0` lets it
+     shrink below content width when the user drags the pane narrower. */
+  flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -218,17 +225,40 @@
   flex: 0 0 auto;
 }
 
-/* Slide transition for folder pane */
+/* Slide transition for folder pane.
+ *
+ * Sizing uses `width` (not `max-width`) so the wrapper actually grows
+ * when --folder-pane-width grows. `max-width` alone leaves the wrapper
+ * content-sized — the user could drag the handle right but the visible
+ * pane never widened past the longest tree row.
+ *
+ * `flex-shrink: 0` keeps the wrapper at exactly --folder-pane-width
+ * inside the flex .main-area (otherwise flex would shrink it back when
+ * the viewer area cannot fit). The drag handler in
+ * src/components/FolderPaneShell.tsx clamps the value to
+ * `window.innerWidth * 0.5`, so the wrapper cannot starve the viewer.
+ *
+ * The transition runs on open/close (when the .folder-pane-hidden
+ * class toggles). During an active resize drag, FolderPaneShell adds
+ * the `is-dragging` class so the wrapper tracks the cursor without
+ * easing — every mousemove sets a new --folder-pane-width and a 0.2 s
+ * transition would lag behind the pointer.
+ */
 .folder-pane-wrapper {
   display: flex;
   overflow: hidden;
-  transition: max-width 0.2s ease-out, opacity 0.2s ease-out;
-  max-width: var(--folder-pane-width, 240px);
+  transition: width 0.2s ease-out, opacity 0.2s ease-out;
+  width: var(--folder-pane-width, 240px);
+  flex-shrink: 0;
   opacity: 1;
 }
 
+.folder-pane-wrapper.is-dragging {
+  transition: none;
+}
+
 .folder-pane-wrapper.folder-pane-hidden {
-  max-width: 0;
+  width: 0;
   opacity: 0;
 }
 


### PR DESCRIPTION
## Bug
Dragging the folder-pane drag handle right did **nothing visible**  the slider value updated and the CSS variable updated, but the visible pane stayed pinned to its content's natural width. Dragging left only shrank the pane once the slider value dropped below content width.

## Root cause
`.folder-pane-wrapper` had only `max-width: var(--folder-pane-width)` with no `width`/`flex-basis`, so the wrapper sized to its content (capped at the slider). `max-width` cannot make a flex item grow past its content  it can only clamp it down.

## Fix
**`src/styles/folder-tree.css`**
- `.folder-pane-wrapper`: switch `max-width` -> `width: var(--folder-pane-width, 240px)` + `flex-shrink: 0` so the wrapper takes the slider value as its actual size and the flex parent (`.main-area`) cannot shrink it back.
- `.folder-tree`: add `flex: 1; min-width: 0` so the tree fills the wrapper (otherwise the drag handle would float at the content edge with empty space behind it).
- New `.folder-pane-wrapper.is-dragging { transition: none }` rule.

**`src/components/FolderPaneShell.tsx`**
- Track `isDragging` state, toggle `is-dragging` class on the wrapper. Without this, the new `width` transition (0.2s ease-out) would run on every mousemove tick and the pane would lag behind the cursor.

## Regression coverage (TDD)
**Unit (`FolderPaneShell.test.tsx`)**  2 new tests:
- CSS contract: `.folder-pane-wrapper` rule contains `width: var(--folder-pane-width)` + `flex-shrink: 0`.
- Class lifecycle: `is-dragging` toggled around mousedown / mouseup.

**Browser E2E (`e2e/browser/folder-pane-resize.spec.ts`)**  3 new tests:
- Drag right widens the visible bounding box by ~drag-delta.
- Drag left narrows the visible bounding box by ~drag-delta.
- Mid-drag the wrapper carries `is-dragging` and computed `transition-duration: 0s`.

All five tests **fail on the pre-fix code** and pass on the fix (verified locally by stashing the fix and re-running the suite).

## Verified locally
- `npm run lint` clean (0 errors).
- `npx vitest run src/components/__tests__/FolderPaneShell.test.tsx`  4 passed.
- `npx playwright test --config=playwright.browser.config.ts e2e/browser/folder-pane-resize.spec.ts`  3 passed.
- 14 adjacent panel/overflow specs pass unchanged.
- Tauri dev build launches and runs cleanly.

## Out of scope
- `#315` rehydrate clamp (oversized persisted `folderPaneWidth` on smaller monitors)  separate FIXME spec already exists.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
