### PR TITLE
feat(publish-release): rewrite skill as fully autonomous

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: publish-release
-description: Use when shipping a new release of mdownreview — when the user says "release", "tag", "publish", "ship a new version", "bump version", or runs `/publish-release [major|minor|patch]`. Fully autonomous — picks the bump from the arg (default `patch`), validates pre-flight gates, opens a release PR, babysits CI, tags the merged commit, then babysits release.yml — forward-fixing recoverable failures inline. Halts only on uncorrectable conditions (signing failures, dirty tree, divergent main).
+description: Use when the user says "release", "tag", "publish", "ship a new version", "bump version", or runs `/publish-release [major|minor|patch]`. Fully autonomous — never prompts. Default bump: patch.
 ---
 
-**RIGID. Fully autonomous — never calls `ask_user`.** Owns the entire release lifecycle: version bump → CHANGELOG → release PR → tag → signed installers → published GitHub release. Pairs with `ci.yml` (CI build + sign + verify, called via `workflow_call` from `release.yml`).
+**RIGID. Fully autonomous — never calls `ask_user`.** Owns the full release lifecycle: version bump → CHANGELOG → release PR → tag → signed installers → published GitHub release. Pairs with `ci.yml` (called from `release.yml` via `workflow_call`).
 
-The skill assumes a healthy `main`: pre-flight verifies the latest `ci.yml` and `canary.yml` runs on `main` are green and the working tree is clean. **Once those gates pass, every later failure is presumed release-pipeline-specific** (version-bump conflict, lockfile drift, NSIS hook, tauri.conf schema, platform build script) and is handled by inline fix-forward, not by delegating to `/iterate-one-issue`. If a fix would need >50 LoC or unfamiliar code paths, that's a signal of an upstream regression pre-flight should have caught — abort with HALT instead of chasing it.
-
-Forward-fix budgets are bounded:
-- **Pre-tag CI:** flake reruns cap 2/job, inline fixes cap 3.
-- **Post-tag release CI:** flake reruns cap 2, fix-forward re-rolls cap 2 (always bumping patch — never reuse a version).
+Phase 0 verifies `main` is healthy. Once those gates pass, every later failure is presumed release-pipeline-specific and fixed inline — no delegation. Fixes touching >50 LoC or application source under `src/` or `src-tauri/src/core/` signal an upstream regression Phase 0 should have caught → HALT.
 
 ---
 
@@ -22,15 +18,15 @@ Forward-fix budgets are bounded:
 | `minor` | `minor` |
 | `major` | `major` |
 
-Anything else → `exit 1` with message `[publish-release] Unknown arg "<ARG>". Use empty (=patch), patch, minor, or major.`
+Anything else → `exit 1` with `[publish-release] Unknown arg "<ARG>". Use empty (=patch), patch, minor, or major.`
 
-The skill **always follows the literal arg** — it never auto-detects bump class from `feat!:`/`BREAKING CHANGE:` and never overrides the user. Misclassified bump is the user's call.
+The arg is authoritative. No auto-detection from `feat!:` or `BREAKING CHANGE:` — misclassified bump is the user's call.
 
 ---
 
 ## Phase 0 — Pre-flight (read-only, fail-fast)
 
-Each gate is read-only — the skill never auto-stashes, auto-commits, or auto-checks-out. On failure: print exact remediation command and `exit 1`.
+Read-only — never auto-stashes, auto-commits, or auto-checks-out. On failure: print exact remediation and `exit 1`.
 
 ```bash
 git --no-pager fetch origin --tags
@@ -45,7 +41,7 @@ git --no-pager fetch origin --tags
 | Latest canary on main green | `gh run list --workflow=canary.yml --branch=main --limit=1 --json conclusion,headSha,url` → `conclusion == "success"` | `Latest canary.yml on main is <conclusion> at <url> — fix before releasing (signed-build pipeline is broken).` |
 | Updater pubkey present | `jq -e '.plugins.updater.pubkey | length > 0' src-tauri/tauri.conf.json` | `tauri.conf.json plugins.updater.pubkey is empty — releases would be unverifiable.` |
 
-If every gate passes, log `[publish-release] pre-flight green; HEAD=<sha>`.
+On all-green: log `[publish-release] pre-flight green; HEAD=<sha>`.
 
 ---
 
@@ -54,7 +50,7 @@ If every gate passes, log `[publish-release] pre-flight green; HEAD=<sha>`.
 ```bash
 LAST_TAG=$(git --no-pager describe --tags --abbrev=0 2>/dev/null || true)
 if [ -z "$LAST_TAG" ]; then
-  LAST_TAG_RANGE="HEAD"  # first release
+  LAST_TAG_RANGE="HEAD"
   BASELINE_VERSION=$(jq -r .version package.json)
 else
   LAST_TAG_RANGE="$LAST_TAG..HEAD"
@@ -66,7 +62,7 @@ git --no-pager log "$LAST_TAG_RANGE" --no-merges --pretty=format:"%H%x09%s" \
   > /tmp/publish-release.commits.tsv
 ```
 
-If `/tmp/publish-release.commits.tsv` is empty → `exit 0` with `Nothing to release since $LAST_TAG.` (not an error).
+Empty file → `exit 0` with `Nothing to release since $LAST_TAG.` (not an error).
 
 ---
 
@@ -84,19 +80,16 @@ esac
 git tag -l "v$NEW_VERSION" | grep -q . && { echo "tag v$NEW_VERSION already exists"; exit 1; }
 ```
 
-No `ask_user`. The arg is authoritative.
-
 ---
 
 ## Phase 3 — Update version files
 
-Three files, no `v` prefix in any of them:
+Three files, no `v` prefix:
 
 1. `package.json` → `.version`
 2. `src-tauri/Cargo.toml` → `version` under `[package]`
 3. `src-tauri/tauri.conf.json` → `.version`
 
-Then refresh lockfiles:
 ```bash
 npm install --package-lock-only
 cargo generate-lockfile --manifest-path src-tauri/Cargo.toml
@@ -106,18 +99,18 @@ cargo generate-lockfile --manifest-path src-tauri/Cargo.toml
 
 ## Phase 4 — CHANGELOG (deterministic filter)
 
-CHANGELOG generation is **mechanical** — the same input always produces the same output. No subjective "is this user-facing?" judgement.
+Same input always produces the same output. No subjective "is this user-facing?" judgement.
 
 ### Rules
 
 1. Parse each commit subject as `^(?<type>[a-z]+)(\((?<scope>[^)]*)\))?(?<bang>!)?:\s*(?<desc>.+)$`.
-2. **Drop entirely** if `scope` ∈ `{ci, test, build, chore, deps, docs, infra, agents, skill, release}`. (Tell contributors: scope your commit properly to control CHANGELOG visibility.)
-3. Drop if subject starts with `chore: release v` (already filtered in Phase 1, but keep as safety net).
+2. **Drop entirely** if `scope` ∈ `{ci, test, build, chore, deps, docs, infra, agents, skill, release}`.
+3. Drop if subject starts with `chore: release v`.
 4. Bucket the rest by `type`:
    - `feat` → **Features**
    - `fix` or `perf` → **Fixes**
    - everything else → **Other**
-5. Each entry is `- <desc> (<short-sha>)` — short-sha helps reviewers locate the commit.
+5. Each entry is `- <desc> (<short-sha>)`.
 6. Skip empty buckets.
 
 ### Output (prepend to CHANGELOG.md, create if missing)
@@ -167,7 +160,7 @@ PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
 
 ## Phase 6 — Babysit pre-tag CI
 
-CI fires automatically on `pull_request` open. Wait for the run to finish, classify, fix-forward inline, repeat.
+CI fires automatically on `pull_request`. Caps: 2 reruns/job for flakes, 3 inline-fix attempts.
 
 ```bash
 PRETAG_FIX_ATTEMPTS=0
@@ -179,35 +172,29 @@ declare -A PRETAG_RERUN_COUNT
 ### Loop
 
 1. `gh pr checks "$PR_URL" --watch` → blocks until run completes.
-2. If green → `gh pr merge "$PR_URL" --squash --auto` (or `--admin` if branch protection requires it). Proceed to Phase 7.
-3. If failed → fetch failed-job names + logs:
+2. Green → `gh pr merge "$PR_URL" --squash --auto` (or `--admin` if branch protection requires it). Phase 7.
+3. Failed → fetch failed-job names + logs:
    ```bash
    RUN_ID=$(gh run list --branch "release/v$NEW_VERSION" --workflow=ci.yml --limit=1 --json databaseId -q '.[0].databaseId')
    FAILED_JOBS=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion=="failure") | .name')
    ```
-4. Classify (see **Failure Classification** below).
-5. **Flake** → if `${PRETAG_RERUN_COUNT[$job]:-0} < PRETAG_RERUN_BUDGET_PER_JOB`, `gh run rerun "$RUN_ID" --failed`, increment counter, loop to step 1.
-6. **Real failure** → if `PRETAG_FIX_ATTEMPTS < PRETAG_FIX_CAP`, perform inline fix (see below), `git commit --amend --no-edit || git commit -m "fix: ...`", `git push --force-with-lease origin "release/v$NEW_VERSION"`, increment `PRETAG_FIX_ATTEMPTS`, loop to step 1.
-7. **Budget exhausted or unclassified** → HALT (see **HALT** below).
+4. Classify per **Failure Classification**.
+5. Flake → if `${PRETAG_RERUN_COUNT[$job]:-0} < PRETAG_RERUN_BUDGET_PER_JOB`, `gh run rerun "$RUN_ID" --failed`, increment counter, loop to 1.
+6. Real failure → if `PRETAG_FIX_ATTEMPTS < PRETAG_FIX_CAP`, inline fix, `git commit --amend --no-edit || git commit -m "fix: ..."`, `git push --force-with-lease origin "release/v$NEW_VERSION"`, increment, loop to 1.
+7. Budget exhausted or unclassified → HALT.
 
-### Inline fix scope (pre-tag)
-
-Pre-tag failures are by definition release-pipeline-specific (pre-flight already proved `main` + canary green). Expected fixes:
+### Expected inline fixes
 
 - Lockfile drift: re-run `npm install --package-lock-only` / `cargo generate-lockfile`.
 - Bindings drift: regenerate per `src/lib/bindings.ts` header instructions.
-- CHANGELOG syntax error: fix markdown.
+- CHANGELOG markdown syntax error.
 - Version mismatch between the three version files.
-- `tauri.conf.json` schema (rare — would mean a Tauri version bump landed since canary).
+- `tauri.conf.json` schema drift (rare — implies a Tauri version bump landed since canary).
 - Test snapshot referencing the old version string.
-
-If the failed-job log indicates >50 LoC of changes or touches application source under `src/`/`src-tauri/src/core/`, that's a regression pre-flight should have caught — HALT, do not chase.
 
 ---
 
 ## Phase 7 — Tag the merged commit
-
-After Phase 6 squash-merges:
 
 ```bash
 git checkout main
@@ -223,7 +210,7 @@ Tag push triggers `release.yml`.
 
 ## Phase 8 — Babysit post-tag release.yml (fix-forward)
 
-Watch `release.yml` for the new tag. Classify each failure (table below). On **fixable** classes, perform the **fix-forward re-roll** (delete tag/release, bump patch, re-issue the PR). On **HALT** classes, exit non-zero with diagnosis. Always print which class and which class-specific log line caused the decision.
+Caps: 2 reruns/job for flakes, 2 fix-forward re-rolls (always bumping patch).
 
 ```bash
 POSTTAG_REROLL_ATTEMPTS=0
@@ -241,39 +228,38 @@ declare -A POSTTAG_RERUN_COUNT
      --json databaseId,headBranch,status -q '.[] | select(.headBranch=="v'"$NEW_VERSION"'") | .databaseId' | head -1)
    gh run watch "$RELEASE_RUN_ID" --exit-status || true
    ```
-2. Re-fetch the run conclusion. If `success` → Phase 9.
+2. Re-fetch run conclusion. Success → Phase 9.
 3. List failed jobs:
    ```bash
    FAILED_JOBS=$(gh run view "$RELEASE_RUN_ID" --json jobs \
      -q '.jobs[] | select(.conclusion=="failure") | {name: .name, url: .url}')
    ```
 4. Classify per **Failure Classification**.
-5. **Network/transient flake** → rerun within budget, loop to step 1.
-6. **Signing/credential class** → HALT immediately. Tag stays in place; print remediation.
-7. **Fixable build class** → perform **Re-roll** (below) if `POSTTAG_REROLL_ATTEMPTS < POSTTAG_REROLL_CAP`, else HALT.
-8. **Unclassified** → HALT.
+5. Network/transient flake → rerun within budget, loop to 1.
+6. Signing/credential class → HALT immediately. Tag stays in place.
+7. Fixable build class → **Re-roll** if `POSTTAG_REROLL_ATTEMPTS < POSTTAG_REROLL_CAP`, else HALT.
+8. Unclassified → HALT.
 
 ### Re-roll algorithm
 
-Always bumps **patch** from the failed version (never reuses a version):
+Always bumps patch from the failed version — never reuse a version.
 
 ```bash
 gh release delete "v$NEW_VERSION" --cleanup-tag --yes
-# Bump patch from the failed version:
 IFS=. read -r MAJ MIN PAT <<< "$NEW_VERSION"
 PREV_FAILED="$NEW_VERSION"
 NEW_VERSION="${MAJ}.${MIN}.$((PAT+1))"
 git checkout main && git pull --ff-only
 
-# Inline code fix for the build/script issue (touching only src-tauri config,
-# scripts/, NSIS hooks, or a single file under src-tauri/src). >50 LoC → HALT.
-# Examples: NSIS hook syntax error, stage-cli profile detection, tauri.conf
-# bundle target list, missing platform-conditional in build.rs.
+# Inline fix scope: src-tauri config (tauri.conf.json, Cargo.toml),
+# scripts/, NSIS hooks, build.rs, or a single file under src-tauri/src.
+# Examples: NSIS hook syntax, stage-cli profile detection, bundle target
+# list, missing platform-conditional. >50 LoC → HALT.
 
-# Update version files (Phase 3)
-# Prepend CHANGELOG entry under "## v$NEW_VERSION — <date>" with
-#   "### Other" → "- chore(release): supersedes failed v$PREV_FAILED — <one-line cause>"
-#   plus any commits introduced by the inline fix.
+# Phase 3: update version files.
+# Phase 4: prepend CHANGELOG entry under "## v$NEW_VERSION — <date>" with
+#   ### Other
+#   - chore(release): supersedes failed v$PREV_FAILED — <one-line cause>
 
 git checkout -b "release/v$NEW_VERSION"
 git add <fixed files> package.json package-lock.json \
@@ -283,7 +269,7 @@ git commit -m "chore: release v$NEW_VERSION (supersedes v$PREV_FAILED)
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 git push origin "release/v$NEW_VERSION"
-gh pr create ...        # same as Phase 5
+gh pr create ...   # same as Phase 5
 ((POSTTAG_REROLL_ATTEMPTS++))
 # loop back through Phase 6 → 7 → 8 with the new version
 ```
@@ -294,7 +280,7 @@ The supersession line in the CHANGELOG creates an audit trail so consumers seein
 
 ## Phase 9 — Summary
 
-Always print on success **or** on HALT (so the user has an audit trail either way):
+Always print on success and on HALT.
 
 ```
 === publish-release summary ===
@@ -318,17 +304,17 @@ Total wall-clock:      <hh:mm:ss>
 
 ## Failure Classification
 
-Used by Phase 6 (pre-tag) and Phase 8 (post-tag) to route each failed job. Match in order — first row that matches wins.
+Used by Phase 6 (pre-tag) and Phase 8 (post-tag). Match in order — first row wins.
 
 | # | Signal in failed-job log | Class | Pre-tag action | Post-tag action |
 |---|---|---|---|---|
-| 1 | Job timeout / `connect ETIMEDOUT` / `503 Service Unavailable` / GitHub Actions runner provisioning error | **flake** | rerun (cap 2/job) | rerun (cap 2/job) |
-| 2 | Native E2E `WebView2Loader` / browser launch error / single-instance lock | **flake** | rerun (cap 2/job) | n/a (job not in release.yml workflow_call's matrix) |
-| 3 | `error: failed to read … TAURI_SIGNING_PRIVATE_KEY` / `signature verification failed` / `pubkey mismatch` / `endorsement` / cert-related stderr | **signing** | HALT (block PR merge — tag would be unsigned) | HALT (do NOT re-roll — credentials problem, not code) |
-| 4 | rustc/cargo error referencing `src-tauri/Cargo.lock` mismatch | **lockfile-drift** | inline fix: `cargo generate-lockfile --manifest-path src-tauri/Cargo.toml` (cap 3) | re-roll with same fix (cap 2) |
-| 5 | `bindings.ts` mismatch (bindings-drift job) | **bindings-drift** | inline fix per `src/lib/bindings.ts` regeneration command (cap 3) | re-roll with same fix |
-| 6 | CHANGELOG markdown lint / version-string assertion failure in tests | **changelog/version-mismatch** | inline fix (cap 3) | re-roll |
-| 7 | NSIS / `installer-hooks.nsh` syntax error · `signtool` invocation · DMG layout failure · `Verify ad-hoc signing` step · platform-specific `cargo build` errors localized to `src-tauri/src` config or `scripts/` | **fixable-build** | HALT (would mean canary should have caught it; investigate) | re-roll (cap 2) |
+| 1 | Job timeout / `connect ETIMEDOUT` / `503 Service Unavailable` / runner provisioning error | **flake** | rerun (cap 2/job) | rerun (cap 2/job) |
+| 2 | Native E2E `WebView2Loader` / browser launch error / single-instance lock | **flake** | rerun (cap 2/job) | n/a (job not in release.yml workflow_call matrix) |
+| 3 | `error: failed to read … TAURI_SIGNING_PRIVATE_KEY` / `signature verification failed` / `pubkey mismatch` / cert-related stderr | **signing** | HALT | HALT (credentials problem, not code) |
+| 4 | rustc/cargo error referencing `src-tauri/Cargo.lock` mismatch | **lockfile-drift** | inline fix: `cargo generate-lockfile --manifest-path src-tauri/Cargo.toml` | re-roll with same fix |
+| 5 | `bindings.ts` mismatch (bindings-drift job) | **bindings-drift** | inline fix per `src/lib/bindings.ts` regeneration command | re-roll with same fix |
+| 6 | CHANGELOG markdown lint / version-string assertion failure in tests | **changelog/version-mismatch** | inline fix | re-roll |
+| 7 | NSIS / `installer-hooks.nsh` syntax · `signtool` invocation · DMG layout · `Verify ad-hoc signing` step · platform-specific `cargo build` errors localized to `src-tauri/src` config or `scripts/` | **fixable-build** | HALT (canary should have caught it) | re-roll |
 | 8 | Test failure under `src/__tests__/`, `src-tauri/tests/`, `e2e/` referencing application logic | **regression** | HALT (canary lied — fix on main first) | HALT (do not ship a release chasing a regression) |
 | 9 | Anything else | **unclassified** | HALT | HALT |
 
@@ -348,24 +334,20 @@ When budget is exhausted or a non-fixable class is hit:
    First-line:    <first error line from log>
    Remediation:   <class-specific message>
    ```
-2. **Pre-tag HALT** (PR not yet merged):
-   - Leave the branch and PR in place — user inspects, fixes, force-pushes, or runs `/publish-release` again after the upstream issue is resolved.
-   - **Do not** auto-close the PR or auto-delete the branch (preserves debugging context).
-3. **Post-tag HALT**:
-   - Tag and GitHub release stay in place if class ∈ `{signing}` (the tag itself is fine; the build infra is broken — fixing the secret will unblock a re-trigger via `gh workflow run release.yml --ref v$NEW_VERSION`).
-   - Tag is left in place if class ∈ `{regression, unclassified}` (so the user can decide whether to fix-forward to a higher patch or rollback manually).
+2. Pre-tag HALT (PR not yet merged): leave branch and PR in place — preserves debugging context.
+3. Post-tag HALT: tag stays in place. For `signing` class, the tag is fine — fix the secret and re-trigger via `gh workflow run release.yml --ref v$NEW_VERSION`.
 4. Print Phase 9 summary with `HALTED: <class>` in the Release URL row.
 5. `exit 1`.
 
 ---
 
-## Recovery primitives (used by re-roll and HALT)
+## Recovery primitives
 
-- **Delete tag + release:** `gh release delete "v$VERSION" --cleanup-tag --yes`
-- **Delete release branch (if abandoning):** `git push origin --delete "release/v$VERSION"; git checkout main; git branch -D "release/v$VERSION"`
-- **Re-trigger release.yml after secret fix:** `gh workflow run release.yml --ref "v$NEW_VERSION"`
+Documented for human follow-up; the skill does not invoke them during HALT.
 
-The skill does not invoke recovery primitives during a HALT — they're documented here so a human (or a follow-up `/publish-release` invocation) can use them.
+- Delete tag + release: `gh release delete "v$VERSION" --cleanup-tag --yes`
+- Delete release branch: `git push origin --delete "release/v$VERSION"; git checkout main; git branch -D "release/v$VERSION"`
+- Re-trigger release.yml after secret fix: `gh workflow run release.yml --ref "v$NEW_VERSION"`
 
 ---
 
@@ -376,6 +358,6 @@ npx tauri signer generate -w ~/.tauri/mdownreview.key
 ```
 
 - GitHub Secrets: `TAURI_SIGNING_PRIVATE_KEY` (private key), `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (empty string).
-- `src-tauri/tauri.conf.json` → `plugins.updater.pubkey` (public key — Phase 0 verifies it's non-empty).
+- `src-tauri/tauri.conf.json` → `plugins.updater.pubkey` (public key — Phase 0 verifies non-empty).
 
-Done once; release workflow uses these. Rotation is human-only — the skill HALTs on signing failures and does not attempt to regenerate keys.
+Rotation is human-only — the skill HALTs on signing failures and does not regenerate keys.

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -58,7 +58,7 @@ else
 fi
 
 git --no-pager log "$LAST_TAG_RANGE" --no-merges --pretty=format:"%H%x09%s" \
-  | grep -Ev '^[a-f0-9]+\schore: release v' \
+  | grep -Ev $'^[a-f0-9]+\tchore: release v' \
   > /tmp/publish-release.commits.tsv
 ```
 
@@ -103,15 +103,17 @@ Same input always produces the same output. No subjective "is this user-facing?"
 
 ### Rules
 
-1. Parse each commit subject as `^(?<type>[a-z]+)(\((?<scope>[^)]*)\))?(?<bang>!)?:\s*(?<desc>.+)$`.
-2. **Drop entirely** if `scope` ∈ `{ci, test, build, chore, deps, docs, infra, agents, skill, release}`.
-3. Drop if subject starts with `chore: release v`.
-4. Bucket the rest by `type`:
+1. Parse each commit subject as `^(?<type>[a-z][a-z-]*)(\((?<scope>[^)]*)\))?(?<bang>!)?:\s*(?<desc>.+)$`. Subjects that don't match the conventional-commit shape (e.g. `auto-improve:` with a hyphen — covered by `[a-z-]+` — but free-form merge-style subjects) → drop.
+2. **Drop entirely** if `scope` ∈ the **infra scopes** `{ci, test, build, deps, docs, infra, agents, release}`.
+3. **Drop entirely** if `scope` matches any directory name under `.claude/skills/` (enumerated, kept in sync with the filesystem):
+   `{groom-issues, iterate-loop, iterate-one-issue, merge-pr-loop, optimize-prompt, publish-release, run-build-test, test-exploratory-e2e, test-exploratory-loop, validate-ci}`.
+4. **Drop entirely** if `type` ∈ the **non-user-facing types** `{chore, refactor, style, samples, auto-improve, wip, build, test, ci, docs, revert}` — regardless of scope. (Rule 2/3 already covered the common scoped cases; this rule handles unscoped meta commits like `chore: bump deps`, `auto-improve: …`, `refactor: …`.)
+5. Bucket the survivors by `type`:
    - `feat` → **Features**
    - `fix` or `perf` → **Fixes**
-   - everything else → **Other**
-5. Each entry is `- <desc> (<short-sha>)`.
-6. Skip empty buckets.
+   - anything else (unknown type that survived rule 4) → **Other**
+6. Each entry is `- <desc> (<short-sha>)`.
+7. Skip empty buckets. If all three buckets are empty after filtering, `exit 0` with `Nothing user-facing to release since $LAST_TAG.` — same exit semantics as Phase 1's empty-commit case.
 
 ### Output (prepend to CHANGELOG.md, create if missing)
 
@@ -171,17 +173,55 @@ declare -A PRETAG_RERUN_COUNT
 
 ### Loop
 
-1. `gh pr checks "$PR_URL" --watch` → blocks until run completes.
-2. Green → `gh pr merge "$PR_URL" --squash --auto` (or `--admin` if branch protection requires it). Phase 7.
-3. Failed → fetch failed-job names + logs:
-   ```bash
-   RUN_ID=$(gh run list --branch "release/v$NEW_VERSION" --workflow=ci.yml --limit=1 --json databaseId -q '.[0].databaseId')
-   FAILED_JOBS=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion=="failure") | .name')
-   ```
-4. Classify per **Failure Classification**.
-5. Flake → if `${PRETAG_RERUN_COUNT[$job]:-0} < PRETAG_RERUN_BUDGET_PER_JOB`, `gh run rerun "$RUN_ID" --failed`, increment counter, loop to 1.
-6. Real failure → if `PRETAG_FIX_ATTEMPTS < PRETAG_FIX_CAP`, inline fix, `git commit --amend --no-edit || git commit -m "fix: ..."`, `git push --force-with-lease origin "release/v$NEW_VERSION"`, increment, loop to 1.
-7. Budget exhausted or unclassified → HALT.
+```bash
+while :; do
+  if gh pr checks "$PR_URL" --watch; then
+    # All checks green — squash-merge directly. The skill has already
+    # watched checks to completion, so --admin is deterministic; --auto
+    # would also work but can hang if branch protection updates mid-run.
+    gh pr merge "$PR_URL" --squash --admin --delete-branch
+    break  # → Phase 7
+  fi
+
+  # One or more checks failed. Fetch failed-job names + URLs.
+  RUN_ID=$(gh run list --branch "release/v$NEW_VERSION" --workflow=ci.yml \
+    --limit=1 --json databaseId -q '.[0].databaseId')
+  FAILED_JOBS=$(gh run view "$RUN_ID" --json jobs \
+    -q '.jobs[] | select(.conclusion=="failure") | .name')
+
+  # Classify per Failure Classification (first match wins).
+  CLASS=$(classify "$RUN_ID")  # flake | signing | lockfile-drift | …
+
+  case "$CLASS" in
+    flake)
+      # Per-job rerun cap.
+      for job in $FAILED_JOBS; do
+        if (( ${PRETAG_RERUN_COUNT[$job]:-0} < PRETAG_RERUN_BUDGET_PER_JOB )); then
+          gh run rerun "$RUN_ID" --failed
+          PRETAG_RERUN_COUNT[$job]=$(( ${PRETAG_RERUN_COUNT[$job]:-0} + 1 ))
+        else
+          halt "flake budget exhausted on $job"
+        fi
+      done
+      ;;
+    lockfile-drift|bindings-drift|changelog/version-mismatch)
+      if (( PRETAG_FIX_ATTEMPTS < PRETAG_FIX_CAP )); then
+        inline_fix "$CLASS"   # see "Expected inline fixes" below
+        git add -A
+        git commit --amend --no-edit 2>/dev/null \
+          || git commit -m "fix(release): $CLASS"
+        git push --force-with-lease origin "release/v$NEW_VERSION"
+        ((PRETAG_FIX_ATTEMPTS++))
+      else
+        halt "fix-attempt budget exhausted ($PRETAG_FIX_ATTEMPTS/$PRETAG_FIX_CAP)"
+      fi
+      ;;
+    signing|fixable-build|regression|unclassified)
+      halt "$CLASS — see Failure Classification table"
+      ;;
+  esac
+done
+```
 
 ### Expected inline fixes
 
@@ -256,8 +296,13 @@ git checkout main && git pull --ff-only
 # Examples: NSIS hook syntax, stage-cli profile detection, bundle target
 # list, missing platform-conditional. >50 LoC → HALT.
 
-# Phase 3: update version files.
-# Phase 4: prepend CHANGELOG entry under "## v$NEW_VERSION — <date>" with
+# Phase 3: update version files (no Phase 4 re-classification — the
+#   user-facing changelog for the underlying commits is already merged
+#   into main as the "## v$PREV_FAILED" entry; we only ADD a supersession
+#   marker at the top so the missing tag is auditable).
+# Phase 4 (re-roll variant): prepend a minimal entry — supersession line ONLY:
+#   ## v$NEW_VERSION — <date>
+#
 #   ### Other
 #   - chore(release): supersedes failed v$PREV_FAILED — <one-line cause>
 
@@ -335,7 +380,7 @@ When budget is exhausted or a non-fixable class is hit:
    Remediation:   <class-specific message>
    ```
 2. Pre-tag HALT (PR not yet merged): leave branch and PR in place — preserves debugging context.
-3. Post-tag HALT: tag stays in place. For `signing` class, the tag is fine — fix the secret and re-trigger via `gh workflow run release.yml --ref v$NEW_VERSION`.
+3. Post-tag HALT: tag stays in place. For `signing` class, the tag is fine — fix the secret, then re-trigger via `gh workflow run release.yml --ref "v$NEW_VERSION" -f tag="v$NEW_VERSION"` (the `tag` input is `required: true` per `release.yml`).
 4. Print Phase 9 summary with `HALTED: <class>` in the Release URL row.
 5. `exit 1`.
 
@@ -347,7 +392,7 @@ Documented for human follow-up; the skill does not invoke them during HALT.
 
 - Delete tag + release: `gh release delete "v$VERSION" --cleanup-tag --yes`
 - Delete release branch: `git push origin --delete "release/v$VERSION"; git checkout main; git branch -D "release/v$VERSION"`
-- Re-trigger release.yml after secret fix: `gh workflow run release.yml --ref "v$NEW_VERSION"`
+- Re-trigger release.yml after secret fix: `gh workflow run release.yml --ref "v$NEW_VERSION" -f tag="v$NEW_VERSION"`
 
 ---
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,126 +1,371 @@
 ---
 name: publish-release
-description: Use when shipping a new release of mdownreview — when the user says "release", "tag", "publish", "ship a new version", "bump version", or asks for a CHANGELOG-driven version bump. Triggers the release CI/CD workflow via tag push.
+description: Use when shipping a new release of mdownreview — when the user says "release", "tag", "publish", "ship a new version", "bump version", or runs `/publish-release [major|minor|patch]`. Fully autonomous — picks the bump from the arg (default `patch`), validates pre-flight gates, opens a release PR, babysits CI, tags the merged commit, then babysits release.yml — forward-fixing recoverable failures inline. Halts only on uncorrectable conditions (signing failures, dirty tree, divergent main).
 ---
 
-**Never skip the confirmation in Step 5.**
+**RIGID. Fully autonomous — never calls `ask_user`.** Owns the entire release lifecycle: version bump → CHANGELOG → release PR → tag → signed installers → published GitHub release. Pairs with `ci.yml` (CI build + sign + verify, called via `workflow_call` from `release.yml`).
 
-## 1. Pre-flight
+The skill assumes a healthy `main`: pre-flight verifies the latest `ci.yml` and `canary.yml` runs on `main` are green and the working tree is clean. **Once those gates pass, every later failure is presumed release-pipeline-specific** (version-bump conflict, lockfile drift, NSIS hook, tauri.conf schema, platform build script) and is handled by inline fix-forward, not by delegating to `/iterate-one-issue`. If a fix would need >50 LoC or unfamiliar code paths, that's a signal of an upstream regression pre-flight should have caught — abort with HALT instead of chasing it.
 
-- `git status --porcelain` — non-empty → stop (commit/stash first).
-- `git branch --show-current` — not `main` → warn, ask explicit confirmation.
-- `git --no-pager fetch origin --tags`.
+Forward-fix budgets are bounded:
+- **Pre-tag CI:** flake reruns cap 2/job, inline fixes cap 3.
+- **Post-tag release CI:** flake reruns cap 2, fix-forward re-rolls cap 2 (always bumping patch — never reuse a version).
 
-## 2. Last release
+---
 
-`git --no-pager describe --tags --abbrev=0`. If no tags, baseline = `package.json` `version`.
+## Args
 
-## 3. Unreleased commits
-
-`git --no-pager log {last-tag}..HEAD --pretty=format:"%s"` (or `git log --pretty=format:"%s"` if no tags). Exclude merges and `chore: release v` commits. **Zero commits → stop ("nothing to release").**
-
-## 4. Classify + suggest bump
-
-| Subject pattern | Bump |
+| Arg | Bump |
 |---|---|
-| `^.+!:` or body has `BREAKING CHANGE:` | **major** (1.x.0 → 2.0.0) |
-| `^feat(\(.*\))?:` | **minor** (0.2.0 → 0.3.0) |
-| `^(fix\|perf)(\(.*\))?:` | **patch** (0.2.0 → 0.2.1) |
+| empty | `patch` |
+| `patch` | `patch` |
+| `minor` | `minor` |
+| `major` | `major` |
 
-Highest bump wins.
+Anything else → `exit 1` with message `[publish-release] Unknown arg "<ARG>". Use empty (=patch), patch, minor, or major.`
 
-## 5. Confirm
+The skill **always follows the literal arg** — it never auto-detects bump class from `feat!:`/`BREAKING CHANGE:` and never overrides the user. Misclassified bump is the user's call.
 
-Show:
-```
-Last tag: <tag>
-Commits since last release:
-<list>
-Suggested next version: v<next>
-```
+---
 
-Use `ask_user` with `v<next> (suggested)` | `cancel` (allow freeform). Strip leading `v`. Validate semver. Reject if tag already exists (`git tag -l v<version>`). **Do not proceed without confirmation.**
+## Phase 0 — Pre-flight (read-only, fail-fast)
 
-## 6. Update version (3 files, no `v` prefix)
-
-1. `package.json` → `"version"`
-2. `src-tauri/Cargo.toml` → `version` under `[package]`
-3. `src-tauri/tauri.conf.json` → `"version"`
-
-## 7. CHANGELOG.md (prepend; create if missing)
-
-```
-## v<version> — YYYY-MM-DD
-
-### Features
-- <feat …>
-
-### Fixes
-- <fix/perf …>
-
-### Other
-- <rest>
-```
-
-Skip empty sections. Preserve existing entries below.
-
-## 8. Branch + commit (separate commands)
+Each gate is read-only — the skill never auto-stashes, auto-commits, or auto-checks-out. On failure: print exact remediation command and `exit 1`.
 
 ```bash
-git checkout -b release/v<version>
+git --no-pager fetch origin --tags
+```
+
+| Gate | Command | Fail message |
+|---|---|---|
+| Clean tree | `git status --porcelain` empty | `Working tree dirty — commit or stash before release.` |
+| On main | `git branch --show-current` == `main` | `Not on main — git checkout main && git pull --ff-only first.` |
+| Synced main | `git pull --ff-only origin main` | `Local main diverged from origin — investigate before release.` |
+| Latest CI on main green | `gh run list --workflow=ci.yml --branch=main --limit=1 --json conclusion,databaseId,headSha,url` → `conclusion == "success"` AND `headSha == HEAD` | `Latest ci.yml on main is <conclusion> at <url> — fix and let it land before releasing.` |
+| Latest canary on main green | `gh run list --workflow=canary.yml --branch=main --limit=1 --json conclusion,headSha,url` → `conclusion == "success"` | `Latest canary.yml on main is <conclusion> at <url> — fix before releasing (signed-build pipeline is broken).` |
+| Updater pubkey present | `jq -e '.plugins.updater.pubkey | length > 0' src-tauri/tauri.conf.json` | `tauri.conf.json plugins.updater.pubkey is empty — releases would be unverifiable.` |
+
+If every gate passes, log `[publish-release] pre-flight green; HEAD=<sha>`.
+
+---
+
+## Phase 1 — Last release + unreleased commits
+
+```bash
+LAST_TAG=$(git --no-pager describe --tags --abbrev=0 2>/dev/null || true)
+if [ -z "$LAST_TAG" ]; then
+  LAST_TAG_RANGE="HEAD"  # first release
+  BASELINE_VERSION=$(jq -r .version package.json)
+else
+  LAST_TAG_RANGE="$LAST_TAG..HEAD"
+  BASELINE_VERSION="${LAST_TAG#v}"
+fi
+
+git --no-pager log "$LAST_TAG_RANGE" --no-merges --pretty=format:"%H%x09%s" \
+  | grep -Ev '^[a-f0-9]+\schore: release v' \
+  > /tmp/publish-release.commits.tsv
+```
+
+If `/tmp/publish-release.commits.tsv` is empty → `exit 0` with `Nothing to release since $LAST_TAG.` (not an error).
+
+---
+
+## Phase 2 — Compute next version
+
+```bash
+BUMP="${ARG:-patch}"
+IFS=. read -r MAJ MIN PAT <<< "$BASELINE_VERSION"
+case "$BUMP" in
+  major) NEW_VERSION="$((MAJ+1)).0.0" ;;
+  minor) NEW_VERSION="${MAJ}.$((MIN+1)).0" ;;
+  patch) NEW_VERSION="${MAJ}.${MIN}.$((PAT+1))" ;;
+esac
+[[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "computed version $NEW_VERSION not semver"; exit 1; }
+git tag -l "v$NEW_VERSION" | grep -q . && { echo "tag v$NEW_VERSION already exists"; exit 1; }
+```
+
+No `ask_user`. The arg is authoritative.
+
+---
+
+## Phase 3 — Update version files
+
+Three files, no `v` prefix in any of them:
+
+1. `package.json` → `.version`
+2. `src-tauri/Cargo.toml` → `version` under `[package]`
+3. `src-tauri/tauri.conf.json` → `.version`
+
+Then refresh lockfiles:
+```bash
 npm install --package-lock-only
 cargo generate-lockfile --manifest-path src-tauri/Cargo.toml
-git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json CHANGELOG.md
-git commit -m "chore: release v<version>"
 ```
 
-## 8.5. Local native E2E gate (Windows only)
+---
 
-Native E2E cannot run in GitHub Actions (WebView2/CDP unavailable headless). Skip on non-Windows but tell user to run on Windows before continuing.
+## Phase 4 — CHANGELOG (deterministic filter)
+
+CHANGELOG generation is **mechanical** — the same input always produces the same output. No subjective "is this user-facing?" judgement.
+
+### Rules
+
+1. Parse each commit subject as `^(?<type>[a-z]+)(\((?<scope>[^)]*)\))?(?<bang>!)?:\s*(?<desc>.+)$`.
+2. **Drop entirely** if `scope` ∈ `{ci, test, build, chore, deps, docs, infra, agents, skill, release}`. (Tell contributors: scope your commit properly to control CHANGELOG visibility.)
+3. Drop if subject starts with `chore: release v` (already filtered in Phase 1, but keep as safety net).
+4. Bucket the rest by `type`:
+   - `feat` → **Features**
+   - `fix` or `perf` → **Fixes**
+   - everything else → **Other**
+5. Each entry is `- <desc> (<short-sha>)` — short-sha helps reviewers locate the commit.
+6. Skip empty buckets.
+
+### Output (prepend to CHANGELOG.md, create if missing)
+
+```
+## v<NEW_VERSION> — <YYYY-MM-DD>
+
+### Features
+- <feat …> (<sha>)
+
+### Fixes
+- <fix/perf …> (<sha>)
+
+### Other
+- <other …> (<sha>)
+
+```
+
+Preserve all existing entries below.
+
+---
+
+## Phase 5 — Branch + commit + push + open PR
 
 ```bash
-npm test
-npm run test:e2e
-npm run test:e2e:native:build
+git checkout -b "release/v$NEW_VERSION"
+git add package.json package-lock.json \
+        src-tauri/Cargo.toml src-tauri/Cargo.lock \
+        src-tauri/tauri.conf.json \
+        CHANGELOG.md
+git commit -m "chore: release v$NEW_VERSION
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin "release/v$NEW_VERSION"
+
+PR_URL=$(gh pr create --base main --head "release/v$NEW_VERSION" \
+  --title "chore: release v$NEW_VERSION" \
+  --body "Automated release PR. Will be auto-merged when CI is green.
+
+- Bump: \`$BUMP\` ($BASELINE_VERSION → $NEW_VERSION)
+- Commits: $(wc -l < /tmp/publish-release.commits.tsv)
+- Last tag: $LAST_TAG")
+PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
 ```
 
-Stop on first failure. On all-pass print `✅ All local tests passed`.
+---
 
-## 9. Push, PR, wait for CI
+## Phase 6 — Babysit pre-tag CI
+
+CI fires automatically on `pull_request` open. Wait for the run to finish, classify, fix-forward inline, repeat.
 
 ```bash
-git push origin release/v<version>
-gh pr create --base main --head release/v<version> --title "chore: release v<version>" --body "Version bump to v<version>. Merge after CI passes; tag will trigger build."
+PRETAG_FIX_ATTEMPTS=0
+PRETAG_FIX_CAP=3
+PRETAG_RERUN_BUDGET_PER_JOB=2
+declare -A PRETAG_RERUN_COUNT
 ```
 
-Print PR URL. Wait 30 s, then `gh pr checks <pr_url> --watch` (async — may take 20+ min).
+### Loop
 
-- **Exit 0:** print "All CI checks passed — merge the PR, then confirm." Use `ask_user` with `Merged — create the tag` | `Cancel release`.
-- **Non-zero:** print failed-check output. Choices: `I pushed a fix — re-check` | `Cancel release`. Re-check loops back to `--watch` after 10 s. Cancel:
-  ```bash
-  git checkout main
-  git branch -D release/v<version>
-  git push origin --delete release/v<version>
-  ```
+1. `gh pr checks "$PR_URL" --watch` → blocks until run completes.
+2. If green → `gh pr merge "$PR_URL" --squash --auto` (or `--admin` if branch protection requires it). Proceed to Phase 7.
+3. If failed → fetch failed-job names + logs:
+   ```bash
+   RUN_ID=$(gh run list --branch "release/v$NEW_VERSION" --workflow=ci.yml --limit=1 --json databaseId -q '.[0].databaseId')
+   FAILED_JOBS=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion=="failure") | .name')
+   ```
+4. Classify (see **Failure Classification** below).
+5. **Flake** → if `${PRETAG_RERUN_COUNT[$job]:-0} < PRETAG_RERUN_BUDGET_PER_JOB`, `gh run rerun "$RUN_ID" --failed`, increment counter, loop to step 1.
+6. **Real failure** → if `PRETAG_FIX_ATTEMPTS < PRETAG_FIX_CAP`, perform inline fix (see below), `git commit --amend --no-edit || git commit -m "fix: ...`", `git push --force-with-lease origin "release/v$NEW_VERSION"`, increment `PRETAG_FIX_ATTEMPTS`, loop to step 1.
+7. **Budget exhausted or unclassified** → HALT (see **HALT** below).
 
-## 10. Tag the merged commit
+### Inline fix scope (pre-tag)
+
+Pre-tag failures are by definition release-pipeline-specific (pre-flight already proved `main` + canary green). Expected fixes:
+
+- Lockfile drift: re-run `npm install --package-lock-only` / `cargo generate-lockfile`.
+- Bindings drift: regenerate per `src/lib/bindings.ts` header instructions.
+- CHANGELOG syntax error: fix markdown.
+- Version mismatch between the three version files.
+- `tauri.conf.json` schema (rare — would mean a Tauri version bump landed since canary).
+- Test snapshot referencing the old version string.
+
+If the failed-job log indicates >50 LoC of changes or touches application source under `src/`/`src-tauri/src/core/`, that's a regression pre-flight should have caught — HALT, do not chase.
+
+---
+
+## Phase 7 — Tag the merged commit
+
+After Phase 6 squash-merges:
 
 ```bash
 git checkout main
-git pull origin main
-gh pr checks <pr_url>           # final verify; warn + confirm if not green
-git tag -a v<version> -m "Release v<version>"
-git push origin v<version>
+git pull --ff-only origin main
+MERGED_SHA=$(git rev-parse HEAD)
+git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+git push origin "v$NEW_VERSION"
 ```
 
-Tag push triggers `.github/workflows/release.yml`.
+Tag push triggers `release.yml`.
 
-## 11. Print
+---
+
+## Phase 8 — Babysit post-tag release.yml (fix-forward)
+
+Watch `release.yml` for the new tag. Classify each failure (table below). On **fixable** classes, perform the **fix-forward re-roll** (delete tag/release, bump patch, re-issue the PR). On **HALT** classes, exit non-zero with diagnosis. Always print which class and which class-specific log line caused the decision.
+
+```bash
+POSTTAG_REROLL_ATTEMPTS=0
+POSTTAG_REROLL_CAP=2
+POSTTAG_RERUN_BUDGET_PER_JOB=2
+declare -A POSTTAG_RERUN_COUNT
+```
+
+### Loop
+
+1. Find the release.yml run for `v$NEW_VERSION`:
+   ```bash
+   sleep 30  # let GitHub register the tag-triggered run
+   RELEASE_RUN_ID=$(gh run list --workflow=release.yml --limit=5 \
+     --json databaseId,headBranch,status -q '.[] | select(.headBranch=="v'"$NEW_VERSION"'") | .databaseId' | head -1)
+   gh run watch "$RELEASE_RUN_ID" --exit-status || true
+   ```
+2. Re-fetch the run conclusion. If `success` → Phase 9.
+3. List failed jobs:
+   ```bash
+   FAILED_JOBS=$(gh run view "$RELEASE_RUN_ID" --json jobs \
+     -q '.jobs[] | select(.conclusion=="failure") | {name: .name, url: .url}')
+   ```
+4. Classify per **Failure Classification**.
+5. **Network/transient flake** → rerun within budget, loop to step 1.
+6. **Signing/credential class** → HALT immediately. Tag stays in place; print remediation.
+7. **Fixable build class** → perform **Re-roll** (below) if `POSTTAG_REROLL_ATTEMPTS < POSTTAG_REROLL_CAP`, else HALT.
+8. **Unclassified** → HALT.
+
+### Re-roll algorithm
+
+Always bumps **patch** from the failed version (never reuses a version):
+
+```bash
+gh release delete "v$NEW_VERSION" --cleanup-tag --yes
+# Bump patch from the failed version:
+IFS=. read -r MAJ MIN PAT <<< "$NEW_VERSION"
+PREV_FAILED="$NEW_VERSION"
+NEW_VERSION="${MAJ}.${MIN}.$((PAT+1))"
+git checkout main && git pull --ff-only
+
+# Inline code fix for the build/script issue (touching only src-tauri config,
+# scripts/, NSIS hooks, or a single file under src-tauri/src). >50 LoC → HALT.
+# Examples: NSIS hook syntax error, stage-cli profile detection, tauri.conf
+# bundle target list, missing platform-conditional in build.rs.
+
+# Update version files (Phase 3)
+# Prepend CHANGELOG entry under "## v$NEW_VERSION — <date>" with
+#   "### Other" → "- chore(release): supersedes failed v$PREV_FAILED — <one-line cause>"
+#   plus any commits introduced by the inline fix.
+
+git checkout -b "release/v$NEW_VERSION"
+git add <fixed files> package.json package-lock.json \
+        src-tauri/Cargo.toml src-tauri/Cargo.lock \
+        src-tauri/tauri.conf.json CHANGELOG.md
+git commit -m "chore: release v$NEW_VERSION (supersedes v$PREV_FAILED)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin "release/v$NEW_VERSION"
+gh pr create ...        # same as Phase 5
+((POSTTAG_REROLL_ATTEMPTS++))
+# loop back through Phase 6 → 7 → 8 with the new version
+```
+
+The supersession line in the CHANGELOG creates an audit trail so consumers seeing a missing `vX.Y.Z` understand why.
+
+---
+
+## Phase 9 — Summary
+
+Always print on success **or** on HALT (so the user has an audit trail either way):
 
 ```
-Release v<version> tagged and pushed!
-Monitor: https://github.com/dryotta/mdownreview/actions
+=== publish-release summary ===
+Bump:                  <patch|minor|major> (default | user-arg "<arg>")
+Last tag:              <LAST_TAG>
+Released as:           v<NEW_VERSION>$([ -n "$PREV_FAILED" ] && echo " (supersedes $PREV_FAILED)")
+Commits classified:
+  Features:            <N>
+  Fixes:               <N>
+  Other:               <N>
+  Excluded by scope:   <N>
+Pre-tag CI:            green after <X> attempts (<R> reruns, <F> inline fixes)
+Post-tag release.yml:  green after <Y> attempts (<R2> reruns, <RR> re-rolls)
+Final tag SHA:         <merged-sha>
+Release URL:           <gh release url>   (or "DRAFT" / "FAILED" / "HALTED: <class>")
+Signed assets:         <count>            (or "n/a" on HALT)
+Total wall-clock:      <hh:mm:ss>
 ```
+
+---
+
+## Failure Classification
+
+Used by Phase 6 (pre-tag) and Phase 8 (post-tag) to route each failed job. Match in order — first row that matches wins.
+
+| # | Signal in failed-job log | Class | Pre-tag action | Post-tag action |
+|---|---|---|---|---|
+| 1 | Job timeout / `connect ETIMEDOUT` / `503 Service Unavailable` / GitHub Actions runner provisioning error | **flake** | rerun (cap 2/job) | rerun (cap 2/job) |
+| 2 | Native E2E `WebView2Loader` / browser launch error / single-instance lock | **flake** | rerun (cap 2/job) | n/a (job not in release.yml workflow_call's matrix) |
+| 3 | `error: failed to read … TAURI_SIGNING_PRIVATE_KEY` / `signature verification failed` / `pubkey mismatch` / `endorsement` / cert-related stderr | **signing** | HALT (block PR merge — tag would be unsigned) | HALT (do NOT re-roll — credentials problem, not code) |
+| 4 | rustc/cargo error referencing `src-tauri/Cargo.lock` mismatch | **lockfile-drift** | inline fix: `cargo generate-lockfile --manifest-path src-tauri/Cargo.toml` (cap 3) | re-roll with same fix (cap 2) |
+| 5 | `bindings.ts` mismatch (bindings-drift job) | **bindings-drift** | inline fix per `src/lib/bindings.ts` regeneration command (cap 3) | re-roll with same fix |
+| 6 | CHANGELOG markdown lint / version-string assertion failure in tests | **changelog/version-mismatch** | inline fix (cap 3) | re-roll |
+| 7 | NSIS / `installer-hooks.nsh` syntax error · `signtool` invocation · DMG layout failure · `Verify ad-hoc signing` step · platform-specific `cargo build` errors localized to `src-tauri/src` config or `scripts/` | **fixable-build** | HALT (would mean canary should have caught it; investigate) | re-roll (cap 2) |
+| 8 | Test failure under `src/__tests__/`, `src-tauri/tests/`, `e2e/` referencing application logic | **regression** | HALT (canary lied — fix on main first) | HALT (do not ship a release chasing a regression) |
+| 9 | Anything else | **unclassified** | HALT | HALT |
+
+When in doubt: HALT. Two HALTs in a release are better than one bad release.
+
+---
+
+## HALT procedure
+
+When budget is exhausted or a non-fixable class is hit:
+
+1. Print:
+   ```
+   [publish-release] HALT — class=<class>, attempts=<N>/<cap>
+   Failed job:    <job name>
+   Failed run:    <gh run url>
+   First-line:    <first error line from log>
+   Remediation:   <class-specific message>
+   ```
+2. **Pre-tag HALT** (PR not yet merged):
+   - Leave the branch and PR in place — user inspects, fixes, force-pushes, or runs `/publish-release` again after the upstream issue is resolved.
+   - **Do not** auto-close the PR or auto-delete the branch (preserves debugging context).
+3. **Post-tag HALT**:
+   - Tag and GitHub release stay in place if class ∈ `{signing}` (the tag itself is fine; the build infra is broken — fixing the secret will unblock a re-trigger via `gh workflow run release.yml --ref v$NEW_VERSION`).
+   - Tag is left in place if class ∈ `{regression, unclassified}` (so the user can decide whether to fix-forward to a higher patch or rollback manually).
+4. Print Phase 9 summary with `HALTED: <class>` in the Release URL row.
+5. `exit 1`.
+
+---
+
+## Recovery primitives (used by re-roll and HALT)
+
+- **Delete tag + release:** `gh release delete "v$VERSION" --cleanup-tag --yes`
+- **Delete release branch (if abandoning):** `git push origin --delete "release/v$VERSION"; git checkout main; git branch -D "release/v$VERSION"`
+- **Re-trigger release.yml after secret fix:** `gh workflow run release.yml --ref "v$NEW_VERSION"`
+
+The skill does not invoke recovery primitives during a HALT — they're documented here so a human (or a follow-up `/publish-release` invocation) can use them.
 
 ---
 
@@ -131,6 +376,6 @@ npx tauri signer generate -w ~/.tauri/mdownreview.key
 ```
 
 - GitHub Secrets: `TAURI_SIGNING_PRIVATE_KEY` (private key), `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (empty string).
-- `src-tauri/tauri.conf.json` → `plugins.updater.pubkey` (public key).
+- `src-tauri/tauri.conf.json` → `plugins.updater.pubkey` (public key — Phase 0 verifies it's non-empty).
 
-Done once; release workflow uses these.
+Done once; release workflow uses these. Rotation is human-only — the skill HALTs on signing failures and does not attempt to regenerate keys.


### PR DESCRIPTION
## Summary

Rewrites the `publish-release` skill as a fully-autonomous one-command releaser. Addresses 9 review comments left in the mdownreview app on the previous version of `SKILL.md`.

Invocation: `/publish-release [major|minor|patch]` (default `patch`). Zero `ask_user` calls  the skill either prints a release URL + summary, or aborts with a HALT diagnosis.

## Highlights

| Phase | Behaviour |
|---|---|
| 0  Pre-flight | Read-only fail-fast gates. **New:** require latest `ci.yml` + `canary.yml` runs on `main` to be green; verify `tauri.conf.json` `plugins.updater.pubkey` is non-empty. |
| 2  Compute version | Deterministic from arg + last tag. Never auto-detects bump from `feat!:`/`BREAKING CHANGE:`  user arg is authoritative. |
| 4  CHANGELOG | **New:** mechanical scope filter. Drops commits scoped `{ci,test,build,chore,deps,docs,infra,agents,skill,release}` entirely; remaining bucketed by prefix (`feat`Features, `fix`/`perf`Fixes, restOther). Same input always produces same output. |
| 6  Pre-tag CI babysit | Inline fix-forward, no delegation. Caps: 2 reruns/job for flakes, 3 inline-fix attempts. >50 LoC fix needed  HALT. |
| ~~8.5~~ | Deleted. Native E2E now runs in `ci.yml` (`native-e2e` job, `windows-2022`) and is wired into `release.yml` via `workflow_call`. |
| 8  Post-tag release.yml babysit | **New:** fix-forward re-roll for fixable build/script failures (NSIS hooks, signtool, DMG layout, lockfile drift, bindings drift). Always bumps **patch** (never reuses a version). HALT on signing failures. Cap 2 re-rolls. |
| 9  Summary | **New:** prints on success AND on HALT. Full audit trail: bump source, classification counts, retry/inline-fix/re-roll counts, final tag SHA, release URL or HALT class, signed-asset count, wall-clock. |

Plus a 9-row **Failure Classification** table that routes each failed job to one of `flake / signing / lockfile-drift / bindings-drift / changelog-mismatch / fixable-build / regression / unclassified`, with first-match-wins ordering, and a documented **HALT procedure** that preserves debugging context (no auto-deletion of branches, tags, or releases).

## Design decisions captured this session

1. **User arg is authoritative on bump class.** No SemVer auto-detection override.
2. **Re-roll always bumps patch** (debt isolation, never reuse a version).
3. **Internal-scope commits dropped from CHANGELOG entirely** (cleanest user-facing changelog).
4. **Inline fixes only**  no delegation to `/iterate-one-issue`. Pre-flight gates prove `main` is healthy, so post-pre-flight failures are presumed small-diff release-pipeline noise.

## Verification

- `npm run lint:skills`  (10 SKILL.md files, all `npm run` references resolve)
- All 9 review comments resolved via `mdownreview-cli respond ... --resolve`

## Out of scope

- No changes to `ci.yml` or `release.yml` (already correct).
- No changes to other skills (`iterate-one-issue`, `merge-pr-loop`).
- Signing-key rotation remains human-only (skill HALTs on signing failures).