### PR TITLE
fix(canary): draft -> upload -> undraft to satisfy release immutability

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -127,8 +127,13 @@ jobs:
         run: |
           set -e
           NAME="mdownreview-${VERSION}"
+          # Create as draft so subsequent `gh release upload` calls succeed
+          # under "Enable release immutability" — published releases reject
+          # asset uploads (HTTP 422). The release is undrafted in a follow-up
+          # step after every asset is verified present, mirroring release.yml.
           gh release view "$TAG" &>/dev/null || \
           gh release create "$TAG" \
+            --draft \
             --prerelease \
             --title "Canary Build #${GITHUB_RUN_NUMBER} (${GITHUB_SHA::7})" \
             --notes "Canary build from main at \`${GITHUB_SHA::7}\`."
@@ -161,6 +166,11 @@ jobs:
                 ;;
             esac
           done
+          # Undraft only after every asset is uploaded — required by
+          # "Enable release immutability" (published releases reject further
+          # uploads). Matches the draft → upload → undraft pattern in
+          # release.yml.
+          gh release edit "$TAG" --draft=false
 
   # ── Update mutable `canary` tag → manifest pointer ──────────────────────
   publish-canary-manifest:
@@ -226,11 +236,17 @@ jobs:
           gh release delete canary --yes 2>/dev/null || true
           git tag -f canary
           git push origin canary --force
+          # Create as draft so the manifest upload succeeds under
+          # "Enable release immutability"; undraft only after the manifest
+          # is attached so auto-update clients never observe a half-published
+          # canary pointer.
           gh release create canary \
+            --draft \
             --prerelease \
             --title "Canary (latest)" \
             --notes "Points to the latest canary build. Auto-updated on each main push."
           gh release upload canary /tmp/canary-latest.json --clobber
+          gh release edit canary --draft=false
           echo "Published canary-latest.json pointing to ${TAG}"
 
       - name: Clean up old canary releases (keep last 5)


### PR DESCRIPTION
## Problem

Recently enabling **Settings -> Code security -> `Enable release immutability`** broke the canary build. Latest run [25968102530](https://github.com/dryotta/mdownreview/actions/runs/25968102530) failed at *Publish canary-194 / Create canary release + upload assets* with:

```
HTTP 422: Cannot upload assets to an immutable release.
(https://uploads.github.com/repos/dryotta/mdownreview/releases/323739972/assets?label=&name=mdownreview-0.4.6-194-windows-x64.zip)
```

Both publish jobs in `canary.yml` created the release as *published* first, then uploaded assets in a follow-up loop. Under release immutability, published releases reject any further asset uploads, deletes, or `--clobber` replacements.

## Fix

Mirror the pattern `release.yml` already uses for tagged `v*` releases: **draft -> upload -> undraft**. Drafts remain mutable, so all asset operations succeed, and the release is only published (becoming immutable) after every asset is verified present.

- `publish-canary-release`: `gh release create canary-N --draft --prerelease ...` -> upload every zip/dmg/sig -> `gh release edit canary-N --draft=false` at the end of the same step.
- `publish-canary-manifest`: same treatment for the mutable `canary` pointer release - create as draft, attach `canary-latest.json`, then undraft. Small bonus: auto-update clients never observe a half-published canary pointer anymore (previously there was a small window where the new `canary` release existed with no manifest asset attached).

## Why not just turn off the setting

Disabling release immutability works but trades away the supply-chain integrity guarantee (asset replay protection) for *all* releases including tagged `v*` releases. `release.yml` is already immutability-compatible, so the cleaner fix is to bring `canary.yml` in line.

## Verification

- `+16 / -0` line diff, no logic changes beyond the draft toggle.
- Job ordering unchanged - `publish-canary-manifest` still gates on `publish-canary-release`.
- The `cleanup` job's `gh release delete --cleanup-tag` calls are unaffected (deletion of immutable releases is still permitted; only modification is blocked).
- End-to-end can only be verified on merge to `main` (canary only triggers on push to main). Recommend merging during a quiet window and watching the next canary run.