### PR TITLE
fix(release): set GH_REPO on gh-using jobs that lack actions/checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,10 @@ jobs:
       - name: Rename + upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `gh release upload` needs the repo context. This job has no
+          # `actions/checkout` step (we only download artefacts), so `gh`
+          # cannot infer the repo from `git remote`. Set it explicitly.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.resolve-tag.outputs.tag }}
         run: |
           set -e
@@ -189,6 +193,9 @@ jobs:
       - name: Build + upload latest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No `actions/checkout` in this job → set repo context for `gh`
+          # release download / view / upload.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.resolve-tag.outputs.tag }}
         run: |
           set -e
@@ -250,5 +257,7 @@ jobs:
       - name: Undraft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No `actions/checkout` in this job → set repo context for `gh`.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.resolve-tag.outputs.tag }}
         run: gh release edit "$TAG" --draft=false


### PR DESCRIPTION
## Problem

PR #376 rewrote release.yml and removed `actions/checkout@v4` from `upload-assets`, `publish-update-manifest`, and `publish-release` jobs (they only need artefact downloads, not source). It did not compensate with `GH_REPO`, so every `gh release upload/download/view/edit` call fails with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `gh` CLI tries to infer the target repo from `git remote get-url origin` when no explicit context is set. Without a checkout AND without `GH_REPO`, all release uploads break.

## Impact

This took down the v0.4.4 release  see run [25633685945](https://github.com/dryotta/mdownreview/actions/runs/25633685945). The build matrix + release-preflight all passed, but `Upload assets` failed before any installer reached the GitHub Release.

## Fix

Add `GH_REPO: ${{ github.repository }}` to each of the three gh-using jobs' env blocks. `canary.yml` already works because it kept `actions/checkout@v4` on every gh-using job (canary.yml:42, 103, 162)  verified.

This is the minimal idiomatic fix for ephemeral upload jobs that deliberately skip checkout: restore the repo context the `gh` CLI needs without reintroducing the checkout overhead.

## After merge

v0.4.4 needs to be re-released:
1. Delete the existing `v0.4.4` tag (local + remote).
2. Delete the draft GitHub Release at v0.4.4 (if present).
3. Re-tag the new main commit with v0.4.4 and push the tag.
