### PR TITLE
feat(skill): perf-trend  render bench history report across recent main CI runs

### DIFF
--- a/.claude/skills/perf-trend/SKILL.md
+++ b/.claude/skills/perf-trend/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: perf-trend
+description: Use when the user asks about benchmark trends, says "perf trend", "/perf-trend", "show bench history", "check if perf is regressing", or "compare benches across commits". Reads the `bench-output` artifact from recent successful `ci.yml` runs on `main`, parses criterion bencher output, and renders a markdown report with per-bench history, budget status, and regression callouts.
+---
+
+# perf-trend
+
+Generates a markdown trend report from the perf-bench artifacts produced by the
+`bench` job in `ci.yml`. Bench artifacts retain for 14 days, so the report's
+natural window is `--days 14`.
+
+## When to invoke
+
+- User says "perf trend", "show bench history", "are we regressing on perf",
+  "check the last week's benches", or runs `/perf-trend`.
+- After a suspected hot-path change has landed on `main` and the user wants to
+  see whether the next `bench` run measured a delta.
+- As a pre-release check before tagging — surfaces any silently-failing
+  bench harness (a panic in one harness short-circuits `cargo bench` and
+  drops the rest of the suite from the artifact).
+
+## How
+
+One command, no flags needed for the default 14-day window on `main`:
+
+```bash
+npm run perf:trend
+```
+
+Or with overrides:
+
+```bash
+node scripts/perf-trend.mjs --days 7 --runs 20
+node scripts/perf-trend.mjs --branch canary-build/canary-194
+node scripts/perf-trend.mjs --summary   # writes to $GITHUB_STEP_SUMMARY
+```
+
+Flags:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--days N` | 14 | Cutoff in days; older runs are filtered out. Cap is effectively the artifact retention (14 days). |
+| `--runs M` | 30 | Max number of `gh run list` rows to consider before the day filter. Bump for sparse branches. |
+| `--workflow F` | `ci.yml` | Workflow file name. |
+| `--branch B` | `main` | Branch filter for `gh run list`. |
+| `--summary` | off | Append the report to `$GITHUB_STEP_SUMMARY` instead of stdout. |
+
+Requires `gh` authenticated against the current repo. Reads
+`.github/workflows/ci.yml` for the canonical budget table (the script parses
+the `declare -A BUDGETS` block, so updates to the workflow's budgets flow
+through automatically).
+
+## Report sections
+
+The renderer emits four sections in order:
+
+1. **⚠️ Missing budgeted benches** — present only if any bench named in the
+   workflow's `BUDGETS` table is absent from every artifact in the window.
+   This is the headline signal for a silently-failing harness. The CI summary
+   step is silent about missing benches; this skill exists in large part to
+   surface them.
+2. **Summary** — one row per bench seen: latest measurement, budget,
+   per-window median, % delta vs median, status (`✅` / `⚠️ over budget`),
+   ASCII sparkline of all samples (left=oldest, right=newest).
+3. **Movers** — benches whose latest sample is ≥10% off their window median
+   (requires ≥3 samples to avoid noise). Split into Regressions and
+   Improvements. Each row cites the commit SHA + PR title of the latest run.
+4. **Per-bench history** — `<details>` block per bench with the full series
+   of (date, commit, ns/iter, ± deviation, title) rows.
+
+## Triage hints
+
+When the report shows…
+
+- **Missing budgeted benches** — download a recent `bench-output` artifact
+  manually (`gh run download <id> --name bench-output`) and grep for `panicked
+  at` / `error: bench failed`. Fix the failing bench harness; otherwise the
+  missing benches' budgets are unenforced.
+- **A bench newly over budget** — cross-reference the per-bench history
+  table for the SHA where the value first crossed the budget. That commit is
+  the prime suspect. Open a perf issue, link the report excerpt.
+- **A bench oscillating ±5–10%** — usually runner noise (release-ci profile
+  is lto=off so codegen variance is real). Don't file an issue unless the
+  trend persists across ≥5 samples on the over-budget side.
+- **The whole window is one commit** — the tree-hash skip on `push` to
+  `main` (see `ci-gate-inputs.outputs.skip`) elides the bench job on
+  byte-identical squash-merges. This is intentional; widen `--days` or
+  re-run on a PR branch.
+
+## Notes
+
+- The script never writes to the repo or opens issues; it only reads. Acting
+  on findings (filing issues, opening PRs) is for the user or a follow-on
+  skill.
+- Bench output capture in `ci.yml` is `2>&1 | tee bench-output.txt`, so the
+  artifact also contains compiler warnings and any panic backtrace. The
+  parser tolerates this noise.
+- Bench IDs in the report are the raw criterion IDs (e.g.
+  `hot_path/get_file_comments_large`), matching the keys in the workflow's
+  `BUDGETS` table — not the human-readable names in `docs/performance.md`.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test-exploratory-loop:sync": "tsx .claude/skills/test-exploratory-loop/runner/sync.ts",
     "audit:zoom-cascade": "node scripts/audit-zoom-cascade.mjs",
     "bench:cli": "cd src-tauri && cargo bench",
-    "bench:cli:script": "pwsh scripts/bench-cli.ps1"
+    "bench:cli:script": "pwsh scripts/bench-cli.ps1",
+    "perf:trend": "node scripts/perf-trend.mjs"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "0.18.1",

--- a/scripts/perf-trend.mjs
+++ b/scripts/perf-trend.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+// Generate a perf-bench trend report across recent ci.yml runs on `main`.
+//
+// Data flow:
+//   1. `gh run list --workflow ci.yml --branch main --status success`
+//   2. For each run, `gh run download <id> --name bench-output` (if present —
+//      skip-on-skip runs and pre-bench-job runs have no artifact).
+//   3. Parse criterion `--output-format bencher` output:
+//        test <bench_id> ... bench:   N,NNN ns/iter (+/- M,MMM)
+//   4. Cross-reference each run with the commit SHA, timestamp, and PR title.
+//   5. Render a markdown report covering all benches present in any run inside
+//      the window, with the budget (parsed from .github/workflows/ci.yml) and
+//      a delta-vs-median column for regression spotting.
+//
+// Output: markdown to stdout, OR to $GITHUB_STEP_SUMMARY if `--summary` is
+// passed (lets a future CI step reuse the same renderer without rewriting).
+//
+// Usage:
+//   node scripts/perf-trend.mjs [--days N] [--runs M] [--workflow ci.yml]
+//                               [--branch main] [--summary]
+//
+// Defaults: --days 14 --runs 30 (artifacts retain 14 days, more runs is
+// harmless — they just get filtered by the days window).
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const DAYS = args.days ?? 14;
+const RUNS = args.runs ?? 30;
+const WORKFLOW = args.workflow ?? "ci.yml";
+const BRANCH = args.branch ?? "main";
+const SUMMARY = args.summary ?? false;
+const ARTIFACT_NAME = "bench-output";
+const ARTIFACT_FILE = "bench-output.txt";
+const WORKSPACE = process.cwd();
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--summary") { out.summary = true; continue; }
+    if (a === "--days") { out.days = Number(argv[++i]); continue; }
+    if (a === "--runs") { out.runs = Number(argv[++i]); continue; }
+    if (a === "--workflow") { out.workflow = argv[++i]; continue; }
+    if (a === "--branch") { out.branch = argv[++i]; continue; }
+    if (a === "--help" || a === "-h") {
+      process.stdout.write(
+        "Usage: node scripts/perf-trend.mjs [--days N] [--runs M] " +
+        "[--workflow ci.yml] [--branch main] [--summary]\n",
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown arg: ${a}`);
+  }
+  return out;
+}
+
+function sh(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...opts,
+  });
+  if (res.error) throw res.error;
+  return res;
+}
+
+// Parse BUDGETS associative array out of .github/workflows/ci.yml. Keeps the
+// budget table single-sourced; if the workflow's budgets change, this script
+// follows automatically.
+function loadBudgets() {
+  const yml = fs.readFileSync(
+    path.join(WORKSPACE, ".github", "workflows", "ci.yml"),
+    "utf8",
+  );
+  const start = yml.indexOf("declare -A BUDGETS=(");
+  if (start < 0) return {};
+  const end = yml.indexOf(")", start);
+  const block = yml.slice(start, end);
+  const out = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/\["([^"]+)"\]=(\d+)/);
+    if (m) out[m[1]] = Number(m[2]);
+  }
+  return out;
+}
+
+function listRuns() {
+  // --status success only — we want clean data, no half-finished or failed runs.
+  const res = sh("gh", [
+    "run", "list",
+    "--workflow", WORKFLOW,
+    "--branch", BRANCH,
+    "--status", "success",
+    "--limit", String(RUNS),
+    "--json", "databaseId,headSha,createdAt,displayTitle",
+  ]);
+  if (res.status !== 0) {
+    throw new Error(`gh run list failed: ${res.stderr}`);
+  }
+  const all = JSON.parse(res.stdout);
+  const cutoff = Date.now() - DAYS * 24 * 60 * 60 * 1000;
+  return all.filter((r) => new Date(r.createdAt).getTime() >= cutoff);
+}
+
+function downloadArtifact(runId, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  const res = sh("gh", [
+    "run", "download", String(runId),
+    "--name", ARTIFACT_NAME,
+    "--dir", destDir,
+  ]);
+  if (res.status !== 0) {
+    // Missing artifact (skipped run, retention expired, bench job didn't exist
+    // yet) is normal — just signal absence to the caller.
+    return null;
+  }
+  const p = path.join(destDir, ARTIFACT_FILE);
+  if (!fs.existsSync(p)) return null;
+  return fs.readFileSync(p, "utf8");
+}
+
+// criterion --output-format bencher produces one line per measurement:
+//   test <bench_id> ... bench:    N,NNN ns/iter (+/- M,MMM)
+const BENCHER_RE = /^test\s+(\S+)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns\/iter\s+\(\+\/-\s*([\d,]+)\)/;
+
+function parseBencherOutput(text) {
+  const out = {};
+  for (const line of text.split("\n")) {
+    const m = line.match(BENCHER_RE);
+    if (!m) continue;
+    out[m[1]] = {
+      ns: Number(m[2].replace(/,/g, "")),
+      dev: Number(m[3].replace(/,/g, "")),
+    };
+  }
+  return out;
+}
+
+function fmtNs(ns) {
+  if (ns >= 1_000_000) return `${(ns / 1_000_000).toFixed(2)} ms`;
+  if (ns >= 1_000) return `${(ns / 1_000).toFixed(2)} µs`;
+  return `${ns} ns`;
+}
+
+function median(nums) {
+  if (nums.length === 0) return null;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function fmtPct(delta) {
+  const sign = delta >= 0 ? "+" : "";
+  return `${sign}${delta.toFixed(1)}%`;
+}
+
+// Tiny ASCII sparkline: 8 levels, normalised across the bench's own range.
+const BLOCKS = "▁▂▃▄▅▆▇█";
+function sparkline(values) {
+  if (values.length === 0) return "";
+  const lo = Math.min(...values);
+  const hi = Math.max(...values);
+  if (hi === lo) return BLOCKS[0].repeat(values.length);
+  return values
+    .map((v) => BLOCKS[Math.min(7, Math.floor(((v - lo) / (hi - lo)) * 7.999))])
+    .join("");
+}
+
+function render({ runs, byBench, budgets, windowDays }) {
+  const lines = [];
+  lines.push(`# Perf bench trend — last ${windowDays} days`);
+  lines.push("");
+  lines.push(
+    `**Window:** ${runs.length} successful \`${WORKFLOW}\` runs on ` +
+    `\`${BRANCH}\` with bench output. ` +
+    `**Profile:** \`release-ci\` (lto=off, codegen-units=16 — expect ` +
+    `~1.5–2× slower than production \`release\`).`,
+  );
+  lines.push("");
+
+  if (runs.length === 0) {
+    lines.push("_No bench data in window._ Widen `--days` or check that the " +
+      "`bench` job is producing the `bench-output` artifact.");
+    return lines.join("\n");
+  }
+
+  // ── Missing benches ───────────────────────────────────────────────────
+  // A budgeted bench that produced no output in the entire window is a
+  // strong signal that a prior bench in `cargo bench`'s execution order
+  // panicked and short-circuited the remaining harnesses. The CI summary
+  // step is silent about this (it only prints rows for benches it sees
+  // in bench-output.txt), so surfacing it here is one of the main
+  // reasons this skill exists.
+  const seenNames = new Set(Object.keys(byBench));
+  const missingBudgeted = Object.keys(budgets)
+    .filter((b) => !seenNames.has(b))
+    .sort();
+  if (missingBudgeted.length > 0) {
+    lines.push("## ⚠️ Missing budgeted benches");
+    lines.push("");
+    lines.push(
+      `${missingBudgeted.length} budgeted bench(es) produced **no output** ` +
+      `in the last ${windowDays} days. Most common cause: an earlier bench ` +
+      `harness panicked (\`cargo bench\` stops on first failure). ` +
+      `Inspect a recent \`bench-output\` artifact for the panic.`,
+    );
+    lines.push("");
+    for (const name of missingBudgeted) {
+      lines.push(`- \`${name}\` (budget ${fmtNs(budgets[name])})`);
+    }
+    lines.push("");
+  }
+
+  // ── Summary table ─────────────────────────────────────────────────────
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Bench | Latest | Budget | Median | Δ vs median | Status | Trend |");
+  lines.push("|---|---:|---:|---:|---:|---|---|");
+
+  const benchNames = Object.keys(byBench).sort();
+  const regressions = [];
+  const improvements = [];
+
+  for (const name of benchNames) {
+    const series = byBench[name]; // [{run, ns, dev}, ...] newest first
+    if (series.length === 0) continue;
+    const latest = series[0];
+    const all = series.map((s) => s.ns);
+    const med = median(all);
+    const budget = budgets[name];
+    const deltaPct = med ? ((latest.ns - med) / med) * 100 : 0;
+
+    let status = "—";
+    if (budget != null) {
+      status = latest.ns <= budget ? "✅" : "⚠️ over budget";
+    }
+    // Reverse sparkline values so left=old, right=new (matches reading order).
+    const reversed = [...all].reverse();
+    const spark = sparkline(reversed);
+    const budgetLabel = budget != null ? fmtNs(budget) : "—";
+    lines.push(
+      `| \`${name}\` | ${fmtNs(latest.ns)} | ${budgetLabel} | ${fmtNs(med)} ` +
+      `| ${fmtPct(deltaPct)} | ${status} | \`${spark}\` |`,
+    );
+
+    if (series.length >= 3 && deltaPct >= 10) {
+      regressions.push({ name, deltaPct, latest, med, budget });
+    } else if (series.length >= 3 && deltaPct <= -10) {
+      improvements.push({ name, deltaPct, latest, med });
+    }
+  }
+  lines.push("");
+
+  // ── Movers ────────────────────────────────────────────────────────────
+  regressions.sort((a, b) => b.deltaPct - a.deltaPct);
+  improvements.sort((a, b) => a.deltaPct - b.deltaPct);
+  if (regressions.length > 0 || improvements.length > 0) {
+    lines.push("## Movers (≥10% vs median, ≥3 samples)");
+    lines.push("");
+  }
+  if (regressions.length > 0) {
+    lines.push("### Regressions");
+    lines.push("");
+    for (const r of regressions.slice(0, 5)) {
+      const sha = r.latest.run.headSha.slice(0, 8);
+      const title = r.latest.run.displayTitle;
+      lines.push(
+        `- \`${r.name}\`: ${fmtNs(r.latest.ns)} vs median ${fmtNs(r.med)} ` +
+        `(**${fmtPct(r.deltaPct)}**) — latest run ${sha} _${title}_`,
+      );
+    }
+    lines.push("");
+  }
+  if (improvements.length > 0) {
+    lines.push("### Improvements");
+    lines.push("");
+    for (const i of improvements.slice(0, 5)) {
+      const sha = i.latest.run.headSha.slice(0, 8);
+      const title = i.latest.run.displayTitle;
+      lines.push(
+        `- \`${i.name}\`: ${fmtNs(i.latest.ns)} vs median ${fmtNs(i.med)} ` +
+        `(**${fmtPct(i.deltaPct)}**) — latest run ${sha} _${title}_`,
+      );
+    }
+    lines.push("");
+  }
+
+  // ── Per-bench history ─────────────────────────────────────────────────
+  lines.push("## Per-bench history");
+  lines.push("");
+  for (const name of benchNames) {
+    const series = byBench[name];
+    if (series.length === 0) continue;
+    lines.push(`<details><summary><code>${name}</code> (${series.length} samples)</summary>`);
+    lines.push("");
+    lines.push("| Date | Commit | ns/iter | ± dev | Title |");
+    lines.push("|---|---|---:|---:|---|");
+    for (const s of series) {
+      const date = s.run.createdAt.slice(0, 16).replace("T", " ");
+      const sha = s.run.headSha.slice(0, 8);
+      const title = s.run.displayTitle.replace(/\|/g, "\\|").slice(0, 80);
+      lines.push(
+        `| ${date} | \`${sha}\` | ${fmtNs(s.ns)} | ±${fmtNs(s.dev)} | ${title} |`,
+      );
+    }
+    lines.push("");
+    lines.push("</details>");
+    lines.push("");
+  }
+
+  // ── Footer ────────────────────────────────────────────────────────────
+  lines.push("---");
+  lines.push(`Generated by \`scripts/perf-trend.mjs\` at ${new Date().toISOString()}.`);
+  return lines.join("\n");
+}
+
+function main() {
+  const budgets = loadBudgets();
+  const runs = listRuns();
+  process.stderr.write(
+    `Found ${runs.length} successful ${WORKFLOW} runs on ${BRANCH} ` +
+    `in last ${DAYS} days.\n`,
+  );
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "perf-trend-"));
+  // Newest-first ordering preserved from `gh run list`.
+  const byBench = {}; // name → [{run, ns, dev}, ...]
+  let downloaded = 0;
+  for (const r of runs) {
+    const dest = path.join(tmpRoot, String(r.databaseId));
+    const text = downloadArtifact(r.databaseId, dest);
+    if (!text) {
+      process.stderr.write(`  skip ${r.databaseId} (no artifact)\n`);
+      continue;
+    }
+    downloaded += 1;
+    const parsed = parseBencherOutput(text);
+    for (const [name, { ns, dev }] of Object.entries(parsed)) {
+      if (!byBench[name]) byBench[name] = [];
+      byBench[name].push({ run: r, ns, dev });
+    }
+    process.stderr.write(
+      `  ok   ${r.databaseId}  ${r.headSha.slice(0, 8)}  ` +
+      `${Object.keys(parsed).length} benches\n`,
+    );
+  }
+  // Best-effort tmp cleanup; we don't care if a worker still holds a handle.
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+
+  const usableRuns = runs.filter((r) =>
+    Object.values(byBench).some((s) => s.some((x) => x.run.databaseId === r.databaseId)),
+  );
+
+  const md = render({
+    runs: usableRuns,
+    byBench,
+    budgets,
+    windowDays: DAYS,
+  });
+
+  if (SUMMARY && process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
+    process.stderr.write(
+      `\nWrote ${md.split("\n").length} lines to $GITHUB_STEP_SUMMARY.\n`,
+    );
+  } else {
+    process.stdout.write(md + "\n");
+  }
+  process.stderr.write(
+    `\nDone. ${downloaded}/${runs.length} runs had bench-output artifacts; ` +
+    `${Object.keys(byBench).length} distinct benches charted.\n`,
+  );
+}
+
+main();


### PR DESCRIPTION
## What

Adds a new `perf-trend` skill plus the supporting `scripts/perf-trend.mjs` helper and `npm run perf:trend` wrapper. The skill pulls the `bench-output` artifact from recent successful `ci.yml` runs on `main`, parses the criterion bencher output, joins it with each run's commit SHA + PR title, and renders a markdown trend report.

## Why

The `bench` job's per-run job-summary table shows only **latest vs budget**. It tells you nothing about:

- whether a number is moving over time,
- whether a regression is new or chronic,
- whether other budgeted benches are silently missing because an earlier harness in `cargo bench` panicked.

The `perf-trend` skill answers all three on demand.

## Report sections

1. ** Missing budgeted benches**  names from the workflow's `BUDGETS` table that produced no output in the window. The CI summary step is silent about these; surfacing them is the headline reason this skill exists.
2. **Summary**  per-bench row: latest, budget, window median, Δ vs median, status ( /  over budget), ASCII sparkline (oldestnewest).
3. **Movers**  top regressions / improvements (10% off median, 3 samples), each citing the commit SHA + PR title of the latest run.
4. **Per-bench history**  `<details>` block with the full series.

## What it found on current `main`

Running on the 14-day window already surfaces **two latent issues** the per-run CI summary has been silent about:

- `hot_path/get_file_comments_large` has been **~34 over its 20 ms budget** (~7083 ms) for at least 8 consecutive runs.
- `matching_bench` panics with *"yaml anchors/aliases not allowed in sidecars"* on every run, short-circuiting `cargo bench` and dropping 4 of 5 budgeted benches from the output (`matching/50_comments_1000_lines`, `fold_regions/large_100kb_jsonlike/default`, `parse_kql/pipeline_50_steps`, `strip_json_comments/large_100kb`).

Both are pre-existing repo issues outside the scope of this PR, but the report makes them impossible to miss going forward.

## Design

- **Budgets parsed live from `.github/workflows/ci.yml`**  single source of truth; if the workflow's BUDGETS table changes, the script follows.
- **14-day default window** matches the `bench-output` artifact retention.
- **`--summary` flag** appends the report to `\` so a future scheduled-workflow caller can post the same renderer's output to a job page without rewriting it.
- **Read-only**  never writes to the repo, never opens issues. Acting on findings is for the user or a follow-on skill (per user direction during design).

## Verified

- `npm run lint:skills`  (11 skills now, all `npm run ` references resolve)
- `npm run lint:markdown-surfaces` 
- `npx eslint scripts/perf-trend.mjs` 
- `node scripts/perf-trend.mjs --help` 
- `node scripts/perf-trend.mjs --days 14 --runs 10`   renders full report with Missing-benches section
- `node scripts/perf-trend.mjs --summary` with `\` set   writes 35 lines to the summary file