### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
-## Unreleased
+## v0.4.3 — 2026-05-03
 
 ### Features
 - **Excalidraw integration** — 3-mode viewer (Source / Visual / Editor) for `.excalidraw`, `.excalidrawlib`, `.excalidraw.png`, `.excalidraw.svg`. Editor mode autosaves edits on a 2-second debounce through a single Rust workspace-write chokepoint (`commands/fs_write.rs::write_workspace_text` / `write_workspace_binary`) gated by extension allowlist, payload size cap, NTFS-ADS reject, parent canonicalisation, and atomic commit. The first round-trip-edit feature in the app — historically a Non-Goal, now scoped via principles.md carve-out (#352). New IPC: `write_workspace_text`, `write_workspace_binary`, `claim_open_file`, `release_open_file`, `release_open_files`, `focus_window`, close-flush handshake. New `<PersistentExcalidrawHost>` keeps Excalidraw instances alive across tab switches (preserves undo, library, viewport pan/zoom). Multi-window same-file singleton: a canonical path is open in at most one window at a time; opening it elsewhere raises the existing window. (#353)
+- **Improved handling for large files** — bounded reads, viewer placeholder, and progressive fallback so multi-MB files no longer freeze the renderer. (#354)
+- **Simplified comment system** — consolidated anchor model and IPC surface; renderer-side legacy adapters removed in favour of typed Rust `Anchor` discriminated union. (#344)
 
 ### Fixes
 - Cmd+S "Saved" pill no longer flashes when auto-save was paused, skipped, or otherwise short-circuited — gated on a real successful write. (#352 ship-readiness review B1)
 - Conflict-banner Reload no longer leaves the user's pre-Reload draft on disk under self-write suppression: in-flight saves are voided (post-success bookkeeping skipped) so the freshly-loaded external version is not silently absorbed. (#352 ship-readiness review B2)
 - "Keep my edits (overwrite disk)" flushes immediately so the user's intent persists at click time, not deferred until the next onChange. (#352 ship-readiness review B3)
 - Auto-save snapshot hash is gated by a cheap reference-identity pre-filter so `JSON.stringify` no longer runs on every Excalidraw `onChange` tick (was 60 Hz during freehand drag). (#352 ship-readiness review B4 — perf regression introduced in iter-14)
+- Comment selection matching now strips block-marker characters from the rendered-text projection so cross-block / soft-wrap selections re-anchor correctly. (#360)
+- Folder pane drag handle now actually resizes the pane (suppresses the parent's width transition during drag and pins the wrapper width via CSS variable). (#358)
+- Minor UX polish bundle — Mermaid backdrop + resize bug, Window menu, Welcome link, Comments panel. (#351)
 
 ### UX
 - Combined first-Editor-entry banner replaces the previous two-banner stack (autosave-info + MRSF warning); dejargonized copy ("comments pinned to specific lines may move to the whole file"). (#352 ship-readiness review P0-2 + P0-3)
@@ -15,6 +20,10 @@
 
 ### Security
 - Vendored Excalidraw `data/` no longer copies orphaned ES module shims with broken imports — filtered to non-JS assets only. (#352 ship-readiness review S1)
+
+### Other
+- Split `src-tauri/src/commands/fs.rs` into sibling module (rule 23 file-size budget). (#356)
+- Add canonical + image-embed Excalidraw sample fixtures. (#357)
 
 ## v0.4.2 — 2026-05-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdownreview",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdownreview",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@excalidraw/excalidraw": "0.18.1",
         "@shikijs/rehype": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdownreview",
   "private": true,
   "description": "Review AI Agent's work",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2677,11 +2677,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "mdownreview"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4657,9 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4676,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4777,9 +4777,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5226,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -5244,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
@@ -5262,7 +5262,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -5290,9 +5290,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-opener"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
 dependencies = [
  "dunce",
  "glob",
@@ -5322,9 +5322,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
 dependencies = [
  "serde",
  "serde_json",
@@ -7505,9 +7505,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.1"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
@@ -7519,9 +7519,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.1"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ members = ["mdr-macros"]
 
 [package]
 name = "mdownreview"
-version = "0.4.2"
+version = "0.4.3"
 description = "A desktop markdown reviewer for developers"
 license = "MIT"
 authors = ["davidzh"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mdownreview",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "com.mdownreview.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to v0.4.3. Merge after CI passes; tag will trigger build.

## Highlights
- **Excalidraw integration** (#352/#353)  3-mode viewer + workspace-write chokepoint + multi-window same-file singleton.
- **Improved large-file handling** (#354).
- **Simplified comment system** (#344).
- Selection-matching fix for cross-block / soft-wrap (#360).
- Folder pane drag-handle resize fix (#358).
- UX polish bundle (#351).
- `fs.rs` split per rule 23 budget (#356).

## Local test gate (Windows)
- `npm test`  2296 passed
- `npm run test:e2e`  160 passed
- `npm run test:e2e:native:build`  26 passed (1 transient CDP flake on first run, passed on retry  known multi-window environmental class)

See CHANGELOG.md for full details.