### PR TITLE
fix(publish-release): quote SKILL.md description so YAML parses

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-release
-description: Use when the user says "release", "tag", "publish", "ship a new version", "bump version", or runs `/publish-release [major|minor|patch]`. Fully autonomous — never prompts. Default bump: patch.
+description: 'Use when the user says "release", "tag", "publish", "ship a new version", "bump version", or runs `/publish-release [major|minor|patch]`. Fully autonomous — never prompts. Default bump: patch.'
 ---
 
 **RIGID. Fully autonomous — never calls `ask_user`.** Owns the full release lifecycle: version bump → CHANGELOG → release PR → tag → signed installers → published GitHub release. Pairs with `ci.yml` (called from `release.yml` via `workflow_call`).


### PR DESCRIPTION
The `description` value in `.claude/skills/publish-release/SKILL.md` contained `Default bump: patch.`  the bare `': '` made the skill loader's YAML parser interpret it as a nested mapping inside a compact mapping, so the skill failed to load:

```n.claude\skills\publish-release\SKILL.md: failed to parse YAML frontmatter: Nested mappings are not allowed in compact mappings at line 2, column 14:

description: Use when the user says `release`, `tag`, `publish`, `ship a new ve
             ^
```n
Wrapping the value in single quotes preserves the embedded double quotes and backticks while disambiguating the inner colon. Verified with `yaml.safe_load`  frontmatter now round-trips cleanly. No other skill in `.claude/skills/` has the same pattern (verified via `grep '^description:.*: '`).