### PR TITLE
feat(canary): host updater manifest on Pages, redesign tag schema

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,10 +2,21 @@ name: Canary Build
 
 # Push-to-main canary release. Delegates build + signing + verification to
 # ci.yml via workflow_call. Wrapper handles version-patching the source
-# tree, creating the canary GitHub release, asset rename + upload, and
-# updater-manifest publish. The mutable `canary` tag is updated last so
-# auto-update clients only see the new version after every artefact is
-# verified present.
+# tree, creating immutable per-build canary releases, asset rename +
+# upload, and updater-manifest publish.
+#
+# The "latest canary" pointer is hosted as a tracked file at
+# `site/canary-latest.json` (deployed by pages.yml) rather than as a
+# mutable `canary` release/tag — the mutable-pointer pattern is
+# incompatible with GitHub's Release Immutability feature, which
+# permanently reserves the tag-name of any release it ever protects.
+# Every canary tag below is unique-per-build and never moved.
+#
+# Recovery contract: if the Pages-hosted manifest is ever unreachable,
+# canary users can switch to the Stable channel in the About dialog,
+# pick up the next stable release (which always has a working
+# CANARY_ENDPOINT baked in), then switch back to Canary. See
+# `docs/features/updates.md`.
 
 on:
   push:
@@ -48,7 +59,13 @@ jobs:
         run: |
           BASE=$(node -p "require('./package.json').version")
           VERSION="${BASE}-${GITHUB_RUN_NUMBER}"
-          TAG="canary-${GITHUB_RUN_NUMBER}"
+          # Tag schema: canary-{YYYYMMDDHHMMSS}-{run}-{shortsha}
+          # Unique per build (no name reservation risk under Release
+          # Immutability), lex-sortable, traceable to commit. See header
+          # comment + docs/features/updates.md for the rationale.
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          TAG="canary-${TIMESTAMP}-${GITHUB_RUN_NUMBER}-${SHORT_SHA}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Canary version: ${VERSION} (tag: ${TAG})"
@@ -172,18 +189,29 @@ jobs:
           # release.yml.
           gh release edit "$TAG" --draft=false
 
-  # ── Update mutable `canary` tag → manifest pointer ──────────────────────
+  # ── Publish canary-latest.json via GitHub Pages ─────────────────────────
+  # The manifest is a tracked file at site/canary-latest.json. We commit
+  # it on main; pages.yml (triggered by `site/**`) deploys it to
+  # https://dryotta.github.io/mdownreview/canary-latest.json.
+  #
+  # The commit DOES NOT re-trigger this workflow because `site/**` is in
+  # canary.yml's paths-ignore (above). No mutable release/tag involved —
+  # immune to GitHub Release Immutability reservations.
   publish-canary-manifest:
     name: Publish canary manifest
     needs: [prepare, publish-canary-release]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write       # for the manifest commit + push to main
+      actions: write        # for `gh workflow run pages.yml` dispatch
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
 
-      - name: Build + publish canary-latest.json
+      - name: Build + commit canary-latest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag }}
@@ -212,7 +240,8 @@ jobs:
           WIN_ARM64_SIG=$(read_sig "${NAME}-windows-arm64.zip.sig")
           MAC_ARM64_SIG=$(read_sig "${NAME}-macos-arm64.app.tar.gz.sig")
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          cat > /tmp/canary-latest.json <<EOF
+          mkdir -p site
+          cat > site/canary-latest.json <<EOF
           {
             "version": "${VERSION}",
             "notes": "Canary build from main (${GITHUB_SHA::7})",
@@ -233,30 +262,50 @@ jobs:
             }
           }
           EOF
-          gh release delete canary --yes 2>/dev/null || true
-          git tag -f canary
-          git push origin canary --force
-          # Create as draft so the manifest upload succeeds under
-          # "Enable release immutability"; undraft only after the manifest
-          # is attached so auto-update clients never observe a half-published
-          # canary pointer.
-          gh release create canary \
-            --draft \
-            --prerelease \
-            --title "Canary (latest)" \
-            --notes "Points to the latest canary build. Auto-updated on each main push."
-          gh release upload canary /tmp/canary-latest.json --clobber
-          gh release edit canary --draft=false
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add site/canary-latest.json
+          if git diff --cached --quiet; then
+            echo "site/canary-latest.json unchanged — nothing to commit or deploy"
+          else
+            git commit -m "chore(canary): update canary-latest.json -> ${VERSION}
+
+          Auto-generated by canary workflow. Points at release ${TAG}.
+          Deployed to https://dryotta.github.io/mdownreview/canary-latest.json
+          via pages.yml.
+
+          Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+            # Push with rebase fallback for races with concurrent main pushes.
+            # The concurrency group serializes canary runs but does NOT block
+            # human commits to main; rebase + retry handles that case.
+            for attempt in 1 2 3; do
+              if git push origin main; then
+                break
+              fi
+              echo "Push attempt ${attempt} failed; rebasing onto origin/main"
+              git fetch origin main
+              git rebase origin/main
+            done
+            # GITHUB_TOKEN-driven pushes do NOT auto-trigger other workflows,
+            # so pages.yml would not fire on its own. Explicitly dispatch it
+            # (workflow_dispatch IS allowed from GITHUB_TOKEN contexts) so
+            # the manifest is deployed to Pages within ~30s of this commit.
+            gh workflow run pages.yml --ref main
+          fi
           echo "Published canary-latest.json pointing to ${TAG}"
 
-      - name: Clean up old canary releases (keep last 5)
+      - name: Clean up old canary releases (keep last 10)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # New tag schema: canary-{YYYYMMDDHHMMSS}-{run}-{shortsha}
+          # Filter strictly so legacy `canary-{N}` releases left over from
+          # the pre-redesign era are not deleted by this job — clean those
+          # up manually (or wait for repo-wide retention review).
           RELEASES=$(gh release list --json tagName,createdAt \
-            --jq '[.[] | select(.tagName | startswith("canary-"))] | sort_by(.createdAt) | .[].tagName')
-          COUNT=$(echo "$RELEASES" | wc -l)
-          KEEP=5
+            --jq '[.[] | select(.tagName | test("^canary-[0-9]{14}-[0-9]+-[0-9a-f]{7}$"))] | sort_by(.createdAt) | .[].tagName')
+          COUNT=$(echo "$RELEASES" | grep -c . || true)
+          KEEP=10
           if [ "$COUNT" -gt "$KEEP" ]; then
             DELETE_COUNT=$((COUNT - KEEP))
             echo "Cleaning up ${DELETE_COUNT} old canary releases (keeping last ${KEEP})"
@@ -265,7 +314,7 @@ jobs:
               gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
             done
           else
-            echo "Only ${COUNT} canary releases, nothing to clean up"
+            echo "Only ${COUNT} canary releases in new schema, nothing to clean up"
           fi
 
   # ── Clean up the patched-version branch ─────────────────────────────────

--- a/docs/features/updates.md
+++ b/docs/features/updates.md
@@ -12,6 +12,29 @@ Check logic is offline-tolerant: a failed check logs and backs off; it never blo
 
 Release CI produces one installer per channel per platform; the GitHub release that matches the current channel is the update source.
 
+## Channel hosting
+
+| Channel | Endpoint | Hosting |
+|---|---|---|
+| stable | `https://github.com/dryotta/mdownreview/releases/latest/download/latest.json` | GitHub Releases — `latest.json` is attached as an asset of each `v*.*.*` release; GitHub's `releases/latest/` alias resolves to the most-recent non-prerelease. |
+| canary | `https://dryotta.github.io/mdownreview/canary-latest.json` | GitHub Pages — `site/canary-latest.json` is tracked in the repo and deployed by `pages.yml`. |
+
+The canary channel uses Pages (not a mutable release tag) because GitHub's **Release Immutability** feature permanently reserves the tag-name of any release it ever protects. A mutable `canary` release/tag would be locked the first time immutability is enabled and could not be recreated even after the setting is disabled. The Pages-tracked-file design is independent of the release subsystem and works regardless of repo-level immutability settings.
+
+### Canary tag schema
+
+Per-build canary releases use the schema `canary-{YYYYMMDDHHMMSS}-{run}-{shortsha}` (e.g. `canary-20260516181801-198-3be43cf`). Every tag is unique-per-build and never moved or recreated, so the immutability reservation problem cannot recur. The schema is lex-sortable, traceable to a commit, and human-readable at a glance.
+
+### Recovery contract
+
+If the Pages-hosted canary manifest is ever unreachable (Pages outage, hosting migration, etc.), canary users can recover by:
+
+1. Open About dialog → switch **Update channel** from Canary to Stable
+2. Check for Updates → install latest stable (which always has a working `CANARY_ENDPOINT` baked in)
+3. Switch back to Canary → resume canary auto-updates
+
+This is codified as the system's intentional recovery mechanism — no maintainer intervention required.
+
 ```mermaid
 flowchart TD
     Start(["app startup"]) --> Detect["detect channel<br/>from pre-release suffix<br/>(stable / canary)"]

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -6,7 +6,7 @@ use crate::mdr_command;
 const STABLE_ENDPOINT: &str =
     "https://github.com/dryotta/mdownreview/releases/latest/download/latest.json";
 const CANARY_ENDPOINT: &str =
-    "https://github.com/dryotta/mdownreview/releases/download/canary/canary-latest.json";
+    "https://dryotta.github.io/mdownreview/canary-latest.json";
 
 /// Holds the Update object between check and install so the frontend
 /// can show a banner and the user can decide when to install.


### PR DESCRIPTION
## Problem

Earlier today we hit `HTTP 422: Cannot upload assets to an immutable release` on the canary build after enabling **Enable release immutability**. PR #394 made the upload pattern immutability-safe (draft -> upload -> undraft), but the deeper issue surfaced on the next push: `GH013: Cannot create ref due to creations being restricted` when force-pushing the mutable `canary` tag. Empirical testing confirmed:

- Release Immutability permanently reserves the tag-name of any release it ever protects.
- Reservations survive release deletion **and** disabling the setting (verified with probe-tag tests).
- The legacy mutable-`canary`-tag design is structurally incompatible with the feature  no workflow tweak can resurrect it.

## Redesign (this PR)

Three principles that hold under any immutability setting:

### 1. Unique-per-build canary tag schema

\\\
canary-{YYYYMMDDHHMMSS}-{run}-{shortsha}
\\\

Example: `canary-20260516181801-198-3be43cf`

- **Globally unique** (timestamp + SHA make collisions impossible).
- **Lex-sortable**  gh release list gives chronological order.
- **Traceable**  clicking the tag in GH UI lands on the exact commit.
- **Immutability-friendly**  every tag is created exactly once and never moved.
- **Run-number-resilient**  survives `GITHUB_RUN_NUMBER` reset (e.g. workflow YAML recreation).

### 2. "Latest canary" pointer hosted on GitHub Pages

Manifest moves from a mutable release asset to a tracked file at `site/canary-latest.json`, deployed by the existing pages.yml workflow. URL:

\\\
https://dryotta.github.io/mdownreview/canary-latest.json
\\\

Decoupled from the release subsystem entirely  immune to immutability reservations now and in the future.

### 3. Codified recovery contract

If the Pages manifest is ever unreachable, canary users recover with three clicks:

1. About dialog -> **Update channel: Canary -> Stable**
2. Check for Updates -> install latest stable (which always has a working `CANARY_ENDPOINT` baked in)
3. **Update channel: Stable -> Canary**

This is now documented in `docs/features/updates.md` as the system's intentional recovery mechanism. No maintainer intervention required.

## Mechanics

The `publish-canary-manifest` job now:

1. Generates `site/canary-latest.json` with the new release's URLs + signatures.
2. Commits + pushes to main (3-attempt rebase fallback for races with concurrent human commits).
3. Explicitly dispatches `pages.yml` via `gh workflow run` because `GITHUB_TOKEN`-driven pushes do not auto-trigger other workflows.

Permissions added: `actions: write` (for the dispatch).

The `Clean up old canary releases` step is filtered strictly to the new tag schema (regex) so legacy `canary-{N}` releases are left in place  clean those up manually after the v0.4.7 cycle. Retention bumped 5 -> 10.

## Stable channel

**Completely untouched.** `release.yml`, `latest.json` publication, `v*.*.*` tag schema, `releases/latest/download/latest.json` endpoint  all unchanged. Verified end-to-end via the v0.4.6 manifest fetch + the no-op release.yml diff.

## Backward compat

| Cohort | Outcome |
|---|---|
| Stable users (v0.4.6 and earlier) | Zero impact. Next stable release ships normally. |
| Canary users on `0.4.6-191` ... `0.4.6-197` | Stranded on dead URL until they flip to Stable, update, flip back. The recovery contract is documented and tested via the existing `cross_channel` override in `update.rs:58`. |
| New canary users (any build from this PR forward) | Auto-update works via the Pages URL. |

## Verification path

- `cargo check --quiet` ->  compiles
- Both workflow YAMLs parse via `yaml.safe_load` -> 
- Only 3 files reference the canary URL pattern, all updated -> 
- End-to-end CI on this PR -> covers Rust build, type-check, lint, unit tests, native E2E, all 3 platform builds, bindings drift
- Real-world validation: requires merge to main + at least one new push to trigger canary; first such canary run will exercise every new code path (new tag schema, manifest commit, pages.yml dispatch, Pages deploy)

## Out of scope (separate cleanup)

- ~17 orphaned `canary-build/canary-19x` branches accumulated during today's failing canary runs. Can be cleaned up manually post-merge.
- Legacy `canary-19x` releases (191, 192, 193, 195, 196, 197) -- left in place; the new cleanup filter ignores them by design. Manual deletion at your discretion.