### PR TITLE
ci: skip heavy jobs on push-to-main when tree already tested green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ name: CI
 # bounded by the slowest of {build matrix, native-e2e}.
 #
 # Jobs (all parallel under `changes` unless noted):
+#   - changes (ubuntu)               — docs-vs-code path filter
+#   - check-redundant (ubuntu)       — tree-hash skip on push-to-main
+#                                      (no-op for PR / workflow_call)
 #   - lint-and-vitest (ubuntu)      — eslint, vitest, frontend build, bundle gates
 #   - rust-test (ubuntu)             — clippy + cargo test + `cargo bench --no-run`
 #   - rust-test-windows (win-2022)   — clippy + cargo test (Windows-cfg code)
@@ -111,12 +114,101 @@ jobs:
           echo "Heavy jobs will run: $CODE"
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Check-redundant — skip heavy jobs on push-to-main when the post-squash
+  # commit's tree is byte-identical to a PR head SHA whose ci.yml run already
+  # concluded `success`. Falls open on every ambiguity (non-squash merge,
+  # direct push, lookup error, stale PR CI) so the safety net is never
+  # weaker than today. See `test-gate` for the skip-on-skip contract.
+  # ─────────────────────────────────────────────────────────────────────────
+  check-redundant:
+    name: Check if tree already tested
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      skip: ${{ steps.compare.outputs.skip }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.ref || github.ref }}
+
+      - id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          # `set +e` so every lookup falls open to `skip=false` on error
+          # rather than failing the job (which would skip heavy jobs by
+          # accident via the `needs:` edge).
+          set +e
+          skip=false
+
+          # Only consider skipping for push-to-main. PR / workflow_call
+          # events always run the full matrix.
+          if [ "${{ github.event_name }}" != "push" ] \
+             || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "Event is not push-to-main; running full matrix."
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tree=$(git rev-parse HEAD^{tree})
+          msg=$(git log -1 --pretty=%s)
+          # GitHub appends "(#N)" to every squash-merge subject. Anything
+          # else (direct push, merge-commit, rebase-merge) falls open.
+          pr=$(echo "$msg" | grep -oE '\(#[0-9]+\)$' | tr -d '(#)')
+          if [ -z "$pr" ]; then
+            echo "HEAD subject is not a squash-merge ('$msg'); running full matrix."
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          head=$(gh pr view "$pr" --json headRefOid -q .headRefOid 2>/dev/null)
+          if [ -z "$head" ]; then
+            echo "Could not resolve PR #$pr head SHA; running full matrix."
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_tree=$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$head" -q .tree.sha 2>/dev/null)
+          if [ -z "$pr_tree" ]; then
+            echo "Could not resolve PR #$pr head tree; running full matrix."
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$tree" != "$pr_tree" ]; then
+            echo "Tree differs from PR #$pr head; running full matrix."
+            echo "  post-merge tree: $tree"
+            echo "  PR head tree:    $pr_tree"
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          conclusion=$(gh run list --commit "$head" --workflow ci.yml \
+                       --json conclusion -q '.[0].conclusion // ""' 2>/dev/null)
+          if [ "$conclusion" != "success" ]; then
+            echo "PR #$pr last ci.yml conclusion on $head is '$conclusion' (need 'success'); running full matrix."
+            echo "skip=$skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          skip=true
+          echo "✓ Tree $tree already tested green on PR #$pr (SHA $head)."
+          echo "  Heavy jobs will skip; CI gate accepts skip-on-skip."
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Lint + Vitest + frontend build + bundle-size gates (Linux).
   # ─────────────────────────────────────────────────────────────────────────
   lint-and-vitest:
     name: Lint + Vitest (Linux)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -163,8 +255,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test:
     name: Rust tests (Linux)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
@@ -225,8 +317,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test-windows:
     name: Rust tests (Windows)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 30
     steps:
@@ -274,8 +366,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test-macos:
     name: Rust tests (macOS)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: macos-14
     timeout-minutes: 30
     env:
@@ -323,8 +415,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   bindings-drift:
     name: Bindings drift check (#263)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -378,8 +470,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   e2e-browser:
     name: E2E browser (Linux)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -436,8 +528,8 @@ jobs:
   # specs share a single CDP-attached debug binary. Sharding deferred.
   native-e2e:
     name: Native E2E (Windows)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 30
     steps:
@@ -509,8 +601,8 @@ jobs:
   # canary / release callers: `profile: release` + `sign: true` — ~10-12 min.
   build:
     name: Build (${{ matrix.name }})
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, check-redundant]
+    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -788,12 +880,12 @@ jobs:
   # `native-e2e`, `rust-test*`, etc.; only its execution waits.
   installer-e2e:
     name: Installer E2E (Windows)
-    needs: [changes, build]
+    needs: [changes, check-redundant, build]
     # Only runs on PR / push (sign=false). On sign=true the build matrix
     # uploads a `.nsis.zip` updater bundle (no standalone setup.exe), so
     # installer-e2e has nothing to consume — release-preflight covers the
     # signed-artefact contract instead.
-    if: needs.changes.outputs.code == 'true' && inputs.sign != true
+    if: needs.changes.outputs.code == 'true' && inputs.sign != true && needs.check-redundant.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 15
     steps:
@@ -870,8 +962,8 @@ jobs:
   # files (the High finding from `tauri-build-expert`).
   release-preflight:
     name: Release preflight
-    needs: [changes, build]
-    if: needs.changes.outputs.code == 'true' && inputs.sign == true
+    needs: [changes, check-redundant, build]
+    if: needs.changes.outputs.code == 'true' && inputs.sign == true && needs.check-redundant.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -918,11 +1010,15 @@ jobs:
   # `installer-e2e` is required only when sign != true (canary/release skip
   # it because the build matrix emits a `.zip` updater bundle, not a setup
   # `.exe` — release-preflight covers the signed-artefact contract).
+  # On push-to-main the gate also accepts skip-on-skip when
+  # `check-redundant` proved the post-squash tree was already tested green
+  # on its source PR — see that job's comment block.
   test-gate:
     name: CI gate
     if: always()
     needs:
       - changes
+      - check-redundant
       - lint-and-vitest
       - rust-test
       - rust-test-windows
@@ -943,6 +1039,10 @@ jobs:
             echo "::error::changes job did not succeed (got ${{ needs.changes.result }})"
             exit 1
           }
+          if [ "${{ needs.check-redundant.outputs.skip }}" = "true" ]; then
+            echo "Post-squash tree already tested green on source PR — heavy jobs correctly skipped. Gate green."
+            exit 0
+          fi
           CODE="${{ needs.changes.outputs.code }}"
           echo "code_changed=$CODE"
           if [ "$CODE" != "true" ]; then


### PR DESCRIPTION
## Problem

Every PR merge to `main` triggers `ci.yml` again on the new SHA. When the PR was up-to-date with main at merge time (the squash-merge happy path), the post-merge commit's **tree object** is byte-identical to the PR head's tree — only the SHA, parent, author, and timestamp change. The full test matrix re-runs against the same bytes that just passed.

Measured cost (PR #383's recent merge):

| | Wall clock | Job-minutes |
|---|---|---|
| PR CI on `b689ae5` | ~12 min | ~57 |
| Post-merge `ci.yml (push)` on `641a71a` | ~12 min | ~57 ← duplicated |
| `canary.yml` on `641a71a` (release profile, signed) | ~14 min | ~80 ← genuinely new work |

The middle row is the optimization target.

## Fix

A new `check-redundant` job (one-time, ~10 seconds, ubuntu-latest):

1. Parse `(#N)` out of the squash-commit subject (`fix: ... (#383)`); fall open if not present.
2. Look up PR #N's head SHA via `gh pr view`.
3. Fetch its tree SHA via `gh api repos/$repo/git/commits/<head>`.
4. Compare `git rev-parse HEAD^{tree}` to the PR head's tree.
5. Look up the PR's last `ci.yml` run conclusion via `gh run list --commit <head>`.
6. Emit `skip=true` only if both conditions hold: tree match AND last run was `success`.

Every heavy job extends its existing `needs:` / `if:` with the new gate:
```yaml
needs: [changes, check-redundant]
if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
```

The aggregate `CI gate` job gains a third short-circuit (mirroring the docs-only path documented at the top of `ci.yml`):
```bash
if [ "${{ needs.check-redundant.outputs.skip }}" = "true" ]; then
  echo "Post-squash tree already tested green on source PR — heavy jobs correctly skipped. Gate green."
  exit 0
fi
```

## Safety

The job uses `set +e` and empty-string guards on every external lookup, so any error path lands on `skip=false` (fall-open). The optimization only fires when the equivalence is **provable** — never on guesswork.

Fall-open scenarios — full CI still runs:

| Scenario | Detected by |
|---|---|
| Non-squash merge (merge commit / rebase merge) | Subject has no `(#N)` |
| Direct push to main (admin override, hotfix) | Same — no `(#N)` |
| PR was not up-to-date with main at merge time | Squash tree ≠ PR head tree |
| PR's last CI run failed/cancelled/missing | `conclusion != "success"` |
| Force-push to PR mid-merge | PR `headRefOid` no longer matches the tested SHA |
| `gh api` rate-limited or down | Empty string → `skip=false` |
| `ci.yml` itself was edited between PR-CI and merge | Workflow is in the tree → tree differs |

Branch protection contract is unchanged: `CI gate` still produces a status on every push-to-main SHA (it just reports `success` via skip-on-skip when the tree was already tested).

## Coverage I deliberately do NOT add in this PR

- **Drift detection** (runner OS image updates, action version rollouts, external dep changes). The window between PR CI and squash-merge is minutes, so this class of drift is not a concern for the redundant-skip itself. If you want belt-and-braces, a follow-up PR could add a daily `schedule: cron: '0 4 * * *'` trigger that forces `skip=false`. Not in scope here.
- **Build-matrix dedup against canary** (Option 2 from the brainstorm). Independent change; can land separately.

## Verification

This PR can only prove itself once it lands and the next PR merge happens after it. The first merge after this lands will exercise the happy path (tree should match → all heavy jobs skip → gate green). I'll watch that merge to confirm before declaring victory.

Synthetic verification of the bash logic is implicit in the YAML guards — every external command's output is checked for empty-string before being compared, and the whole step runs under `set +e`.

## Expected savings

~57 job-minutes per merge (the full `ci.yml (push)` cost). Wall-clock on `main` after a green PR drops from ~12 minutes to ~30 seconds for the redundant-skip case. `canary.yml` is unaffected and continues to publish unsigned + signed builds + updater manifests as today.
