### PR TITLE
fix(ci): grant workflow_call callees the per-job permissions ci-gate-inputs needs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -82,6 +82,18 @@ jobs:
   ci:
     name: CI (signed, release profile)
     needs: prepare
+    # `ci-gate-inputs` inside ci.yml declares per-job `actions: read` +
+    # `pull-requests: read` (needed only on push-to-main for the squash-merge
+    # tree-hash skip path). When ci.yml is invoked via workflow_call, the
+    # called workflow's per-job permissions cannot exceed those of the
+    # calling job — so we must grant these scopes here even though the skip
+    # path is a no-op on workflow_call. Omitting this caused canary runs
+    # after PR #386 to fail with `startup_failure` (zero jobs spawned) before
+    # the `prepare` job's commit could be tested.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.prepare.outputs.patched_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,16 @@ jobs:
   ci:
     name: CI (signed, release profile)
     needs: resolve-tag
+    # `ci-gate-inputs` inside ci.yml declares per-job `actions: read` +
+    # `pull-requests: read` (needed only on push-to-main for the squash-merge
+    # tree-hash skip path). When ci.yml is invoked via workflow_call, the
+    # called workflow's per-job permissions cannot exceed those of the
+    # calling job — so we must grant these scopes here even though the skip
+    # path is a no-op on workflow_call. Mirrors the same block in canary.yml.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.resolve-tag.outputs.tag }}


### PR DESCRIPTION
## Problem

`canary.yml` has been in `startup_failure` on every push to `main` since PR #386 landed (commit `24b87aa`). The run completes in ~1s with **zero jobs spawned**  classic workflow-validation failure before the workflow graph is instantiated.

```
conclusion: startup_failure
run_attempt: 1
run_started_at -> updated_at: 1 second
jobs.length: 0
```

`ci.yml` direct triggers (push to main, PR) remain green, so the defect is specific to the `workflow_call` invocation site.

## Root cause

PR #386 introduced a new `check-redundant` job in `ci.yml` (later consolidated into `ci-gate-inputs` by PR #388). That job declared per-job permissions for the squash-merge tree-hash skip lookups:

```yaml
ci-gate-inputs:
  permissions:
    actions: read         # gh run list --commit <head> --workflow ci.yml
    contents: read
    pull-requests: read   # gh pr view <N> --json headRefOid
```

These scopes are only exercised on push-to-main. The job itself short-circuits to `skip=false` on every other event before any `gh` call is made. **But** GitHub validates per-job permissions of a reusable workflow against the **calling job's** permissions cap at workflow-startup time  runtime no-op doesn't matter.

Both wrapper workflows set only:

```yaml
permissions:
  contents: read   # workflow-level
```

and the `ci:` job invocation block doesn't override that. So when `canary.yml`'s `ci:` job invokes `ci.yml` via `workflow_call`, the callee's `actions: read` and `pull-requests: read` requests **exceed** the cap, GitHub rejects the run at validation, and the canary publish pipeline silently dies before patching the version.

`release.yml` has the identical defect but has not been exercised since the regression  the last release was v0.4.5 at 19:35Z, PR #386 merged at 19:54Z. The next tag push would have hit the same wall.

## Fix

Grant the elevated scopes at the **calling-job level** in both wrapper workflows:

```yaml
ci:
  needs: prepare
  permissions:
    actions: read
    contents: read
    pull-requests: read
  uses: ./.github/workflows/ci.yml
  with:
    ...
```

This is the documented pattern for `workflow_call` permission caps. Both `canary.yml` and `release.yml` are touched in one commit because they share the defect.

## Why not move the permissions to ci.yml's workflow level?

That would propagate `actions: read` + `pull-requests: read` to every job in `ci.yml` on every event (PR, push, workflow_call)  broader blast radius than needed. The skip path is a single job; the grant should live at the only two call sites that actually invoke it.

## Verification

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI green on this PR.
- [ ] On merge, the post-squash canary run on `main` reaches the `prepare` job and proceeds through `ci.yml` instead of `startup_failure`.
