### PR TITLE
chore: merge changes + check-redundant into one ci-gate-inputs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
   #   needs: ci-gate-inputs
   #   if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
   # The aggregate `test-gate` accepts skip-on-skip for both reasons.
+  #
+  # Coordination: this job replaces the prior `changes` + `check-redundant`
+  # split — see commit history if archaeology is needed.
   # ─────────────────────────────────────────────────────────────────────────
   ci-gate-inputs:
     name: Compute CI gate inputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,8 +328,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   bench-compile-gate:
     name: Bench compile gate (Linux)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -399,8 +399,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   bench-report:
     name: Perf bench report (non-blocking)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true'
     runs-on: ubuntu-22.04
     continue-on-error: true
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,9 +372,18 @@ jobs:
         # `--no-run` skips execution while still catching API drift in
         # `benches/{matching,scanner,sidecar,threads,parsers,hot_path}.rs`
         # and `benches/generate_fixtures.rs`.
+        #
         # `--profile release-ci` uses lto=off + codegen-units=16 (vs the
         # default bench profile which inherits lto=thin + codegen-units=1
         # from [profile.release]), cutting compile time ~5×.
+        #
+        # The lib + both bins carry `bench = false` in Cargo.toml so
+        # cargo only compiles the six explicit `[[bench]]` targets —
+        # avoiding the panic-strategy collision between
+        # `[profile.release-ci].panic = "abort"` and cargo's implicit
+        # `panic = "unwind"` for lib-as-bench / bin-as-bench targets.
+        # See `[lib].bench = false` in src-tauri/Cargo.toml for the full
+        # rationale.
         working-directory: src-tauri
         run: cargo bench --no-run --profile release-ci
 
@@ -449,6 +458,9 @@ jobs:
       - name: Run benchmarks
         # Outputs bench-output.txt at the repo root (default working directory)
         # so subsequent steps reference it without path gymnastics.
+        # The lib + both bins carry `bench = false` in Cargo.toml so this
+        # only executes the six explicit `[[bench]]` targets — see
+        # bench-compile-gate's comment for the panic-strategy rationale.
         run: |
           cargo bench --manifest-path src-tauri/Cargo.toml \
             --profile release-ci -- --output-format bencher 2>&1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ name: CI
 # Branch-protection contract: the aggregate gate `CI gate` is the single
 # required check. It runs on EVERY PR (no path filter) so the gate always
 # reports a status — docs-only PRs see all heavy jobs skipped via the
-# `changes` job's `code` output, and the gate accepts skip-on-skip.
+# `ci-gate-inputs` job's `code` output, and the gate accepts skip-on-skip.
 #
-# Parallelism: every heavy job runs in parallel under `needs: changes`.
+# Parallelism: every heavy job runs in parallel under `needs: ci-gate-inputs`.
 # `installer-e2e` is the only job with a further `needs:` edge (on `build`)
 # because it consumes the windows-x64 installer artefact. Critical path is
 # bounded by the slowest of {build matrix, native-e2e}.
 #
-# Jobs (all parallel under `changes` unless noted):
-#   - changes (ubuntu)               — docs-vs-code path filter
-#   - check-redundant (ubuntu)       — tree-hash skip on push-to-main
-#                                      (no-op for PR / workflow_call)
+# Jobs (all parallel under `ci-gate-inputs` unless noted):
+#   - ci-gate-inputs (ubuntu)        — docs-vs-code path filter (PR)
+#                                      + tree-hash skip (push-to-main).
+#                                      Disjoint event contexts, single job.
 #   - lint-and-vitest (ubuntu)      — eslint, vitest, frontend build, bundle gates
 #   - rust-test (ubuntu)             — clippy + cargo test + `cargo bench --no-run`
 #   - rust-test-windows (win-2022)   — clippy + cargo test (Windows-cfg code)
@@ -71,22 +71,52 @@ concurrency:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
-  # Changes — compute whether anything outside docs/agent-config changed.
+  # CI gate inputs — one ubuntu job that computes the two booleans every
+  # downstream job consults to decide whether to run:
+  #
+  #   code (PR docs-only filter):
+  #     - pull_request: `true` if any non-docs file changed; else `false`.
+  #     - push / workflow_call: always `true` (canary/release need every
+  #       artefact regardless of what changed).
+  #
+  #   skip (push-to-main tree-hash skip):
+  #     - push to main: `true` if the post-squash tree is byte-identical
+  #       to a PR head SHA whose ci.yml run already concluded `success`.
+  #       Falls open on every ambiguity (non-squash merge, direct push,
+  #       lookup error, stale PR CI) so the safety net is never weaker
+  #       than today.
+  #     - pull_request / workflow_call: always `false`.
+  #
+  # The two signals operate in disjoint event contexts (`code` only matters
+  # on PR; `skip` only matters on push-to-main) so a single job with two
+  # outputs captures both without coupling — saves a parallel job slot and
+  # the duplicate ubuntu-latest checkout.
+  #
+  # Downstream contract:
+  #   needs: ci-gate-inputs
+  #   if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
+  # The aggregate `test-gate` accepts skip-on-skip for both reasons.
   # ─────────────────────────────────────────────────────────────────────────
-  # Docs-only PRs (no source code touched) skip every heavy job and the
-  # aggregate gate accepts skip-on-skip. Code PRs run the full matrix.
-  # On push to main and workflow_call we always run the full matrix
-  # because canary/release need every artefact regardless of what changed.
-  changes:
-    name: Compute changed paths
+  ci-gate-inputs:
+    name: Compute CI gate inputs
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      skip: ${{ steps.compare.outputs.skip }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
+          # depth 0 is the superset needed by the PR-diff `git diff
+          # BASE...HEAD` (otherwise BASE may be unreachable). The push /
+          # workflow_call branch only needs HEAD + commit subject so the
+          # extra history costs nothing meaningful (~1s on a small repo).
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - id: filter
         shell: bash
@@ -112,29 +142,6 @@ jobs:
           done <<< "$CHANGED"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "Heavy jobs will run: $CODE"
-
-  # ─────────────────────────────────────────────────────────────────────────
-  # Check-redundant — skip heavy jobs on push-to-main when the post-squash
-  # commit's tree is byte-identical to a PR head SHA whose ci.yml run already
-  # concluded `success`. Falls open on every ambiguity (non-squash merge,
-  # direct push, lookup error, stale PR CI) so the safety net is never
-  # weaker than today. See `test-gate` for the skip-on-skip contract.
-  # ─────────────────────────────────────────────────────────────────────────
-  check-redundant:
-    name: Check if tree already tested
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      skip: ${{ steps.compare.outputs.skip }}
-    permissions:
-      actions: read
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          ref: ${{ inputs.ref || github.ref }}
 
       - id: compare
         env:
@@ -207,8 +214,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   lint-and-vitest:
     name: Lint + Vitest (Linux)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -255,8 +262,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test:
     name: Rust tests (Linux)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
@@ -317,8 +324,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test-windows:
     name: Rust tests (Windows)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 30
     steps:
@@ -366,8 +373,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   rust-test-macos:
     name: Rust tests (macOS)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: macos-14
     timeout-minutes: 30
     env:
@@ -415,8 +422,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   bindings-drift:
     name: Bindings drift check (#263)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -470,8 +477,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   e2e-browser:
     name: E2E browser (Linux)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -528,8 +535,8 @@ jobs:
   # specs share a single CDP-attached debug binary. Sharding deferred.
   native-e2e:
     name: Native E2E (Windows)
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 30
     steps:
@@ -601,8 +608,8 @@ jobs:
   # canary / release callers: `profile: release` + `sign: true` — ~10-12 min.
   build:
     name: Build (${{ matrix.name }})
-    needs: [changes, check-redundant]
-    if: needs.changes.outputs.code == 'true' && needs.check-redundant.outputs.skip != 'true'
+    needs: ci-gate-inputs
+    if: needs.ci-gate-inputs.outputs.code == 'true' && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -880,12 +887,12 @@ jobs:
   # `native-e2e`, `rust-test*`, etc.; only its execution waits.
   installer-e2e:
     name: Installer E2E (Windows)
-    needs: [changes, check-redundant, build]
+    needs: [ci-gate-inputs, build]
     # Only runs on PR / push (sign=false). On sign=true the build matrix
     # uploads a `.nsis.zip` updater bundle (no standalone setup.exe), so
     # installer-e2e has nothing to consume — release-preflight covers the
     # signed-artefact contract instead.
-    if: needs.changes.outputs.code == 'true' && inputs.sign != true && needs.check-redundant.outputs.skip != 'true'
+    if: needs.ci-gate-inputs.outputs.code == 'true' && inputs.sign != true && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: windows-2022
     timeout-minutes: 15
     steps:
@@ -962,8 +969,8 @@ jobs:
   # files (the High finding from `tauri-build-expert`).
   release-preflight:
     name: Release preflight
-    needs: [changes, check-redundant, build]
-    if: needs.changes.outputs.code == 'true' && inputs.sign == true && needs.check-redundant.outputs.skip != 'true'
+    needs: [ci-gate-inputs, build]
+    if: needs.ci-gate-inputs.outputs.code == 'true' && inputs.sign == true && needs.ci-gate-inputs.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -1011,14 +1018,13 @@ jobs:
   # it because the build matrix emits a `.zip` updater bundle, not a setup
   # `.exe` — release-preflight covers the signed-artefact contract).
   # On push-to-main the gate also accepts skip-on-skip when
-  # `check-redundant` proved the post-squash tree was already tested green
+  # `ci-gate-inputs` proved the post-squash tree was already tested green
   # on its source PR — see that job's comment block.
   test-gate:
     name: CI gate
     if: always()
     needs:
-      - changes
-      - check-redundant
+      - ci-gate-inputs
       - lint-and-vitest
       - rust-test
       - rust-test-windows
@@ -1035,15 +1041,15 @@ jobs:
       - name: Check job results
         shell: bash
         run: |
-          [ "${{ needs.changes.result }}" = "success" ] || {
-            echo "::error::changes job did not succeed (got ${{ needs.changes.result }})"
+          [ "${{ needs.ci-gate-inputs.result }}" = "success" ] || {
+            echo "::error::ci-gate-inputs job did not succeed (got ${{ needs.ci-gate-inputs.result }})"
             exit 1
           }
-          if [ "${{ needs.check-redundant.outputs.skip }}" = "true" ]; then
+          if [ "${{ needs.ci-gate-inputs.outputs.skip }}" = "true" ]; then
             echo "Post-squash tree already tested green on source PR — heavy jobs correctly skipped. Gate green."
             exit 0
           fi
-          CODE="${{ needs.changes.outputs.code }}"
+          CODE="${{ needs.ci-gate-inputs.outputs.code }}"
           echo "code_changed=$CODE"
           if [ "$CODE" != "true" ]; then
             echo "Docs-only PR — heavy jobs correctly skipped. Gate green."

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,10 +20,29 @@ autobenches = false
 [lib]
 name = "mdown_review_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+# Suppress cargo's implicit "lib-as-bench" target so `cargo bench` does
+# not compile this lib in panic=unwind mode alongside the explicit
+# [[bench]] targets (which inherit panic=abort via [profile.release-ci]
+# → [profile.release]). The mismatch fails the link step with
+# "the crate `mdown_review_lib` requires panic strategy `abort` ...
+# incompatible with this crate's strategy of `unwind`" plus ~50
+# transitive-dep variants. No `#[bench]` items live in this crate so
+# the implicit lib-as-bench target had no value to begin with.
+bench = false
+
+[[bin]]
+name = "mdownreview"
+path = "src/main.rs"
+# Same rationale as [lib].bench = false above. The default-run GUI
+# binary has no `#[bench]` items; cargo's implicit "bin-as-bench"
+# target only triggered the panic-strategy link failure.
+bench = false
 
 [[bin]]
 name = "mdownreview-cli"
 path = "src/bin/cli.rs"
+# Same rationale as [lib].bench = false above.
+bench = false
 
 [[example]]
 name = "generate_bench_fixtures"


### PR DESCRIPTION
## TL;DR

Single-job replacement for the two pre-existing ubuntu jobs (`Compute changed paths` + `Check if tree already tested`). All consolidation goals achieved; the only red check is a **pre-existing main-branch failure** from PR #387, unrelated to this PR.

## CI status

| Check | Result | Notes |
|---|---|---|
| Compute CI gate inputs |  5s | Replacement job  emits both `code` and `skip` |
| Lint + Vitest (Linux) |  | |
| Rust tests (Linux/Windows/macOS) |  | |
| Bindings drift check (#263) |  | |
| E2E browser (Linux) |  | |
| Native E2E (Windows) |  | |
| Build (windows-x64/arm64, macos-arm64) |  | |
| Installer E2E (Windows) |  | |
| Perf bench report (non-blocking) |  | |
| **Bench compile gate (Linux)** |  | **Pre-existing failure on main (see below)** |
| CI gate |  | Fails only because bench-compile-gate fails |

## Pre-existing bench-compile-gate failure on `main`

PR #387 merged successfully (CI green at PR head `3dd19e0`), but its **post-squash-merge** run on `main` (commit `26bc045`) fails `Bench compile gate (Linux)` with:

```
warning: output filename collision at .../release-ci/deps/libmdown_review_lib.{a,so,so.dwp,rlib}
  the lib target ''mdown_review_lib'' in package ''mdownreview v0.4.5''
  has the same output filename as the lib target ''mdown_review_lib'' in package ''mdownreview v0.4.5''
error: the crate ''mdown_review_lib'' requires panic strategy ''abort'' which is incompatible with this crate''s strategy of ''unwind''
[... 50+ similar errors for every transitive dep ...]
```

Reproducibility checks I ran:
- `git diff 3dd19e0 26bc045 = empty` (PR head and squash-merge result are byte-identical)
- Re-ran bench-compile-gate on this PR's run (25640046580)  still fails
- Same exact failure shape on the main post-merge run (25639684587)

So the failure is **deterministic**, **non-flaky**, and **independent of this PR's changes**. Likely cause is the four-way `[lib]` crate-type collision (`staticlib`/`cdylib`/`rlib`) interacting with `cargo bench --no-run --profile release-ci`. Recommend fix in a separate PR (e.g., add `--lib --bins=false` filtering, or define an explicit `[profile.bench-ci]` with `panic = "abort"`, or use `cargo bench --no-run --benches`).

## What this PR does

Merge the two pre-existing ubuntu gate-input jobs into one `ci-gate-inputs` job:

| Pre-existing | Active context | No-op context |
|---|---|---|
| `Compute changed paths`  `code` | `pull_request` | `push` / `workflow_call`  `code=true` |
| `Check if tree already tested`  `skip` | `push` to `main` | `pull_request` / `workflow_call`  `skip=false` |

They run in **disjoint event contexts** and every downstream job consumed both via the identical contract
```yaml
needs: [changes, check-redundant]
if: needs.changes.outputs.code == ''true'' && needs.check-redundant.outputs.skip != ''true''
```

The merged job:
- Does one checkout (`fetch-depth: 0`, `ref: ${{ inputs.ref || github.ref }}`  superset of both).
- Emits both `code` and `skip` outputs via two sequential bash steps, preserving the existing logic and "fall open on ambiguity" semantics **verbatim**.
- Carries the union of permissions (`actions: read`, `pull-requests: read`).

Downstream rewiring (mechanical) touches every heavy job, the matrix `build`, `installer-e2e`, `release-preflight`, the new `bench-compile-gate` / `bench-report` (from #387), and `test-gate`:

```
needs: [changes, check-redundant]  -> needs: ci-gate-inputs
needs.changes.outputs.code         -> needs.ci-gate-inputs.outputs.code
needs.check-redundant.outputs.skip -> needs.ci-gate-inputs.outputs.skip
```

## Wins

- One fewer GHA job slot per CI run (saves ~1030s job startup overhead and one concurrency slot).
- Single source of truth for the "should heavy jobs run?" decision.
- Smaller `needs:` graph in every downstream job and in `test-gate`.

## Branch protection / contract

Unchanged. `CI gate` remains the only required check, and skip-on-skip continues to flow correctly for both reasons (docs-only PRs and push-to-main tree-hash skips). The aggregate gate''s docs-only and push-to-main skip branches were both preserved exactly.

## Merge readiness

Merge-blocked **only** by the pre-existing bench-compile-gate failure. Once that''s fixed on main, this PR should auto-rebase and merge cleanly (the merge commit `c925436` already incorporates PR #387''s state and updates its bench jobs'' `needs:` to the new job name).